### PR TITLE
297 omp sentinels

### DIFF
--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -288,7 +288,7 @@ class FortranAnalyser(FortranAnalyserBase):
         comment = obj.items[0].strip()
         if depends_str in comment:
             self.depends_on_comment_found = True
-            dep = obj.items[0].split(depends_str)[-1].strip()
+            dep = comment.split(depends_str)[-1].strip()
             # with .o means a c file
             if dep.endswith(".o"):
                 analysed_file.mo_commented_file_deps.add(dep.replace(".o", ".c"))

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 from typing import Union, Optional, Iterable, Dict, Any, Set
 
+from fparser.common.readfortran import FortranStringReader
 from fparser.two.Fortran2003 import (  # type: ignore
     Entity_Decl_List, Use_Stmt, Module_Stmt, Program_Stmt, Subroutine_Stmt, Function_Stmt, Language_Binding_Spec,
     Char_Literal_Constant, Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def, Derived_Type_Stmt,
@@ -284,7 +285,8 @@ class FortranAnalyser(FortranAnalyserBase):
         # TODO: error handling in case we catch a genuine comment
         # TODO: separate this project-specific code from the generic f analyser?
         depends_str = "DEPENDS ON:"
-        if depends_str in obj.items[0]:
+        comment = obj.items[0].strip()
+        if depends_str in comment:
             self.depends_on_comment_found = True
             dep = obj.items[0].split(depends_str)[-1].strip()
             # with .o means a c file
@@ -293,6 +295,26 @@ class FortranAnalyser(FortranAnalyserBase):
             # without .o means a fortran symbol
             else:
                 analysed_file.add_symbol_dep(dep)
+        if comment[:2] == "!$":
+            # Check if it is a use statement with an OpenMP sentinel:
+            # Use fparser's string reader to discard potential comments
+            reader = FortranStringReader(comment[2:])
+            line = reader.next()
+            try:
+                # match returns a 5-tuple, the third one being the module name
+                module_name = Use_Stmt.match(line.strline)[2]
+                module_name = module_name.string
+            except Exception:
+                # Not a use statement in a sentinel, ignore:
+                return
+
+            # Register the module name
+            if module_name in self.ignore_mod_deps:
+                logger.debug(f"ignoring use of {module_name}")
+                return
+            if module_name.lower() not in self._intrinsic_modules:
+                # found a dependency on fortran
+                analysed_file.add_module_dep(module_name)
 
     def _process_subroutine_or_function(self, analysed_file, fpath, obj):
         # binding?

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Union, Optional, Iterable, Dict, Any, Set
 
-from fparser.common.readfortran import FortranStringReader
+from fparser.common.readfortran import FortranStringReader   # type: ignore
 from fparser.two.Fortran2003 import (  # type: ignore
     Entity_Decl_List, Use_Stmt, Module_Stmt, Program_Stmt, Subroutine_Stmt, Function_Stmt, Language_Binding_Spec,
     Char_Literal_Constant, Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def, Derived_Type_Stmt,

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -297,7 +297,9 @@ class FortranAnalyser(FortranAnalyserBase):
                 analysed_file.add_symbol_dep(dep)
         if comment[:2] == "!$":
             # Check if it is a use statement with an OpenMP sentinel:
-            # Use fparser's string reader to discard potential comments
+            # Use fparser's string reader to discard potential comment
+            # TODO #13: once fparser supports reading the sentinels,
+            # this can be removed.
             reader = FortranStringReader(comment[2:])
             line = reader.next()
             try:

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
@@ -17,6 +17,11 @@ CONTAINS
         RETURN
     END SUBROUTINE internal_sub
 
+    SUBROUTINE openmp_sentinel
+!$ USE compute_chunk_size_mod, ONLY: compute_chunk_size  ! Note OpenMP sentinel
+!$ USE test that is not a sentinel with a use statement inside
+    END SUBROUTINE openmp_sentinel
+
     INTEGER FUNCTION internal_func()
         internal_func = 456
     END FUNCTION internal_func

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
@@ -20,6 +20,10 @@ CONTAINS
     SUBROUTINE openmp_sentinel
 !$ USE compute_chunk_size_mod, ONLY: compute_chunk_size  ! Note OpenMP sentinel
 !$ USE test that is not a sentinel with a use statement inside
+!GCC$ unroll 6
+!DIR$ assume (mod(p, 6) == 0)
+!$omp do
+!$acc parallel copyin (array, scalar).
     END SUBROUTINE openmp_sentinel
 
     INTEGER FUNCTION internal_func()

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -31,11 +31,11 @@ def module_fpath():
 def module_expected(module_fpath):
     return AnalysedFortran(
         fpath=module_fpath,
-        file_hash=4039845747,
+        file_hash=1344519263,
         module_defs={'foo_mod'},
         symbol_defs={'external_sub', 'external_func', 'foo_mod'},
-        module_deps={'bar_mod'},
-        symbol_deps={'monty_func', 'bar_mod'},
+        module_deps={'bar_mod', 'compute_chunk_size_mod'},
+        symbol_deps={'monty_func', 'bar_mod', 'compute_chunk_size_mod'},
         file_deps=set(),
         mo_commented_file_deps={'some_file.c'},
     )
@@ -72,10 +72,10 @@ class Test_Analyser(object):
                 analysis, artefact = fortran_analyser.run(fpath=Path(tmp_file.name))
 
             module_expected.fpath = Path(tmp_file.name)
-            module_expected._file_hash = 768896775
+            module_expected._file_hash = 731743441
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
-            module_expected.symbol_defs.update({'internal_sub', 'internal_func'})
+            module_expected.symbol_defs.update({'internal_sub', 'openmp_sentinel', 'internal_func'})
 
             assert analysis == module_expected
             assert artefact == fortran_analyser._config.prebuild_folder \


### PR DESCRIPTION
Adds some support for OMP sentinels (#297), which are required for compiling lfric_atm.

The next release of fparser adds support for sentinels to fparser, so this change can then be removed again (#todo in place to remind us, so I would also leave #297 open), we only need to trigger this behaviour in fparser (which means it will not only work for declaration statements). We need this patch for now to continue LFRic compilation (but the source code in question is UM, so I added label UM, and not LFRic).