### PR TITLE
Additional compilers clean

### DIFF
--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -467,21 +467,7 @@ class Nvc(CCompiler):
     def __init__(self, name: str = "nvc", exec_name: str = "nvc"):
         super().__init__(name, exec_name, suite="nvidia",
                          openmp_flag="-mp",
-                         version_regex=r"nvc (\d[\d\.-]+\d)")
-
-    def run_version_command(
-            self, version_command: Optional[str] = '--version') -> str:
-        '''Run the compiler's command to get its version. This implementation
-        runs the function in the base class, and changes any '-' into a
-        '.' to support nvidia version numbers which have dashes, e.g. 23.5-0.
-
-        :param version_command: The compiler argument used to get version info.
-
-        :returns: The output from the version command, with any '-' replaced
-            with '.'
-        '''
-        version_string = super().run_version_command()
-        return version_string.replace("-", ".")
+                         version_regex=r"nvc (\d[\d\.]+\d)")
 
 
 # ============================================================================
@@ -499,21 +485,7 @@ class Nvfortran(FortranCompiler):
                          module_folder_flag="-module",
                          openmp_flag="-mp",
                          syntax_only_flag="-Msyntax-only",
-                         version_regex=r"nvfortran (\d[\d\.-]+\d)")
-
-    def run_version_command(
-            self, version_command: Optional[str] = '--version') -> str:
-        '''Run the compiler's command to get its version. This implementation
-        runs the function in the base class, and changes any '-' into a
-        '.' to support nvidia version numbers which have dashes, e.g. 23.5-0.
-
-        :param version_command: The compiler argument used to get version info.
-
-        :returns: The output from the version command, with any '-' replaced
-            with '.'
-        '''
-        version_string = super().run_version_command()
-        return version_string.replace("-", ".")
+                         version_regex=r"nvfortran (\d[\d\.]+\d)")
 
 
 # ============================================================================

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -47,26 +47,27 @@ def test_compiler():
 def test_compiler_openmp():
     '''Test that the openmp flag is correctly reflected in the test if
     a compiler supports OpenMP or not.'''
-    cc = CCompiler("gcc", "gcc", "gnu", openmp_flag="-fopenmp")
+    cc = CCompiler("gcc", "gcc", "gnu", openmp_flag="-fopenmp",
+                   version_regex=None)
     assert cc.openmp_flag == "-fopenmp"
     assert cc.openmp
-    cc = CCompiler("gcc", "gcc", "gnu", openmp_flag=None)
+    cc = CCompiler("gcc", "gcc", "gnu", openmp_flag=None, version_regex=None)
     assert cc.openmp_flag == ""
     assert not cc.openmp
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = CCompiler("gcc", "gcc", "gnu", version_regex=None)
     assert cc.openmp_flag == ""
     assert not cc.openmp
 
     fc = FortranCompiler("gfortran", "gfortran", "gnu", openmp_flag="-fopenmp",
-                         module_folder_flag="-J")
+                         module_folder_flag="-J", version_regex=None)
     assert fc.openmp_flag == "-fopenmp"
     assert fc.openmp
     fc = FortranCompiler("gfortran", "gfortran", "gnu", openmp_flag=None,
-                         module_folder_flag="-J")
+                         module_folder_flag="-J", version_regex=None)
     assert fc.openmp_flag == ""
     assert not fc.openmp
     fc = FortranCompiler("gfortran", "gfortran", "gnu",
-                         module_folder_flag="-J")
+                         module_folder_flag="-J", version_regex=None)
     assert fc.openmp_flag == ""
     assert not fc.openmp
 

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -778,7 +778,7 @@ Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
     """)
     nvc = Nvc()
     with mock.patch.object(nvc, "run", mock.Mock(return_value=full_output)):
-        assert nvc.get_version() == (23, 5, 0)
+        assert nvc.get_version() == (23, 5)
 
 
 def test_nvc_get_version_with_icc_string():
@@ -819,7 +819,7 @@ Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
     nvfortran = Nvfortran()
     with mock.patch.object(nvfortran, "run",
                            mock.Mock(return_value=full_output)):
-        assert nvfortran.get_version() == (23, 5, 0)
+        assert nvfortran.get_version() == (23, 5)
 
 
 def test_nvfortran_get_version_with_ifort_string():

--- a/tests/unit_tests/tools/test_tool_repository.py
+++ b/tests/unit_tests/tools/test_tool_repository.py
@@ -137,7 +137,7 @@ def test_tool_repository_get_default_error_missing_openmp_compiler():
     ToolRepository.'''
     tr = ToolRepository()
     fc = FortranCompiler("gfortran", "gfortran", "gnu", openmp_flag=None,
-                         module_folder_flag="-J")
+                         module_folder_flag="-J", version_regex=None)
 
     with mock.patch.dict(tr, {Category.FORTRAN_COMPILER: [fc]}), \
             pytest.raises(RuntimeError) as err:


### PR DESCRIPTION
Removes support for "-" in nvidia compiler versions (e.g. 2.5-0). This caused problems with compiler wrapper:
`nvfortran` would accept 2.5-0, but `mpif90(nvfortran)` would not accept (resulting in `mpif90` not available for nvfortran).

Fixing this properly is a larger effort, while only supporting non-development version numbers (according to semantic versioning) is easy and is all we need.