### PR TITLE
Removed fparser stop concatenation workround after fparser update

### DIFF
--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -20,8 +20,7 @@ from fab.steps.find_source_files import find_source_files, Exclude, Include
 from fab.tools import ToolBox
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
-from lfric_common import (API, configurator, fparser_workaround_stop_concatenation,
-                          get_transformation_script)
+from lfric_common import (API, configurator, get_transformation_script)
 
 logger = logging.getLogger('fab')
 
@@ -249,9 +248,6 @@ if __name__ == '__main__':
             cli_args=[],
             api=API,
         )
-
-        # todo: do we need this one in here?
-        fparser_workaround_stop_concatenation(state)
 
         analyse(
             state,

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -22,8 +22,7 @@ from fab.steps.psyclone import psyclone, preprocess_x90
 from fab.tools import ToolBox
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
-from lfric_common import (API, configurator, fparser_workaround_stop_concatenation,
-                          get_transformation_script)
+from lfric_common import (API, configurator, get_transformation_script)
 
 logger = logging.getLogger('fab')
 
@@ -74,8 +73,6 @@ if __name__ == '__main__':
             cli_args=[],
             api=API,
         )
-
-        fparser_workaround_stop_concatenation(state)
 
         analyse(
             state,

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -1,10 +1,8 @@
 import logging
 import os
-import shutil
 from typing import Optional
 from pathlib import Path
 
-from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps import step
 from fab.steps.find_source_files import find_source_files

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -85,36 +85,6 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
 
 
 # ============================================================================
-@step
-def fparser_workaround_stop_concatenation(config):
-    """
-    fparser can't handle string concat in a stop statement. This step is
-    a workaround.
-
-    https://github.com/stfc/fparser/issues/330
-
-    """
-    feign_path = None
-    for file_path in config.artefact_store[ArtefactSet.FORTRAN_BUILD_FILES]:
-        if file_path.name == 'feign_config_mod.f90':
-            feign_path = file_path
-            break
-    else:
-        raise RuntimeError("Could not find 'feign_config_mod.f90'.")
-
-    # rename "broken" version
-    broken_version = feign_path.with_suffix('.broken')
-    shutil.move(feign_path, broken_version)
-
-    # make fixed version
-    bad = "_config: '// &\n        'Unable to close temporary file'"
-    good = "_config: Unable to close temporary file'"
-
-    open(feign_path, 'wt').write(
-        open(broken_version, 'rt').read().replace(bad, good))
-
-
-# ============================================================================
 def get_transformation_script(fpath: Path,
                               config: BuildConfig) -> Optional[Path]:
     ''':returns: the transformation script to be used by PSyclone.

--- a/run_configs/lfric/mesh_tools.py
+++ b/run_configs/lfric/mesh_tools.py
@@ -13,7 +13,7 @@ from fab.steps.find_source_files import find_source_files, Exclude
 from fab.steps.psyclone import psyclone, preprocess_x90
 from fab.tools import ToolBox
 
-from lfric_common import API, configurator, fparser_workaround_stop_concatenation
+from lfric_common import API, configurator
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 
 
@@ -59,8 +59,6 @@ if __name__ == '__main__':
             overrides_folder=state.source_root / 'mesh_tools_overrides',
             api=API,
         )
-
-        fparser_workaround_stop_concatenation(state)
 
         analyse(
             state,


### PR DESCRIPTION
This is related to Issue #341 . The work around for stop concaenation is no longer needed after fparser update. This PR removes this redundant step from the example configs.