### PR TITLE
Subprocess testing port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Unit tests with Pytest
         run: |
-          pip install .[tests]
+          pip install .[dev]
           python -m pytest --cov=fab tests/unit_tests
 
       - name: System tests with Pytest
         run: |
-          pip install .[tests]
+          pip install .[dev]
           python -m pytest --cov=fab tests/system_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 license = {file = 'LICENSE.txt'}
 dynamic = ['version', 'readme']
-requires-python = '>=3.7, <4'
+requires-python = '>=3.9, <4'
 dependencies = ['fparser >= 0.2']
 classifiers = [
     'Development Status :: 1 - Planning',
@@ -21,13 +21,19 @@ classifiers = [
 [project.optional-dependencies]
 c-language = ['libclang']
 plots = ['matplotlib']
-tests = ['pytest', 'pytest-cov', 'pytest-mock']
-checks = ['flake8>=5.0.4', 'mypy']
 docs = ['sphinx',
         'pydata-sphinx-theme>=0.13.3',
         'sphinx-autodoc-typehints',
         'sphinx-copybutton']
-dev = ['sci-fab[plots, tests, checks, docs]']
+dev = [
+    'pytest >= 8.3.0',
+    'pytest-cov',
+    'pytest-mock',
+    'pytest-subprocess >= 1.5.3',
+    'pyfakefs',
+    'flake8 >= 5.0.4',
+    'mypy'
+]
 
 [project.scripts]
 fab = 'fab.cli:cli_fab'

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -82,13 +82,16 @@ class ArtefactStore(dict):
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    key: str, values: Union[str, Iterable]):
-        '''For ArtefactSets that are a dictionary of sets: update
-        the set with the specified values.
-        :param collection: the name of the collection to add this to.
-        :param key: the key in the dictionary to update.
-        :param values: the values to update with.
-        '''
+                    values: Union[str, Iterable],
+                    key: Optional[str] = None):
+        """
+        Modifies data associated with artefact set.
+
+        :param collection: Name or enumeration of set to modify.
+        :param values: New data for set.
+        :param key: Executable name associated with data. Do not specify for
+                    libraries.
+        """
         self[collection][key].update([values] if isinstance(values, str)
                                      else values)
 

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -12,7 +12,7 @@ Classes and helper functions related to the dependency tree, as created by the a
 from abc import ABC
 import logging
 from pathlib import Path
-from typing import Set, Dict, Iterable, List, Union, Optional, Any
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 from fab.parse import AnalysedFile
 
@@ -98,7 +98,8 @@ class AnalysedDependent(AnalysedFile, ABC):
         return result
 
 
-def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent], root: Path, verbose=False)\
+def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent],
+                     root: Path, verbose=False)\
         -> Dict[Path, AnalysedDependent]:
     """
     Extract the subtree required to build the target, from the full source tree of all analysed source files.
@@ -114,7 +115,11 @@ def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent], root: Path, ver
     result: Dict[Path, AnalysedDependent] = dict()
     missing: Set[Path] = set()
 
-    _extract_sub_tree(src_tree=source_tree, key=root, dst_tree=result, missing=missing, verbose=verbose)
+    _extract_sub_tree(src_tree=source_tree,
+                      key=root,
+                      dst_tree=result,
+                      missing=missing,
+                      verbose=verbose)
 
     if missing:
         logger.warning(f"{root} has missing deps: {missing}")
@@ -122,8 +127,12 @@ def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent], root: Path, ver
     return result
 
 
-def _extract_sub_tree(src_tree: Dict[Path, AnalysedDependent], key: Path,
-                      dst_tree: Dict[Path, AnalysedDependent], missing: Set[Path], verbose: bool, indent: int = 0):
+def _extract_sub_tree(src_tree: Dict[Path, AnalysedDependent],
+                      key: Path,
+                      dst_tree: Dict[Path, AnalysedDependent],
+                      missing: Set[Path],
+                      verbose: bool,
+                      indent: int = 0):
     # is this node already in the sub tree?
     if key in dst_tree:
         return

--- a/source/fab/steps/__init__.py
+++ b/source/fab/steps/__init__.py
@@ -5,9 +5,9 @@
 ##############################################################################
 """
 Predefined build steps with sensible defaults.
-
 """
 import multiprocessing
+from typing import Iterable, Optional, Union
 
 from fab.metrics import send_metric
 from fab.util import by_type, TimerLogger
@@ -79,7 +79,8 @@ def run_mp_imap(config, items, func, result_handler):
         result_handler(analysis_results)
 
 
-def check_for_errors(results, caller_label=None):
+def check_for_errors(results: Iterable[Union[str, Exception]],
+                     caller_label: Optional[str] = None) -> None:
     """
     Check an iterable of results for any exceptions and handle them gracefully.
 
@@ -90,7 +91,6 @@ def check_for_errors(results, caller_label=None):
         An iterable of results.
     :param caller_label:
         Optional human-friendly name of the caller for logging.
-
     """
     caller_label = f'during {caller_label}' if caller_label else ''
 

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -38,7 +38,7 @@ import logging
 import sys
 import warnings
 from pathlib import Path
-from typing import Dict, List, Iterable, Set, Optional, Union
+from typing import Dict, Iterable, List, Optional, Set, Union
 
 from fab import FabException
 from fab.artefacts import ArtefactsGetter, ArtefactSet, CollectionConcat

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -135,5 +135,4 @@ def archive_objects(config: BuildConfig,
         except RuntimeError as err:
             raise RuntimeError(f"error creating object archive:\n{err}") from err
 
-        config.artefact_store.update_dict(output_collection, root,
-                                          output_fpath)
+        config.artefact_store.update_dict(output_collection, output_fpath, root)

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -116,7 +116,7 @@ def store_artefacts(compiled_files: List[CompiledFile],
     lookup = {c.input_fpath: c for c in compiled_files}
     for root, source_files in build_lists.items():
         new_objects = [lookup[af.fpath].output_fpath for af in source_files]
-        artefact_store.update_dict(ArtefactSet.OBJECT_FILES, root, new_objects)
+        artefact_store.update_dict(ArtefactSet.OBJECT_FILES, new_objects, root)
 
 
 def _compile_file(arg: Tuple[AnalysedC, MpCommonArgs]):

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -154,7 +154,6 @@ def handle_compiler_args(config: BuildConfig, common_flags=None,
 def compile_pass(config, compiled: Dict[Path, CompiledFile],
                  uncompiled: Set[AnalysedFortran],
                  mp_common_args: MpCommonArgs, mod_hashes: Dict[str, int]):
-
     # what can we compile next?
     compile_next = get_compile_next(compiled, uncompiled)
 
@@ -232,7 +231,7 @@ def store_artefacts(compiled_files: Dict[Path, CompiledFile],
     lookup = {c.input_fpath: c for c in compiled_files.values()}
     for root, source_files in build_lists.items():
         new_objects = {lookup[af.fpath].output_fpath for af in source_files}
-        artefact_store.update_dict(ArtefactSet.OBJECT_FILES, root, new_objects)
+        artefact_store.update_dict(ArtefactSet.OBJECT_FILES, new_objects, root)
 
 
 def process_file(arg: Tuple[AnalysedFortran, MpCommonArgs]) \

--- a/source/fab/steps/grab/archive.py
+++ b/source/fab/steps/grab/archive.py
@@ -3,8 +3,9 @@
 #  For further details please refer to the file COPYRIGHT
 #  which you should have received as part of this distribution
 # ##############################################################################
-import shutil
+from inspect import signature
 from pathlib import Path
+from shutil import unpack_archive
 from typing import Union
 
 from fab.steps import step
@@ -27,4 +28,17 @@ def grab_archive(config, src: Union[Path, str], dst_label: str = ''):
     dst: Path = config.source_root / dst_label
     dst.mkdir(parents=True, exist_ok=True)
 
-    shutil.unpack_archive(src, dst)
+    # The filtering was added at v3.12 so this check may be removed once we
+    # nolonger support earlier versions. It must be specified as default
+    # behaviour of the filter changes at v3.14.
+    #
+    unpack_archive_sig = signature(unpack_archive)
+    if 'filter' in unpack_archive_sig.parameters:
+        #
+        # The "data" filter does a number of things including disallowing
+        # symlinks. It also does not recreate ownership or permissions from
+        # the archive.
+        #
+        unpack_archive(src, dst, filter='data')
+    else:
+        unpack_archive(src, dst)

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -103,7 +103,6 @@ def link_shared_object(config, output_fpath: str, flags=None,
     :param source:
         An optional :class:`~fab.artefacts.ArtefactsGetter`.
         Typically not required, as there is a sensible default.
-
     """
     linker = config.tool_box[Category.LINKER]
     logger.info(f'linker is {linker}')

--- a/source/fab/tools/compiler_wrapper.py
+++ b/source/fab/tools/compiler_wrapper.py
@@ -136,7 +136,6 @@ class CompilerWrapper(Compiler):
                      config: "BuildConfig",
                      add_flags: Union[None, List[str]] = None,
                      syntax_only: Optional[bool] = None):
-        # pylint: disable=too-many-arguments
         '''Compiles a file using the wrapper compiler. It will temporarily
         change the executable name of the wrapped compiler, and then calls
         the original compiler (to get all its parameters)
@@ -165,7 +164,7 @@ class CompilerWrapper(Compiler):
             # which also supports the syntax_only flag anyway)
             self._compiler = cast(FortranCompiler, self._compiler)
             self._compiler.compile_file(input_file, output_file, config=config,
-                                        add_flags=self.get_flags() + add_flags,
+                                        add_flags=super().get_flags() + add_flags,
                                         syntax_only=syntax_only,
                                         )
         else:
@@ -173,7 +172,7 @@ class CompilerWrapper(Compiler):
                 raise RuntimeError(f"Syntax-only cannot be used with compiler "
                                    f"'{self.name}'.")
             self._compiler.compile_file(input_file, output_file, config=config,
-                                        add_flags=self.get_flags()+add_flags
+                                        add_flags=super().get_flags()+add_flags
                                         )
         self._compiler.change_exec_name(orig_compiler_name)
 

--- a/source/fab/tools/flags.py
+++ b/source/fab/tools/flags.py
@@ -119,7 +119,7 @@ class ProfileFlags:
 
         :raises KeyError: if a profile is specified it is not defined
         '''
-        if not profile:
+        if profile is None:
             profile = ""
         else:
             profile = profile.lower()

--- a/source/fab/tools/preprocessor.py
+++ b/source/fab/tools/preprocessor.py
@@ -27,7 +27,8 @@ class Preprocessor(Tool):
     def __init__(self, name: str, exec_name: Union[str, Path],
                  category: Category,
                  availability_option: Optional[str] = None):
-        super().__init__(name, exec_name, category)
+        super().__init__(name, exec_name, category,
+                         availability_option=availability_option)
         self._version = None
 
     def preprocess(self, input_file: Path, output_file: Path,

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -193,8 +193,8 @@ class Tool:
             res = subprocess.run(command, capture_output=capture_output,
                                  env=env, cwd=cwd, check=False)
         except FileNotFoundError as err:
-            raise RuntimeError(f"Command '{command}' could not be "
-                               f"executed.") from err
+            raise RuntimeError("Unable to execute command: "
+                               + str(command)) from err
         if res.returncode != 0:
             msg = (f'Command failed with return code {res.returncode}:\n'
                    f'{command}')

--- a/source/fab/tools/tool_repository.py
+++ b/source/fab/tools/tool_repository.py
@@ -163,11 +163,12 @@ class ToolRepository(dict):
                        f"in ToolRepository.")
 
     def set_default_compiler_suite(self, suite: str):
-        '''Sets the default for linker and compilers to be of the
+        """
+        Sets the default for linker and compilers to be of the
         given compiler suite.
 
         :param suite: the name of the compiler suite to make the default.
-        '''
+        """
         for category in [Category.FORTRAN_COMPILER, Category.C_COMPILER,
                          Category.LINKER]:
             # Now sort the tools in this category to have all tools with the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,79 +1,174 @@
-# ##############################################################################
-#  (c) Crown copyright Met Office. All rights reserved.
-#  For further details please refer to the file COPYRIGHT
-#  which you should have received as part of this distribution
-# ##############################################################################
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Fixtures and helpers for testing.
+"""
+from pathlib import Path
+from typing import Dict, List, Optional
 
-'''This file is read by pytest and provides common fixtures.
-'''
+from pytest import fixture
+from pytest_subprocess.fake_process import FakeProcess, ProcessRecorder
 
-from unittest import mock
-
-import pytest
-
-from fab.tools import CCompiler, FortranCompiler, Linker, ToolBox
-
-
-# This avoids pylint warnings about Redefining names from outer scope
-@pytest.fixture(name="mock_c_compiler")
-def fixture_mock_c_compiler():
-    '''Provides a mock C-compiler.'''
-    mock_compiler = CCompiler("mock_c_compiler", "mock_exec", "suite",
-                              version_regex="something")
-    mock_compiler.run = mock.Mock()
-    mock_compiler._version = (1, 2, 3)
-    mock_compiler._name = "mock_c_compiler"
-    mock_compiler._exec_name = "mock_c_compiler.exe"
-    mock_compiler._openmp_flag = "-fopenmp"
-    return mock_compiler
+from fab.build_config import BuildConfig
+from fab.tools.compiler import CCompiler, FortranCompiler
+from fab.tools.linker import Linker
+from fab.tools.tool_box import ToolBox
 
 
-@pytest.fixture(name="mock_fortran_compiler")
-def fixture_mock_fortran_compiler():
-    '''Provides a mock Fortran-compiler.'''
-    mock_compiler = FortranCompiler("mock_fortran_compiler", "mock_exec",
-                                    "suite", module_folder_flag="",
-                                    version_regex="something",
-                                    syntax_only_flag=None, compile_flag=None,
-                                    output_flag=None, openmp_flag=None)
-    mock_compiler.run = mock.Mock()
-    mock_compiler._name = "mock_fortran_compiler"
-    mock_compiler._exec_name = "mock_fortran_compiler.exe"
-    mock_compiler._version = (1, 2, 3)
-    return mock_compiler
+def not_found_callback(process):
+    """
+    Raises a FileNotFoundError.
+
+    This is useful for generating this specific error when mocking
+    subprocesses.
+    """
+    process.returncode = 1
+    raise FileNotFoundError("Executable file missing")
 
 
-@pytest.fixture(name="mock_linker")
-def fixture_mock_linker(mock_fortran_compiler):
-    '''Provides a mock linker.'''
-    mock_linker = Linker(mock_fortran_compiler)
-    mock_linker.run = mock.Mock()
-    mock_linker._version = (1, 2, 3)
-    mock_linker.add_lib_flags("netcdf", ["-lnetcdff", "-lnetcdf"])
-    return mock_linker
+def call_list(fake_process: FakeProcess) -> List[List[str]]:
+    """
+    Converts FakeProcess calls to strings.
+
+    :returns: List of argument strings per call.
+    """
+    result: List[List[str]] = []
+    for call in fake_process.calls:
+        result.append([str(arg) for arg in call])
+    return result
 
 
-@pytest.fixture(name="tool_box")
-def fixture_tool_box(mock_c_compiler, mock_fortran_compiler, mock_linker):
-    '''Provides a tool box with a mock Fortran and a mock C compiler.'''
-    tool_box = ToolBox()
-    tool_box.add_tool(mock_c_compiler)
-    tool_box.add_tool(mock_fortran_compiler)
-    tool_box.add_tool(mock_linker)
-    return tool_box
+def arg_list(record: ProcessRecorder) -> List[Dict[str, str]]:
+    """
+    Converts ProcessRecorder calls to subprocess arguments.
+
+    This gives access to e.g. pwd specified with each call.
+
+    :returns: Dictionary of argument passed to subprocess per call.
+    """
+    result: List[Dict[str, str]] = []
+    for call in record.calls:
+        if call.kwargs is None:
+            args = {}
+        else:
+            args = {key: str(value) for key, value in call.kwargs.items()}
+        result.append(args)
+    return result
 
 
-@pytest.fixture(name="mock_config")
-def fixture_mock_config(tool_box):
-    '''Provides a dummy fixture with mock ToolBox.'''
-    # Avoid cylic import
-    # pylint: disable=import-outside-toplevel
-    from fab.build_config import BuildConfig
-    return BuildConfig(project_label="label", tool_box=tool_box)
+class ExtendedRecorder:
+    """
+    Adds convenience functionality to ProcessRecorder.
+    """
+    def __init__(self, recorder: ProcessRecorder):
+        self.recorder = recorder
+
+    def invocations(self) -> List[List[str]]:
+        """
+        Lists invocations as simple string lists.
+        """
+        calls = []
+        for call in self.recorder.calls:
+            calls.append([str(arg) for arg in call.args])
+        return calls
+
+    def extras(self) -> List[Dict[str, Optional[str]]]:
+        """
+        Lists arguments passed to subprocess.
+
+        This allows .e.g. pwd to be seen, if set.
+        """
+        args: List[Dict[str, Optional[str]]] = []
+        for call in self.recorder.calls:
+            things: Dict[str, Optional[str]] = {}
+            if call.kwargs is None:
+                continue
+            for key, value in call.kwargs.items():
+                if value is None:
+                    things[key] = None
+                else:
+                    if key in ('stdout', 'stderr') and value == -1:
+                        things[key] = None
+                    else:
+                        things[key] = str(value)
+            args.append(things)
+        return args
 
 
-@pytest.fixture(name="psyclone_lfric_api")
-def fixture_psyclone_lfric_api():
-    '''A simple fixture to provide the name of the LFRic API for
-    PSyclone.'''
-    return "dynamo0.3"
+@fixture(scope='function')
+def subproc_record(fake_process: FakeProcess) -> ExtendedRecorder:
+    """
+    Mocks the 'subprocess' module and returns a recorder of commands issued.
+    """
+    fake_process.keep_last_process(True)
+    return ExtendedRecorder(fake_process.register([FakeProcess.any()]))
+
+
+@fixture(scope='function')
+def stub_fortran_compiler() -> FortranCompiler:
+    """
+    Provides a minimal Fortran compiler.
+    """
+    compiler = FortranCompiler('some Fortran compiler', 'sfc', 'stub',
+                               r'([\d.]+)', openmp_flag='-omp',
+                               module_folder_flag='-mods')
+    return compiler
+
+
+@fixture(scope='function')
+def stub_c_compiler() -> CCompiler:
+    """
+    Provides a minial C compiler.
+    """
+    compiler = CCompiler("some C compiler", "scc", "stub",
+                         version_regex=r"([\d.]+)", openmp_flag='-omp')
+    return compiler
+
+
+@fixture(scope='function')
+def stub_linker(stub_c_compiler) -> Linker:
+    """
+    Provides a minimal linker.
+    """
+    linker = Linker(stub_c_compiler, None, 'sln')
+    return linker
+
+
+def return_true():
+    """
+    Returns true.
+
+    Useful when monkeypatching methods.
+    """
+    return True
+
+
+@fixture(scope='function')
+def stub_tool_box(stub_fortran_compiler,
+                  stub_c_compiler,
+                  stub_linker,
+                  monkeypatch) -> ToolBox:
+    """
+    Provides a minimal toolbox containing just Fortran and C compilers and a
+    linker.
+    """
+    monkeypatch.setattr(stub_fortran_compiler, 'check_available', return_true)
+    monkeypatch.setattr(stub_c_compiler, 'check_available', return_true)
+    monkeypatch.setattr(stub_linker, 'check_available', return_true)
+    toolbox = ToolBox()
+    toolbox.add_tool(stub_fortran_compiler)
+    toolbox.add_tool(stub_c_compiler)
+    toolbox.add_tool(stub_linker)
+    return toolbox
+
+
+@fixture(scope='function')
+def stub_configuration(stub_tool_box: ToolBox, tmp_path: Path) -> BuildConfig:
+    """
+    Provides a minimal configuration with stub compilers.
+    """
+    return BuildConfig("Stub config", stub_tool_box,
+                       fab_workspace=tmp_path / 'fab')

--- a/tests/system_tests/CFortranInterop/test_CFortranInterop.py
+++ b/tests/system_tests/CFortranInterop/test_CFortranInterop.py
@@ -6,6 +6,8 @@
 import subprocess
 from pathlib import Path
 
+from pytest import importorskip, warns
+
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps.analyse import analyse
@@ -18,7 +20,7 @@ from fab.steps.link import link_exe
 from fab.steps.preprocess import preprocess_fortran, preprocess_c
 from fab.tools import ToolBox
 
-import pytest
+clang = importorskip('clang', reason="Clang bindings not found.")
 
 PROJECT_SOURCE = Path(__file__).parent / 'project-source'
 
@@ -35,7 +37,7 @@ def test_CFortranInterop(tmp_path):
         preprocess_fortran(config)
         analyse(config, root_symbol='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
-        with pytest.warns(UserWarning, match="Removing managed flag"):
+        with warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])
         link_exe(config, flags=['-lgfortran'])
         # todo: on an ubuntu vm, we needed these before the object files - investigate further

--- a/tests/system_tests/CUserHeader/test_CUserHeader.py
+++ b/tests/system_tests/CUserHeader/test_CUserHeader.py
@@ -6,6 +6,8 @@
 import subprocess
 from pathlib import Path
 
+from pytest import importorskip
+
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps.analyse import analyse
@@ -16,6 +18,8 @@ from fab.steps.grab.folder import grab_folder
 from fab.steps.link import link_exe
 from fab.steps.preprocess import preprocess_c
 from fab.tools import ToolBox
+
+clang = importorskip('clang', reason="Clang bindings not found.")
 
 PROJECT_SOURCE = Path(__file__).parent / 'project-source'
 

--- a/tests/system_tests/MinimalC/test_MinimalC.py
+++ b/tests/system_tests/MinimalC/test_MinimalC.py
@@ -6,6 +6,8 @@
 import subprocess
 from pathlib import Path
 
+from pytest import importorskip
+
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps.analyse import analyse
@@ -16,6 +18,8 @@ from fab.steps.grab.folder import grab_folder
 from fab.steps.link import link_exe
 from fab.steps.preprocess import preprocess_c
 from fab.tools import ToolBox
+
+clang = importorskip('clang', reason="Clang bindings not found.")
 
 PROJECT_SOURCE = Path(__file__).parent / 'project-source'
 

--- a/tests/system_tests/grab_archive/test_grab_archive.py
+++ b/tests/system_tests/grab_archive/test_grab_archive.py
@@ -4,18 +4,20 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 from pathlib import Path
-from unittest import mock
+from unittest.mock import Mock
+
+from pytest import warns
 
 from fab.steps.grab.archive import grab_archive
-
-import pytest
 
 
 class TestGrabArchive(object):
 
     def test(self, tmp_path):
-        with pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-            tar_file = Path(__file__).parent / '../git/tiny_fortran.tar'
-            grab_archive(config=mock.Mock(source_root=tmp_path), src=tar_file)
+        tar_file = Path(__file__).parent / '../git/tiny_fortran.tar'
 
-            assert (tmp_path / 'tiny_fortran/src/my_mod.F90').exists()
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            grab_archive(config=Mock(source_root=tmp_path), src=tar_file)
+
+        assert (tmp_path / 'tiny_fortran/src/my_mod.F90').exists()

--- a/tests/system_tests/incremental_fortran/test_incremental_fortran.py
+++ b/tests/system_tests/incremental_fortran/test_incremental_fortran.py
@@ -1,14 +1,17 @@
+from datetime import timedelta, datetime
 import logging
 import os
-import zlib
-from datetime import timedelta, datetime
 from pathlib import Path
+from typing import List
+from unittest.mock import Mock
+import zlib
 
-import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import fixture, mark
 
-from fab.artefacts import ArtefactSet
+from fab.artefacts import ArtefactSet, ArtefactStore
 from fab.build_config import BuildConfig
-from fab.constants import PREBUILD, BUILD_OUTPUT
+from fab.constants import PREBUILD
 from fab.steps.analyse import analyse
 from fab.steps.cleanup_prebuilds import cleanup_prebuilds
 from fab.steps.compile_fortran import compile_fortran
@@ -22,7 +25,7 @@ from fab.util import file_walk, get_prebuild_file_groups
 PROJECT_LABEL = 'tiny_project'
 
 
-class TestIncremental():
+class TestIncremental:
     """
     Checks:
         - basic Fortran project build
@@ -34,7 +37,7 @@ class TestIncremental():
 
     # todo: check incremental build of other file types as Fab is upgraded
 
-    @pytest.fixture
+    @fixture(scope='function')
     def config(self, tmp_path):  # tmp_path is a pytest fixture which differs per test, per run
         logging.getLogger('fab').setLevel(logging.WARNING)
 
@@ -226,8 +229,44 @@ class TestIncremental():
             assert clean_hashes[prebuild_folder / pb_fpath] == rebuild_hashes[prebuild_folder / pb_fpath]
 
 
-class TestCleanupPrebuilds():
-    # Test cleanup of the incremental build artefacts
+class TestCleanupPrebuilds:
+    """
+    Tests cleanup of the incremental build artefacts.
+    """
+    @fixture(scope='function')
+    def example_config(self, fs: FakeFilesystem) -> BuildConfig:
+        """
+        Creates several versions of the same artefact.
+        """
+        artefacts = [
+            ('a.123.foo', datetime(2022, 10, 31)),
+            ('a.234.foo', datetime(2022, 10, 21)),
+            ('a.345.foo', datetime(2022, 10, 11)),
+            ('a.456.foo', datetime(2022, 10, 1)),
+        ]
+        configuration = BuildConfig(PROJECT_LABEL, Mock(),
+                                    fab_workspace=Path('/fab'),
+                                    multiprocessing=False)
+
+        configuration.prebuild_folder.mkdir(parents=True, exist_ok=True)
+        for filename, create_datetime in artefacts:
+            path = configuration.prebuild_folder / filename
+            path.touch(exist_ok=False)
+            os.utime(path, (create_datetime.timestamp(),
+                            create_datetime.timestamp()))
+        return configuration
+
+    @staticmethod
+    def prebuilt_files(configuration: BuildConfig) -> List[str]:
+        """
+        Determines a list of files in the pre-build directory.
+
+        Paths are given relative to the pre-build directory to avoid having to
+        deal with tmp_path. Paths are also sorted for reliable comparison.
+        """
+        files = file_walk(configuration.prebuild_folder)
+        filenames = [str(f.name) for f in files]
+        return sorted(filenames)
 
     in_out = [
         # prune artefacts by age
@@ -243,51 +282,29 @@ class TestCleanupPrebuilds():
         ({'older_than': timedelta(days=15), 'n_versions': 2}, ['a.123.foo', 'a.234.foo']),
     ]
 
-    @pytest.mark.parametrize("kwargs,expect", in_out)
-    def test_clean(self, tmp_path, kwargs, expect):
+    @mark.parametrize("kwargs, expect", in_out)
+    def test_clean(self, kwargs, expect, example_config: BuildConfig) -> None:
+        """
+        Tests expiry of prebuild files.
+        """
+        cleanup_prebuilds(example_config, **kwargs)
+        assert self.prebuilt_files(example_config) == expect
 
-        with BuildConfig(project_label=PROJECT_LABEL, tool_box=ToolBox(),
-                         fab_workspace=tmp_path, multiprocessing=False) as config:
-            remaining = self._prune(config, kwargs=kwargs)
+    def test_prune_unused(self, example_config: BuildConfig) -> None:
+        """
+        Tests pruning everything not current.
 
-        assert sorted(remaining) == expect
-
-    def test_prune_unused(self, tmp_path):
-        # pruning everything not current
-
+        Todo: Monkeying with private state.
+        """
         current_prebuilds = ArtefactSet.CURRENT_PREBUILDS
-        with BuildConfig(project_label=PROJECT_LABEL, tool_box=ToolBox(),
-                         fab_workspace=tmp_path,
-                         multiprocessing=False) as config:
-            config._artefact_store = {current_prebuilds: {
-                tmp_path / PROJECT_LABEL / BUILD_OUTPUT / PREBUILD / 'a.123.foo',
-                tmp_path / PROJECT_LABEL / BUILD_OUTPUT / PREBUILD / 'a.456.foo',
-            }}
+        store = ArtefactStore()
+        store.add(current_prebuilds, example_config.prebuild_folder / 'a.123.foo')
+        store.add(current_prebuilds, example_config.prebuild_folder / 'a.456.foo')
+        example_config._artefact_store = store
 
-            remaining = self._prune(config, kwargs={'all_unused': True})
+        cleanup_prebuilds(example_config, all_unused=True)
 
-        assert sorted(remaining) == [
+        assert self.prebuilt_files(example_config) == [
             'a.123.foo',
             'a.456.foo',
         ]
-
-    def _prune(self, config, kwargs):
-
-        # create several versions of the same artefact
-        artefacts = [
-            ('a.123.foo', datetime(2022, 10, 31)),
-            ('a.234.foo', datetime(2022, 10, 21)),
-            ('a.345.foo', datetime(2022, 10, 11)),
-            ('a.456.foo', datetime(2022, 10, 1)),
-        ]
-        for a, t in artefacts:
-            path = config.prebuild_folder / a
-            path.touch(exist_ok=False)
-            os.utime(path, (t.timestamp(), t.timestamp()))
-
-        cleanup_prebuilds(config, **kwargs)
-
-        remaining_artefacts = file_walk(config.prebuild_folder)
-        # pull out just the filenames so we can parameterise the tests without knowing tmp_path
-        remaining_artefacts = [str(f.name) for f in remaining_artefacts]
-        return remaining_artefacts

--- a/tests/system_tests/incremental_fortran/test_incremental_fortran.py
+++ b/tests/system_tests/incremental_fortran/test_incremental_fortran.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import zlib
 
 from pyfakefs.fake_filesystem import FakeFilesystem
-from pytest import fixture, mark
+from pytest import fixture, mark, warns
 
 from fab.artefacts import ArtefactSet, ArtefactStore
 from fab.build_config import BuildConfig
@@ -287,7 +287,9 @@ class TestCleanupPrebuilds:
         """
         Tests expiry of prebuild files.
         """
-        cleanup_prebuilds(example_config, **kwargs)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            cleanup_prebuilds(example_config, **kwargs)
         assert self.prebuilt_files(example_config) == expect
 
     def test_prune_unused(self, example_config: BuildConfig) -> None:
@@ -302,7 +304,9 @@ class TestCleanupPrebuilds:
         store.add(current_prebuilds, example_config.prebuild_folder / 'a.456.foo')
         example_config._artefact_store = store
 
-        cleanup_prebuilds(example_config, all_unused=True)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            cleanup_prebuilds(example_config, all_unused=True)
 
         assert self.prebuilt_files(example_config) == [
             'a.123.foo',

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -9,7 +9,7 @@ from os import unlink
 from pathlib import Path
 from unittest import mock
 
-import pytest
+from pytest import fixture, mark, warns
 
 from fab.build_config import BuildConfig
 from fab.parse.x90 import X90Analyser, AnalysedX90
@@ -117,19 +117,20 @@ class Test_analysis_for_x90s_and_kernels:
         }
 
 
-@pytest.mark.skipif(not Psyclone().is_available, reason="psyclone cli tool not available")
+@mark.skipif(not Psyclone().is_available, reason="psyclone cli tool not available")
 class TestPsyclone:
     """
     Basic run of the psyclone step.
 
     """
-    @pytest.fixture
+    @fixture(scope='function')
     def config(self, tmp_path):
         config = BuildConfig('proj', ToolBox(), fab_workspace=tmp_path,
                              multiprocessing=False)
         return config
 
-    def steps(self, config, psyclone_lfric_api):
+    @staticmethod
+    def steps(config):
         here = Path(__file__).parent
         grab_folder(config, here / 'skeleton')
         find_source_files(config)
@@ -143,9 +144,14 @@ class TestPsyclone:
             config.build_output / 'kernel',
             # this second folder is just to test the multiple folders code, which was bugged. There's no kernels there.
             Path(__file__).parent / 'skeleton/algorithm',
-        ], api=psyclone_lfric_api)
+        ], api='lfric')
 
-    def test_run(self, config, psyclone_lfric_api):
+    def test_run(self, config):
+        """
+        Tests a simple PSyclone transformation.
+        """
+        config.prebuild_folder.mkdir(parents=True)
+
         # if these files exist after the run then we know:
         #   a) the expected files were created
         #   b) the prebuilds were protected from automatic cleanup
@@ -168,25 +174,26 @@ class TestPsyclone:
         # So use a list instead:
         assert all(list(config.prebuild_folder.glob(f)) == [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) == [] for f in expect_build_files)
-        with config, pytest.warns(UserWarning, match="no transformation script specified"):
-            self.steps(config, psyclone_lfric_api)
+        with warns(UserWarning, match="no transformation script specified"):
+            self.steps(config)
         assert all(list(config.prebuild_folder.glob(f)) != [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) != [] for f in expect_build_files)
 
-    def test_prebuild(self, tmp_path, config, psyclone_lfric_api):
-        with config, pytest.warns(UserWarning, match="no transformation script specified"):
-            self.steps(config, psyclone_lfric_api)
+    def test_prebuild(self, config: BuildConfig) -> None:
+        """
+        Tests prebuilds are not rebuild the second time round.
+        """
+        config.prebuild_folder.mkdir(parents=True)
 
-        # make sure no work gets done the second time round
-        with mock.patch('fab.parse.x90.X90Analyser.walk_nodes') as mock_x90_walk, \
-                mock.patch('fab.parse.fortran.FortranAnalyser.walk_nodes') as mock_fortran_walk, \
-                mock.patch('fab.tools.psyclone.Psyclone.process') as mock_run, \
-                config, pytest.warns(UserWarning, match="no transformation script specified"):
-            self.steps(config, psyclone_lfric_api)
+        with warns(UserWarning, match="no transformation script specified"):
+            self.steps(config)
+        first_timestamps = {file: file.stat() for file in config.prebuild_folder.iterdir()}
 
-        mock_x90_walk.assert_not_called()
-        mock_fortran_walk.assert_not_called()
-        mock_run.assert_not_called()
+        with warns(UserWarning, match="no transformation script specified"):
+            self.steps(config)
+        second_timestamps = {file: file.stat() for file in config.prebuild_folder.iterdir()}
+
+        assert second_timestamps == first_timestamps
 
 
 class TestTransformationScript:
@@ -194,16 +201,17 @@ class TestTransformationScript:
     Check whether transformation script is called with x90 file once
     and whether transformation script is passed to psyclone after '-s'.
 
+    ToDo: Mockkery not appropriate in system tests.
     """
-    def test_transformation_script(self, psyclone_lfric_api):
+    def test_transformation_script(self) -> None:
         psyclone_tool = Psyclone()
-        psyclone_tool._version = (2, 4, 0)
+        psyclone_tool._version = (3, 0, 0)
         psyclone_tool._is_available = True
 
         mock_transformation_script = mock.Mock(return_value=__file__)
         with mock.patch('fab.tools.psyclone.Psyclone.run') as mock_run_command:
             mock_transformation_script.return_value = Path(__file__)
-            psyclone_tool.process(api=psyclone_lfric_api,
+            psyclone_tool.process(api='lfric',
                                   x90_file=Path(__file__),
                                   psy_file=Path(__file__),
                                   alg_file=Path(__file__),
@@ -217,7 +225,7 @@ class TestTransformationScript:
             mock_transformation_script.assert_called_once_with(Path(__file__), None)
             # check transformation_script is passed to psyclone command with '-s'
             mock_run_command.assert_called_with(
-                additional_parameters=['-api', psyclone_lfric_api,
+                additional_parameters=['--psykal-dsl', 'lfric',
                                        '-opsy',  Path(__file__),
                                        '-oalg', Path(__file__),
                                        '-l', 'all',

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -4,9 +4,10 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 import filecmp
-import shutil
 from os import unlink
 from pathlib import Path
+import shutil
+from typing import Any, Dict
 from unittest import mock
 
 from pytest import fixture, mark, warns
@@ -174,10 +175,25 @@ class TestPsyclone:
         # So use a list instead:
         assert all(list(config.prebuild_folder.glob(f)) == [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) == [] for f in expect_build_files)
-        with warns(UserWarning, match="no transformation script specified"):
+        with warns(UserWarning, match="no transformation script specified"), \
+                warns(UserWarning, match="_metric_send_conn not set.*"):
             self.steps(config)
         assert all(list(config.prebuild_folder.glob(f)) != [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) != [] for f in expect_build_files)
+
+    @staticmethod
+    def __file_stats(path: Path) -> Dict[str, Dict[str, Any]]:
+        stat_map: Dict[str, Dict[str, Any]] = {}
+        for file in path.iterdir():
+            stats = file.stat()
+            stat_map[str(file)] = {key: getattr(stats, key) for key in dir(stats) if key.startswith('st_')}
+            #
+            # We remove atime (time of most recent access) as we aren't
+            # interested in accesses, only modifications.
+            #
+            del stat_map[str(file)]['st_atime']
+            del stat_map[str(file)]['st_atime_ns']
+        return stat_map
 
     def test_prebuild(self, config: BuildConfig) -> None:
         """
@@ -185,13 +201,15 @@ class TestPsyclone:
         """
         config.prebuild_folder.mkdir(parents=True)
 
-        with warns(UserWarning, match="no transformation script specified"):
+        with warns(UserWarning, match="no transformation script specified"), \
+                warns(UserWarning, match="_metric_send_conn not set.*"):
             self.steps(config)
-        first_timestamps = {file: file.stat() for file in config.prebuild_folder.iterdir()}
+        first_timestamps = self.__file_stats(config.prebuild_folder)
 
-        with warns(UserWarning, match="no transformation script specified"):
+        with warns(UserWarning, match="no transformation script specified"), \
+                warns(UserWarning, match="_metric_send_conn not set.*"):
             self.steps(config)
-        second_timestamps = {file: file.stat() for file in config.prebuild_folder.iterdir()}
+        second_timestamps = self.__file_stats(config.prebuild_folder)
 
         assert second_timestamps == first_timestamps
 

--- a/tests/system_tests/zero_config/test_zero_config.py
+++ b/tests/system_tests/zero_config/test_zero_config.py
@@ -1,53 +1,76 @@
 from pathlib import Path
+from shutil import copytree
 
 import pytest
+from pytest import warns
 
 from fab.cli import cli_fab
-from fab.tools import ToolRepository
 
 
 class TestZeroConfig:
+    """
+    Exercises "zero configuration" mode.
+    """
+    def test_fortran(self, tmp_path: Path) -> None:
+        """
+        Tests a sample Fortran source.
 
-    def test_fortran_dependencies(self, tmp_path):
-        # test the sample project in the fortran dependencies system test
-        with pytest.warns(DeprecationWarning, match="RootIncFiles is deprecated as .inc files are due to be removed."):
-            kwargs = {'project_label': 'fortran deps test', 'fab_workspace': tmp_path, 'multiprocessing': False}
+        ToDo: Fragile due to assumption of donor code.
+        """
+        copytree(
+            Path(__file__).parent.parent / 'FortranDependencies' / 'project-source',
+            tmp_path / 'source'
+        )
 
-            config = cli_fab(
-                folder=Path(__file__).parent.parent / 'FortranDependencies',
-                kwargs=kwargs)
+        kwargs = {'project_label': 'fortran test',
+                  'fab_workspace': tmp_path,
+                  'multiprocessing': False}
 
-            assert (config.project_workspace / 'first').exists()
-            assert (config.project_workspace / 'second').exists()
+        with warns(DeprecationWarning,
+                   match="RootIncFiles is deprecated as .inc files are due "
+                         "to be removed."):
 
-    def test_c_fortran_interop(self, tmp_path):
-        # test the sample project in the fortran dependencies system test
-        with pytest.warns(DeprecationWarning, match="RootIncFiles is deprecated as .inc files are due to be removed."):
-            kwargs = {'project_label': 'CFInterop test', 'fab_workspace': tmp_path, 'multiprocessing': 'False'}
+            config = cli_fab(folder=tmp_path / 'source', kwargs=kwargs)
 
-            config = cli_fab(
-                folder=Path(__file__).parent.parent / 'CFortranInterop',
-                kwargs=kwargs)
+        assert (config.project_workspace / 'first').exists()
+        assert (config.project_workspace / 'second').exists()
 
-            assert (config.project_workspace / 'main').exists()
+    def test_c(self, tmp_path: Path) -> None:
+        """
+        Tests a sample C project.
 
-    def test_fortran_explicit_gfortran(self, tmp_path):
-        # test the sample project in the fortran dependencies system test
-        kwargs = {'project_label': 'fortran explicit gfortran', 'fab_workspace': tmp_path, 'multiprocessing': False}
+        ToDo: Fragility due to assumption of source donor.
+        """
+        pytest.importorskip('clang', reason="Missing libclang bindings.")
+        copytree(
+            Path(__file__).parent.parent / 'CUserHeader' / 'project-source',
+            tmp_path / 'source'
+        )
 
-        tr = ToolRepository()
-        tr.set_default_compiler_suite("gnu")
+        kwargs = {'project_label': 'c test',
+                  'fab_workspace': tmp_path,
+                  'multiprocessing': False}
+        with warns(DeprecationWarning,
+                   match="RootIncFiles is deprecated as .inc files are due to be removed."):
+            config = cli_fab(folder=tmp_path / 'source', kwargs=kwargs)
+        assert (config.project_workspace / 'main').exists()
 
-        # TODO: If the intel compiler should be used here, the linker will
-        # need an additional flag (otherwise duplicated `main` symbols will
-        # occur). The following code can be used e.g. in cli.py:
-        #
-        # if config.tool_box.get_tool(Category.LINKER).name == "linker-ifort":
-        #    flags = ["-nofor-main"]
+    def test_c_fortran(self, tmp_path: Path) -> None:
+        """
+        Tests a sample C project which interworks with Fortran.
 
-        with pytest.warns(DeprecationWarning, match="RootIncFiles is deprecated as .inc files are due to be removed."):
-            config = cli_fab(
-                folder=Path(__file__).parent.parent / 'CFortranInterop',
-                kwargs=kwargs)
+        ToDo: Fragility due to assumption of source donor.
+        """
+        pytest.importorskip('clang', reason="Missing libclang bindings.")
+        copytree(
+            Path(__file__).parent.parent / 'CFortranInterop' / 'project-source',
+            tmp_path / 'source'
+        )
 
+        kwargs = {'project_label': 'C test',
+                  'fab_workspace': tmp_path / 'fab',
+                  'multiprocessing': False}
+        with warns(DeprecationWarning,
+                   match="RootIncFiles is deprecated as .inc files are due to be removed."):
+            config = cli_fab(folder=tmp_path / 'source', kwargs=kwargs)
         assert (config.project_workspace / 'main').exists()

--- a/tests/unit_tests/steps/grab/test_svn_fcm_unit_test.py
+++ b/tests/unit_tests/steps/grab/test_svn_fcm_unit_test.py
@@ -3,28 +3,55 @@
 #  For further details please refer to the file COPYRIGHT
 #  which you should have received as part of this distribution
 # ##############################################################################
+"""
+Exercises grab from Subversion and FCM steps.
 
-# Most of the testing of svn and fcm grab classes are in the system tests.
+Most of the testing happens at the task level.
+
+ToDo: Messing with "private" members.
+"""
+from typing import Optional, Tuple
+
+from pytest import mark, raises
 
 from fab.steps.grab.svn import _get_revision
-import pytest
 
 
 class TestRevision(object):
-    # test the handling of the revision in the base class
+    """
+    Tests handling of revisions.
+    """
+    @mark.parametrize(
+        ['url', 'expected'],
+        [
+            ('http://example.net/repo', ('http://example.net/repo', None)),
+            ('http://example.net/repo@rev', ('http://example.net/repo', 'rev'))
+        ]
+    )
+    def test_no_revision(self, url: str,
+                         expected: Tuple[str, Optional[str]]) -> None:
+        """
+        Tests revision argument not given.
+        """
+        assert _get_revision(src=url) == expected
 
-    def test_no_revision(self):
-        assert _get_revision(src='url') == ('url', None)
-
-    def test_url_revision(self):
-        assert _get_revision(src='url@rev') == ('url', 'rev')
-
-    def test_revision_param(self):
-        assert _get_revision(src='url', revision='rev') == ('url', 'rev')
-
-    def test_both_matching(self):
-        assert _get_revision(src='url@rev', revision='rev') == ('url', 'rev')
+    @mark.parametrize(
+        ['url', 'revision', 'expected'],
+        [
+            ('http://example.net/repo', 'rev', ('http://example.net/repo', 'rev')),
+            ('http://example.net/repo@rev', 'rev', ('http://example.net/repo', 'rev'))
+        ]
+    )
+    def test_revision_param(self, url: str, revision: str,
+                            expected: Tuple[str, Optional[str]]):
+        """
+        Tests revision argument given.
+        """
+        assert _get_revision(src=url, revision=revision) == expected
 
     def test_both_different(self):
-        with pytest.raises(ValueError):
-            assert _get_revision(src='url@rev', revision='bev')
+        """
+        Tests mismatch between URL revision and argument.
+        """
+        with raises(ValueError):
+            assert _get_revision(src='url@rev', revision='bez')

--- a/tests/unit_tests/steps/test_analyse.py
+++ b/tests/unit_tests/steps/test_analyse.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from unittest import mock
+from typing import Dict, List, Set
+from unittest.mock import Mock
 
-import pytest
+from pytest import fixture, warns
 
 from fab.build_config import BuildConfig
 from fab.dep_tree import AnalysedDependent
@@ -13,15 +14,20 @@ from fab.util import HashedFile
 
 
 class Test_gen_symbol_table(object):
-
-    @pytest.fixture
-    def analysed_files(self):
+    """
+    Tests source symbol management.
+    """
+    @fixture
+    def analysed_files(self) -> List[AnalysedDependent]:
         return [AnalysedDependent(fpath=Path('foo.c'),
-                                  symbol_defs=['foo_1', 'foo_2'], file_hash=0),
+                                  symbol_defs=['foo_1', 'foo_2'], file_hash=1),
                 AnalysedDependent(fpath=Path('bar.c'),
-                                  symbol_defs=['bar_1', 'bar_2'], file_hash=0)]
+                                  symbol_defs=['bar_1', 'bar_2'], file_hash=2)]
 
-    def test_vanilla(self, analysed_files):
+    def test_vanilla(self, analysed_files: List[AnalysedDependent]) -> None:
+        """
+        Tests symbol table generation.
+        """
         result = _gen_symbol_table(analysed_files=analysed_files)
 
         assert result == {
@@ -31,11 +37,14 @@ class Test_gen_symbol_table(object):
             'bar_2': Path('bar.c'),
         }
 
-    def test_duplicate_symbol(self, analysed_files):
-        # duplicate a symbol from the first file in the second file
+    def test_duplicate_symbol(self,
+                              analysed_files: List[AnalysedDependent]) -> None:
+        """
+        Tests duplicate symbols in different files.
+        """
         analysed_files[1].symbol_defs.add('foo_1')
 
-        with pytest.warns(UserWarning):
+        with warns(UserWarning):
             result = _gen_symbol_table(analysed_files=analysed_files)
 
         assert result == {
@@ -47,9 +56,15 @@ class Test_gen_symbol_table(object):
 
 
 class Test_gen_file_deps(object):
+    """
+    Tests file dpendency management.
+    """
+    def test_vanilla(self) -> None:
+        """
+        Tests analysing files.
 
-    def test_vanilla(self):
-
+        ToDo: Messing with "private" state.
+        """
         my_file = Path('my_file.f90')
         symbols = {
             'my_mod': my_file,
@@ -59,9 +74,11 @@ class Test_gen_file_deps(object):
         }
 
         analysed_files = [
-            mock.Mock(
-                spec=AnalysedDependent, fpath=my_file,
-                symbol_deps={'my_func', 'dep1_mod', 'dep2'}, file_deps=set()),
+            AnalysedDependent(my_file,
+                              3,
+                              None,
+                              {'my_func', 'dep1_mod', 'dep2'},
+                              set())
         ]
 
         _gen_file_deps(analysed_files=analysed_files, symbols=symbols)
@@ -72,10 +89,15 @@ class Test_gen_file_deps(object):
 
 # todo: this is fortran-ey, move it?
 class Test_add_unreferenced_deps(object):
+    """
+    Tests handling unrefrenced dependencies.
+    """
+    def test_vanilla(self) -> None:
+        """
+        Tests
 
-    def test_vanilla(self):
-        # analyser = Analyse(root_symbol=None)
-
+        ToDo: Messing with "private" methods.
+        """
         # we analysed the source folder and found these symbols
         symbol_table = {
             "root": Path("root.f90"),
@@ -85,9 +107,9 @@ class Test_add_unreferenced_deps(object):
         }
 
         # we extracted the build tree
-        build_tree = {
-            Path('root.f90'): AnalysedFortran(fpath=Path(), file_hash=0),
-            Path('root_dep.f90'): AnalysedFortran(fpath=Path(), file_hash=0),
+        build_tree: Dict[Path, AnalysedDependent] = {
+            Path('root.f90'): AnalysedFortran(fpath=Path(), file_hash=1),
+            Path('root_dep.f90'): AnalysedFortran(fpath=Path(), file_hash=2),
         }
 
         # we want to force this symbol into the build (because it's not used
@@ -95,14 +117,14 @@ class Test_add_unreferenced_deps(object):
         unreferenced_deps = ['util']
 
         # the stuff to add to the build tree will be found in here
-        all_analysed_files = {
+        all_analysed_files: Dict[Path, AnalysedDependent] = {
             # root.f90 and root_util.f90 would also be in here but the test
             # doesn't need them
             Path('util.f90'): AnalysedFortran(fpath=Path('util.f90'),
                                               file_deps={Path('util_dep.f90')},
-                                              file_hash=0),
+                                              file_hash=3),
             Path('util_dep.f90'): AnalysedFortran(fpath=Path('util_dep.f90'),
-                                                  file_hash=0),
+                                                  file_hash=4),
         }
 
         _add_unreferenced_deps(
@@ -121,44 +143,56 @@ class Test_add_unreferenced_deps(object):
 
 
 class Test_parse_files(object):
+    """
+    Tests examining a file.
 
-    # todo: test the correct artefacts are marked as current for the
-    #       cleanup step
-    # todo: this method should be tested a bit more thoroughly
+    todo: test the correct artefacts are marked as current for the
+          cleanup step.
+    todo: this method should be tested a bit more thoroughly.
+    """
+    def test_exceptions(self, tmp_path: Path, monkeypatch) -> None:
+        """
+        Tests exceptions thrown from processing do not halt build.
 
-    def test_exceptions(self, tmp_path):
-        # make sure parse exceptions do not stop the build
-        with mock.patch('fab.steps.run_mp',
-                        return_value=[(Exception('foo'), None)]), \
-             pytest.warns(UserWarning, match="deprecated 'DEPENDS ON:'"):
-            # The warning "deprecated 'DEPENDS ON:' comment found in fortran
-            # code" is in "def _parse_files" in "source/steps/analyse.py"
-            config = BuildConfig('proj', ToolBox(), fab_workspace=tmp_path)
+        ToDo: Do we want this? Shouldn't exceptions stop build?
 
+        ToDo: Messing with "private" methods.
+        """
+        def raises(*args, **kwargs):
+            raise Exception("foo")
+
+        # The warning "deprecated 'DEPENDS ON:' comment found in fortran
+        # code" is in "def _parse_files" in "source/steps/analyse.py"
+        config = BuildConfig('proj', ToolBox(), fab_workspace=tmp_path)
+
+        monkeypatch.setattr('fab.steps.run_mp', raises)
+        with warns(UserWarning, match="deprecated 'DEPENDS ON:'"):
             # the exception should be suppressed (and logged) and this step
             # should run to completion
-            _parse_files(config, files=[], fortran_analyser=mock.Mock(),
-                         c_analyser=mock.Mock())
+            _parse_files(config, files=[],
+                         fortran_analyser=Mock(),
+                         c_analyser=Mock())
 
 
 class TestAddManualResults:
-    '''test user-specified analysis results, for when fparser fails to parse a
-    valid file.
-    '''
+    """
+    Tests user over-ridden results. Covers parser failures.
+    """
+    def test_vanilla(self, monkeypatch) -> None:
+        """
+        Tests simple replacement.
 
-    def test_vanilla(self):
-        # test normal usage of manual analysis results
+        ToDo: Messing with "private" methods.
+        """
         workaround = FortranParserWorkaround(fpath=Path('foo.f'),
                                              symbol_defs={'foo', })
-        analysed_files = set()
+        analysed_files: Set[AnalysedDependent] = set()
 
-        with mock.patch('fab.parse.fortran.file_checksum',
-                        return_value=HashedFile(None, 123)), \
-             pytest.warns(UserWarning, match="SPECIAL MEASURE: injecting user-"
-                                             "defined analysis results"):
-            # This warning "UserWarning: SPECIAL MEASURE: injecting
-            # user-defined analysis results" is in "def _add_manual_results"
-            # in "source/steps/analyse.py"
+        monkeypatch.setattr('fab.parse.fortran.file_checksum',
+                            lambda x: HashedFile(None, 123))
+        with warns(UserWarning,
+                   match="SPECIAL MEASURE: "
+                         "injecting user-defined analysis results"):
             _add_manual_results(special_measure_analysis_results=[workaround],
                                 analysed_files=analysed_files)
 

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -6,103 +6,102 @@
 """
 Test for the archive step.
 """
+from pathlib import Path
 
-from unittest import mock
-from unittest.mock import call
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import raises, warns
+from pytest_subprocess.fake_process import FakeProcess
 
-import pytest
+from tests.conftest import call_list
 
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps.archive_objects import archive_objects
-from fab.tools import Category, ToolBox
+from fab.tools.category import Category
 
 
 class TestArchiveObjects:
-    '''Test the achive step.
-    '''
-
-    def test_for_exes(self):
-        '''As used when archiving before linking exes.
-        '''
+    """
+    Test the achive step.
+    """
+    def test_for_exes(self, stub_tool_box,
+                      fake_process: FakeProcess,
+                      fs: FakeFilesystem) -> None:
+        """
+        As used when archiving before linking exes.
+        """
+        version_command = ['ar', '--version']
+        fake_process.register(version_command, stdout='1.2.3')
+        commands = []
+        commands.append(version_command)
         targets = ['prog1', 'prog2']
+        for target in targets:
+            ar_command = ['ar', 'cr', f'/fab/proj/build_output/{target}.a',
+                          f'{target}.o', 'util.o']
+            fake_process.register(ar_command)
+            commands.append(ar_command)
 
-        config = BuildConfig('proj', ToolBox())
+        config = BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab'))
         for target in targets:
             config.artefact_store.update_dict(
-                ArtefactSet.OBJECT_FILES, target,
-                set([f'{target}.o', 'util.o']))
+                ArtefactSet.OBJECT_FILES,
+                {f'{target}.o', 'util.o'},
+                target
+            )
 
-        mock_result = mock.Mock(returncode=0, return_value=123)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as mock_run_command, \
-                pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                                "cannot send metrics"):
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             archive_objects(config=config)
-
-        # ensure the correct command line calls were made
-        expected_calls = [
-            call(['ar', 'cr', str(config.build_output / f'{target}.a'),
-                  f'{target}.o', 'util.o'],
-                 capture_output=True, env=None, cwd=None, check=False)
-            for target in targets
-        ]
-        mock_run_command.assert_has_calls(expected_calls)
+        assert call_list(fake_process) == commands
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            target: set([str(config.build_output / f'{target}.a')])
+            target: {str(config.build_output / f'{target}.a')}
             for target in targets}
 
-    def test_for_library(self):
-        '''As used when building an object archive or archiving before linking
+    def test_for_library(self, stub_tool_box,
+                         fake_process: FakeProcess,
+                         fs: FakeFilesystem) -> None:
+        """
+        As used when building an object archive or archiving before linking
         a shared library.
-        '''
+        """
+        help_command = ['ar', '--version']
+        fake_process.register(help_command, stdout='1.0.0')
+        ar_command = ['ar', 'cr', '/fab/proj/build_output/mylib.a',
+                      'util1.o', 'util2.o']
+        fake_process.register(ar_command)
 
-        # Make sure that 'ar' is initialised, which means `ar --version` was
-        # called. Otherwise (esp. in parallel runs) the test below can report
-        # two calls, the first one to determine the version. Note that the
-        # previous test does not have this problem since it uses
-        # `assert_has_calls`. It is sufficient to just get ar from a ToolBox,
-        # this will make sure ar actually works, so `ar --version` is called.
-        tool_box = ToolBox()
-        _ = tool_box.get_tool(Category.AR)
-
-        config = BuildConfig('proj', tool_box)
+        config = BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab'),
+                             multiprocessing=False)
         config.artefact_store.update_dict(
-            ArtefactSet.OBJECT_FILES, None, {'util1.o', 'util2.o'})
+            ArtefactSet.OBJECT_FILES, {'util1.o', 'util2.o'}, None
+        )
 
-        mock_result = mock.Mock(returncode=0, return_value=123)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as mock_run_command, \
-                pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                                "cannot send metrics"):
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             archive_objects(config=config,
                             output_fpath=config.build_output / 'mylib.a')
-
-        # ensure the correct command line calls were made
-        mock_run_command.assert_called_once_with([
-            'ar', 'cr', str(config.build_output / 'mylib.a'),
-            'util1.o', 'util2.o'],
-            capture_output=True, env=None, cwd=None, check=False)
+        assert call_list(fake_process) == [ar_command]
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            None: set([str(config.build_output / 'mylib.a')])}
+            None: {str(config.build_output / 'mylib.a')}}
 
-    def test_incorrect_tool(self, tool_box):
-        '''Test that an incorrect archive tool is detected
-        '''
-        config = BuildConfig('proj', tool_box)
-        cc = tool_box.get_tool(Category.C_COMPILER, config.mpi, config.openmp)
+    def test_incorrect_tool(self, stub_tool_box):
+        """
+        Test that an incorrect archive tool is detected.
+        """
+        config = BuildConfig('proj', stub_tool_box)
+        cc = stub_tool_box.get_tool(Category.C_COMPILER, config.mpi, config.openmp)
         # And set its category to be AR
         cc._category = Category.AR
         # Now add this 'ar' tool to the tool box
-        tool_box.add_tool(cc)
+        stub_tool_box.add_tool(cc)
 
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             archive_objects(config=config,
                             output_fpath=config.build_output / 'mylib.a')
-        assert ("Unexpected tool 'mock_c_compiler' of type '<class "
-                "'fab.tools.compiler.CCompiler'>' instead of Ar"
-                in str(err.value))
+        assert str(err.value) == ("Unexpected tool 'some C compiler' of type "
+                                  "'<class 'fab.tools.compiler.CCompiler'>' "
+                                  "instead of Ar")

--- a/tests/unit_tests/steps/test_c_pragma_injector.py
+++ b/tests/unit_tests/steps/test_c_pragma_injector.py
@@ -1,19 +1,17 @@
-from sys import version_info as python_version
+from pathlib import Path
 from textwrap import dedent
-from unittest import mock
-from unittest.mock import mock_open
-
-import pytest
 
 from fab.steps.c_pragma_injector import inject_pragmas
 
 
 class Test_inject_pragmas(object):
-
-    @pytest.mark.skipif(python_version < (3, 8),
-                        reason="Requires python version 3.8 or higher for "
-                               "mock_open iteration")
-    def test_vanilla(self):
+    """
+    Tests injection of C inclusion bracketing.
+    """
+    def test_vanilla(self, fs):
+        """
+        Tests straight forward bracketing.
+        """
         source = dedent(
             """
             // C++ style comment, ignore this.
@@ -28,13 +26,12 @@ class Test_inject_pragmas(object):
             #include "final_user_include.h"
             """
         )
+        test_file = Path('/foo.c')
+        test_file.write_text(source)
 
-        with mock.patch('fab.steps.c_pragma_injector.open',
-                        mock_open(read_data=source)):
-            result = inject_pragmas(fpath="foo")
-            output = list(result)
+        result = inject_pragmas(fpath=test_file)
 
-        assert output == [
+        assert [line for line in result] == [
             '\n',
             '// C++ style comment, ignore this.\n',
             '#pragma FAB UsrIncludeStart\n',

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from typing import Dict
-from unittest import mock
-from unittest.mock import call
+from unittest.mock import Mock
+from warnings import catch_warnings
 
-import pytest
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import fixture, mark, raises
+from pytest_subprocess.fake_process import FakeProcess
 
 from fab.artefacts import ArtefactSet, ArtefactStore
 from fab.build_config import BuildConfig, FlagsConfig
@@ -11,78 +13,103 @@ from fab.parse.fortran import AnalysedFortran
 from fab.steps.compile_fortran import (
     compile_pass, get_compile_next,
     get_mod_hashes, handle_compiler_args, MpCommonArgs, process_file,
-    store_artefacts)
-from fab.tools import Category, ToolBox
+    store_artefacts
+)
+from fab.tools.category import Category
+from fab.tools.tool_box import ToolBox
 from fab.util import CompiledFile
 
 
-# This avoids pylint warnings about Redefining names from outer scope
-@pytest.fixture(name="analysed_files")
-def fixture_analysed_files():
-    a = AnalysedFortran(fpath=Path('a.f90'), file_deps={Path('b.f90')}, file_hash=0)
-    b = AnalysedFortran(fpath=Path('b.f90'), file_deps={Path('c.f90')}, file_hash=0)
-    c = AnalysedFortran(fpath=Path('c.f90'), file_hash=0)
+@fixture(scope='function')
+def analysed_files():
+    a = AnalysedFortran(fpath=Path('/fab/a.f90'),
+                        file_deps={Path('/fab/b.f90')},
+                        file_hash=0)
+    b = AnalysedFortran(fpath=Path('/fab/b.f90'),
+                        file_deps={Path('/fab/c.f90')},
+                        file_hash=0)
+    c = AnalysedFortran(fpath=Path('/fab/c.f90'), file_hash=0)
     return a, b, c
 
 
-@pytest.fixture(name="artefact_store")
-def fixture_artefact_store(analysed_files):
+@fixture(scope='function')
+def artefact_store(analysed_files):
     build_tree = {af.fpath: af for af in analysed_files}
     artefact_store = {ArtefactSet.BUILD_TREES: {None: build_tree}}
     return artefact_store
 
 
-def test_compile_cc_wrong_compiler(tool_box):
-    '''Test if a non-C compiler is specified as c compiler.
-    '''
-    config = BuildConfig('proj', tool_box, mpi=False, openmp=False)
+def test_compile_cc_wrong_compiler(stub_tool_box,
+                                   fs: FakeFilesystem,
+                                   fake_process: FakeProcess) -> None:
+    """
+    Tests specifying the wrong compiler causes an error.
+
+    ToDo: Is this a thing which can ever happen?
+    """
+    config = BuildConfig('proj', stub_tool_box, mpi=False, openmp=False)
     # Get the default Fortran compiler into the ToolBox
-    fc = tool_box[Category.FORTRAN_COMPILER]
+    fc = stub_tool_box[Category.FORTRAN_COMPILER]
     # But then change its category to be a C compiler:
+    #
+    # ToDo: Monkeying with private state is bad.
+    #
     fc._category = Category.C_COMPILER
 
     # Now check that _compile_file detects the incorrect category of the
     # Fortran compiler
-    mp_common_args = mock.Mock(config=config)
-    with pytest.raises(RuntimeError) as err:
-        process_file((None, mp_common_args))
-    assert ("Unexpected tool 'mock_fortran_compiler' of category "
-            "'C_COMPILER' instead of FortranCompiler" in str(err.value))
+    mp_common_args = Mock(config=config)
+    with raises(RuntimeError) as err:
+        process_file((Mock(), mp_common_args))
+    assert str(err.value) \
+           == "Unexpected tool 'some Fortran compiler' of category " \
+              + "'C_COMPILER' instead of FortranCompiler"
 
-    with pytest.raises(RuntimeError) as err:
+    with raises(RuntimeError) as err:
         handle_compiler_args(config)
-    assert ("Unexpected tool 'mock_fortran_compiler' of category "
-            "'C_COMPILER' instead of FortranCompiler" in str(err.value))
+    assert str(err.value) \
+        == "Unexpected tool 'some Fortran compiler' of category " \
+           + "'C_COMPILER' instead of FortranCompiler"
 
 
 class TestCompilePass:
 
-    def test_vanilla(self, analysed_files, tool_box: ToolBox):
-        # make sure it compiles b only
-        a, b, c = analysed_files
-        uncompiled = {a, b}
-        compiled: Dict[Path, CompiledFile] = {c.fpath: mock.Mock(input_fpath=c.fpath)}
+    def test_vanilla(self, analysed_files, stub_tool_box: ToolBox,
+                     tmp_path: Path, fake_process: FakeProcess) -> None:
+        """
+        Tests only uncompiled artefacts are compiled.
 
-        run_mp_results = [
-            (
-                mock.Mock(spec=CompiledFile, input_fpath=Path('b.f90')),
-                [Path('/prebuild/b.123.o')]
-            )
-        ]
+        This test uses a real filesystem as it seems that multiprocessing
+        doesn't work will with the fake one.
+        """
+        a, b, c = analysed_files
+
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        fake_process.register(['sfc', fake_process.any()])
+
+        uncompiled = {a, b}
+        compiled = {
+            c.fpath: CompiledFile(c.fpath,
+                                  tmp_path / 'proj/build_output/_prebuild/' / c.fpath.name)
+        }
 
         # this gets filled in
         mod_hashes: Dict[str, int] = {}
 
-        config = BuildConfig('proj', tool_box)
-        mp_common_args = MpCommonArgs(config, FlagsConfig(), {}, True)
-        with mock.patch('fab.steps.compile_fortran.run_mp', return_value=run_mp_results):
-            with mock.patch('fab.steps.compile_fortran.get_mod_hashes'):
-                uncompiled_result = compile_pass(config=config, compiled=compiled, uncompiled=uncompiled,
-                                                 mod_hashes=mod_hashes, mp_common_args=mp_common_args)
+        config = BuildConfig('proj', stub_tool_box, fab_workspace=tmp_path)
+        mp_common_args = MpCommonArgs(config,
+                                      FlagsConfig(),
+                                      {},
+                                      syntax_only=True)
+        uncompiled_result = compile_pass(config=config,
+                                         compiled=compiled,
+                                         uncompiled=uncompiled,
+                                         mod_hashes=mod_hashes,
+                                         mp_common_args=mp_common_args)
 
-        assert Path('a.f90') not in compiled
-        assert Path('b.f90') in compiled
-        assert list(uncompiled_result)[0].fpath == Path('a.f90')
+        assert Path('/fab/a.f90') not in compiled
+        assert Path('/fab/b.f90') in compiled
+        assert list(uncompiled_result)[0].fpath == Path('/fab/a.f90')
 
 
 class TestGetCompileNext:
@@ -90,7 +117,7 @@ class TestGetCompileNext:
     def test_vanilla(self, analysed_files):
         a, b, c = analysed_files
         uncompiled = {a, b}
-        compiled = {c.fpath: mock.Mock(input_fpath=c.fpath)}
+        compiled = {c.fpath: Mock(input_fpath=c.fpath)}
 
         compile_next = get_compile_next(compiled, uncompiled)
 
@@ -102,7 +129,7 @@ class TestGetCompileNext:
         to_compile = {a, b}
         already_compiled_files = {}
 
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             get_compile_next(already_compiled_files, to_compile)
 
 
@@ -113,21 +140,21 @@ class TestStoreArtefacts:
         # what we wanted to compile
         build_lists = {
             'root1': [
-                mock.Mock(fpath=Path('root1.f90')),
-                mock.Mock(fpath=Path('dep1.f90')),
+                Mock(fpath=Path('root1.f90')),
+                Mock(fpath=Path('dep1.f90')),
             ],
             'root2': [
-                mock.Mock(fpath=Path('root2.f90')),
-                mock.Mock(fpath=Path('dep2.f90')),
+                Mock(fpath=Path('root2.f90')),
+                Mock(fpath=Path('dep2.f90')),
             ],
         }
 
         # what we actually compiled
         compiled_files = {
-            Path('root1.f90'): mock.Mock(input_fpath=Path('root1.f90'), output_fpath=Path('root1.o')),
-            Path('dep1.f90'): mock.Mock(input_fpath=Path('dep1.f90'), output_fpath=Path('dep1.o')),
-            Path('root2.f90'): mock.Mock(input_fpath=Path('root2.f90'), output_fpath=Path('root2.o')),
-            Path('dep2.f90'): mock.Mock(input_fpath=Path('dep2.f90'), output_fpath=Path('dep2.o')),
+            Path('root1.f90'): Mock(input_fpath=Path('root1.f90'), output_fpath=Path('root1.o')),
+            Path('dep1.f90'): Mock(input_fpath=Path('dep1.f90'), output_fpath=Path('dep1.o')),
+            Path('root2.f90'): Mock(input_fpath=Path('root2.f90'), output_fpath=Path('root2.o')),
+            Path('dep2.f90'): Mock(input_fpath=Path('dep2.f90'), output_fpath=Path('dep2.o')),
         }
 
         # where it stores the results
@@ -143,10 +170,10 @@ class TestStoreArtefacts:
 
 
 # This avoids pylint warnings about Redefining names from outer scope
-@pytest.fixture(name="content")
-def fixture_content(tool_box):
+@fixture(scope='function')
+def content(stub_tool_box, fs: FakeFilesystem):
     flags = ['flag1', 'flag2']
-    flags_config = mock.Mock()
+    flags_config = Mock()
     flags_config.flags_for_path.return_value = flags
 
     analysed_file = AnalysedFortran(fpath=Path('foofile'), file_hash=34567)
@@ -155,317 +182,411 @@ def fixture_content(tool_box):
     analysed_file.add_module_def('mod_def_1')
     analysed_file.add_module_def('mod_def_2')
 
-    obj_combo_hash = '18c460326'
-    mods_combo_hash = '115b4701c'
     mp_common_args = MpCommonArgs(
-        config=BuildConfig('proj', tool_box, fab_workspace=Path('/fab')),
+        config=BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab')),
         flags=flags_config,
         mod_hashes={'mod_dep_1': 12345, 'mod_dep_2': 23456},
         syntax_only=False,
     )
 
-    return (mp_common_args, flags, analysed_file, obj_combo_hash,
-            mods_combo_hash)
+    return (mp_common_args, flags, analysed_file)
 
 
 class TestProcessFile:
+    def test_without_prebuild(self, content,
+                              fake_process: FakeProcess,
+                              fs: FakeFilesystem) -> None:
+        """
+        Tests compile when prebuids are not present.
+        """
+        mp_common_args, flags, analysed_file = content
 
-    # Developer's note: If the "mods combo hash" changes you'll get an unhelpful message from pytest.
-    # It'll come from this function but pytest won't tell you that.
-    # You'll have to set a breakpoint here to see the changed hash in calls to mock_copy.
-    def ensure_mods_stored(self, mock_copy, mods_combo_hash):
-        # Make sure the newly created mod files were copied TO the prebuilds folder.
-        mock_copy.assert_has_calls(
-            calls=[
-                call(Path('/fab/proj/build_output/mod_def_1.mod'),
-                     Path(f'/fab/proj/build_output/_prebuild/mod_def_1.{mods_combo_hash}.mod')),
-                call(Path('/fab/proj/build_output/mod_def_2.mod'),
-                     Path(f'/fab/proj/build_output/_prebuild/mod_def_2.{mods_combo_hash}.mod')),
-            ],
-            any_order=True,
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
+
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
         )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag2', 'foofile',
+             '-o', '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o']
+        ]
 
-    def ensure_mods_restored(self, mock_copy, mods_combo_hash):
-        # make sure previously built mod files were copied FROM the prebuilds folder
-        mock_copy.assert_has_calls(
-            calls=[
-                call(Path(f'/fab/proj/build_output/_prebuild/mod_def_1.{mods_combo_hash}.mod'),
-                     Path('/fab/proj/build_output/mod_def_1.mod')),
-                call(Path(f'/fab/proj/build_output/_prebuild/mod_def_2.{mods_combo_hash}.mod'),
-                     Path('/fab/proj/build_output/mod_def_2.mod')),
-            ],
-            any_order=True,
-        )
-
-    def test_without_prebuild(self, content):
-        # call compile_file() and return a CompiledFile
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
-
-        flags_config = mock.Mock()
-        flags_config.flags_for_path.return_value = flags
-
-        with mock.patch('pathlib.Path.exists', return_value=False):  # no output files exist
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
-
-        # check we got the expected compilation result
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-
-        # check we called the tool correctly
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-
-        # check the correct mod files were copied to the prebuild folder
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
-
-        # check the correct artefacts were returned
+        # check the correct artefacts were generated.
+        #
+        # This is done before opening files in case hasehse have changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.1ff6e93b2.o',
+            pb / 'mod_def_2.188dd00a8.mod',
+            pb / 'mod_def_1.188dd00a8.mod'
         }
 
-    def test_with_prebuild(self, content):
-        # If the mods and obj are prebuilt, don't compile.
-        mp_common_args, _, analysed_file, obj_combo_hash, mods_combo_hash = content
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).read_text() == "Second module"
 
-        with mock.patch('pathlib.Path.exists', return_value=True):  # mod def files and obj file all exist
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+    def test_with_prebuild(self, content,
+                           fs: FakeFilesystem,
+                           fake_process: FakeProcess) -> None:
+        """
+        Tests compilation only if prebuidlds are not present.
+        """
+        mp_common_args, _, analysed_file = content
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_not_called()
-        self.ensure_mods_restored(mock_copy, mods_combo_hash)
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        # check the correct artefacts were returned
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).write_text("First module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
+        ).write_text("Object file")
+
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
+        )
+
+        # check the correct artefacts were generated.
+        #
+        # This is done before anything else in case hashes have changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.1ff6e93b2.o',
+            pb / 'mod_def_2.188dd00a8.mod',
+            pb / 'mod_def_1.188dd00a8.mod'
         }
 
-    def test_file_hash(self, content):
-        # Changing the source hash must change the combo hash for the mods and obj.
-        # Note: This test adds 1 to the analysed files hash. We're using checksums so
-        #       the resulting object file and mod file combo hashes can be expected to increase by 1 too.
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
+        assert [call.args for call in record.calls] == []
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).read_text() == "Second module"
+
+    def test_file_hash(self, content, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests changing source hash leads to new module and object hashes.
+        """
+        mp_common_args, flags, analysed_file = content
 
         analysed_file._file_hash += 1
-        obj_combo_hash = f'{int(obj_combo_hash, 16) + 1:x}'
-        mods_combo_hash = f'{int(mods_combo_hash, 16) + 1:x}'
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a9.mod'
+        ).write_text("First module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a9.mod'
+        ).write_text("Second module")
 
-        # check the correct artefacts were returned
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b3.o'
+        )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag2', 'foofile',
+             '-o', '/fab/proj/build_output/_prebuild/foofile.1ff6e93b3.o']
+        ]
+
+        # check the correct artefacts were generated.
+        #
+        # This is done before opening the files incase hashes have changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.1ff6e93b3.o',
+            pb / 'mod_def_2.188dd00a9.mod',
+            pb / 'mod_def_1.188dd00a9.mod'
         }
 
-    def test_flags_hash(self, content):
-        # changing the flags must change the object combo hash, but not the mods combo hash
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a9.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a9.mod'
+        ).read_text() == "Second module"
+
+    def test_flags_hash(self, content, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests changing compiler arguments changes generated object and
+        module hashes. Not source modules.
+        """
+        mp_common_args, flags, analysed_file = content
+
         flags = ['flag1', 'flag3']
         mp_common_args.flags.flags_for_path.return_value = flags
-        obj_combo_hash = '18d0868fb'
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).write_text("First module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).write_text("Second module")
 
-        # check the correct artefacts were returned
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.20030f987.o'
+        )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag3', 'foofile',
+             '-o', '/fab/proj/build_output/_prebuild/foofile.20030f987.o']
+        ]
+
+        # check the correct artefacts were generated.
+        #
+        # This is done before attempting to open files in case hashes have
+        # changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.20030f987.o',
+            pb / 'mod_def_2.188dd00a8.mod',
+            pb / 'mod_def_1.188dd00a8.mod'
         }
 
-    def test_deps_hash(self, content):
-        # Changing the checksums of any mod dependency must change the object combo hash but not the mods combo hash.
-        # Note the difference between mods we depend on and mods we define.
-        # The mods we define are not affected by the mods we depend on.
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).read_text() == "Second module"
+
+    def test_deps_hash(self, content, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests changing a module dependency checksum causes a rebuild.
+        The generated object hash should change but the generated module
+        hashes should not.
+        """
+        mp_common_args, flags, analysed_file = content
 
         mp_common_args.mod_hashes['mod_dep_1'] += 1
-        obj_combo_hash = f'{int(obj_combo_hash, 16) + 1:x}'
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).write_text("First module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).write_text("Second module")
 
-        # check the correct artefacts were returned
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b3.o'
+        )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag2', 'foofile',
+             '-o', '/fab/proj/build_output/_prebuild/foofile.1ff6e93b3.o']
+        ]
+
+        # check the correct artefacts were created.
+        #
+        # This is done before attempting to open the files incase their
+        # hashes have changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.1ff6e93b3.o',
+            pb / 'mod_def_2.188dd00a8.mod',
+            pb / 'mod_def_1.188dd00a8.mod'
         }
 
-    def test_compiler_hash(self, content):
-        # changing the compiler must change the combo hash for the mods and obj
-        mp_common_args, flags, analysed_file, orig_obj_hash, orig_mods_hash = content
-        compiler = mp_common_args.config.tool_box[Category.FORTRAN_COMPILER]
-        compiler._name += "xx"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).read_text() == "Second module"
 
-        obj_combo_hash = '1ab4727ac'
-        mods_combo_hash = '134b594a2'
-        assert obj_combo_hash != orig_obj_hash
-        assert mods_combo_hash != orig_mods_hash
+    def test_mod_missing(self, content, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests compilation on missing module.
+        """
+        mp_common_args, flags, analysed_file = content
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+        fake_process.register(['sfc', '--version'], stdout='1.2.3')
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).write_text("Second module")
+        Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
+        ).write_text("Object file")
 
-        # check the correct artefacts were returned
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
+
+        expect_object_fpath = Path(
+            '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
+        )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag2', 'foofile',
+             '-o', '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o']
+        ]
+
+        # check the correct artefacts were created.
+        #
+        # This is done before checking their contents to avoid problems
+        # failing to poen the file if the checksum has changed.
+        #
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / 'foofile.1ff6e93b2.o',
+            pb / 'mod_def_2.188dd00a8.mod',
+            pb / 'mod_def_1.188dd00a8.mod'
         }
 
-    def test_compiler_version_hash(self, content):
-        # changing the compiler version must change the combo hash for the mods and obj
-        mp_common_args, flags, analysed_file, orig_obj_hash, orig_mods_hash = content
-        compiler = mp_common_args.config.tool_box[Category.FORTRAN_COMPILER]
-        compiler._version = (9, 8, 7)
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_1.188dd00a8.mod'
+        ).read_text() == "First module"
+        assert Path(
+            '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
+        ).read_text() == "Second module"
 
-        obj_combo_hash = '1b5cc0930'
-        mods_combo_hash = '13f3a7626'
-        assert orig_obj_hash != obj_combo_hash
-        assert orig_mods_hash != mods_combo_hash
+    @mark.parametrize(['version', 'mod_hash', 'obj_hash'], [
+        ('1.2.3', '188dd00a8', '1ff6e93b2'),
+        ('9.8.7', '1b26306b2', '228f499bc')
+    ])
+    def test_obj_missing(self, content, version, mod_hash, obj_hash,
+                         fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests compilation of missing object. Also tests that different compiler
+        version numbers lead to different hashes.
+        """
+        mp_common_args, flags, analysed_file = content
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # mod files exist, obj file doesn't
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
+        fake_process.register(['sfc', '--version'], stdout=version)
+        record = fake_process.register(['sfc', fake_process.any()])
 
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        Path('/fab/proj/build_output/_prebuild').mkdir(parents=True)
+        Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
+        Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
+        Path(
+            f'/fab/proj/build_output/_prebuild/mod_def_1.{mod_hash}.mod'
+        ).write_text("First module")
+        Path(
+            f'/fab/proj/build_output/_prebuild/mod_def_2.{mod_hash}.mod'
+        ).write_text("Second module")
 
-        # check the correct artefacts were returned
-        pb = mp_common_args.config.prebuild_folder
-        assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
-        }
+        with catch_warnings():
+            res, artefacts = process_file((analysed_file, mp_common_args))
 
-    def test_mod_missing(self, content):
-        # if one of the mods we define is not present, we must recompile
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
+        expect_object_fpath = Path(
+            f'/fab/proj/build_output/_prebuild/foofile.{obj_hash}.o'
+        )
+        assert res == CompiledFile(input_fpath=analysed_file.fpath,
+                                   output_fpath=expect_object_fpath)
+        assert [call.args for call in record.calls] == [
+            ['sfc', '-c', 'flag1', 'flag2', 'foofile',
+             '-o', f'/fab/proj/build_output/_prebuild/foofile.{obj_hash}.o']
+        ]
 
-        with mock.patch('pathlib.Path.exists', side_effect=[False, True, True]):  # one mod file missing
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
-
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
-
-        # check the correct artefacts were returned
-        pb = mp_common_args.config.prebuild_folder
-        assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
-        }
-
-    def test_obj_missing(self, content):
-        # the object file we define is not present, so we must recompile
-        mp_common_args, flags, analysed_file, obj_combo_hash, mods_combo_hash = content
-
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True, False]):  # object file missing
-            with mock.patch('fab.steps.compile_fortran.compile_file') as mock_compile_file:
-                with mock.patch('shutil.copy2') as mock_copy, \
-                     pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-                    res, artefacts = process_file((analysed_file, mp_common_args))
-
-        expect_object_fpath = Path(f'/fab/proj/build_output/_prebuild/foofile.{obj_combo_hash}.o')
-        assert res == CompiledFile(input_fpath=analysed_file.fpath, output_fpath=expect_object_fpath)
-        mock_compile_file.assert_called_once_with(
-            analysed_file.fpath, flags, output_fpath=expect_object_fpath, mp_common_args=mp_common_args)
-        self.ensure_mods_stored(mock_copy, mods_combo_hash)
+        assert Path(
+            f'/fab/proj/build_output/_prebuild/mod_def_1.{mod_hash}.mod'
+        ).read_text() == "First module"
+        assert Path(
+            f'/fab/proj/build_output/_prebuild/mod_def_2.{mod_hash}.mod'
+        ).read_text() == "Second module"
 
         # check the correct artefacts were returned
         pb = mp_common_args.config.prebuild_folder
+        assert artefacts is not None
         assert set(artefacts) == {
-            pb / f'foofile.{obj_combo_hash}.o',
-            pb / f'mod_def_2.{mods_combo_hash}.mod',
-            pb / f'mod_def_1.{mods_combo_hash}.mod'
+            pb / f'foofile.{obj_hash}.o',
+            pb / f'mod_def_2.{mod_hash}.mod',
+            pb / f'mod_def_1.{mod_hash}.mod'
         }
 
 
 class TestGetModHashes:
-    '''Contains hashing-tests.'''
-
-    def test_vanilla(self, tool_box):
-        '''Test hashing. '''
-        # get a hash value for every module in the analysed file
+    """
+    Tests of hashing functionality.
+    """
+    def test_vanilla(self, stub_tool_box, fs) -> None:
+        """
+        Tests hashing of every module in an analysed file.
+        """
+        Path('/fab_workspace/proj/build_output').mkdir(parents=True)
+        Path('/fab_workspace/proj/build_output/foo.mod').write_text("Foo file.")
+        Path('/fab_workspace/proj/build_output/bar.mod').write_text("Bar file.")
+        Path('foo_mod.f90').touch()
         analysed_files = {
-            mock.Mock(module_defs=['foo', 'bar']),
+            AnalysedFortran('foo_mod.f90',
+                            module_defs=['foo', 'bar'],
+                            symbol_defs=['foo', 'bar'])
         }
 
-        config = BuildConfig('proj', tool_box,
+        config = BuildConfig('proj', stub_tool_box,
                              fab_workspace=Path('/fab_workspace'))
 
-        with mock.patch('pathlib.Path.exists', side_effect=[True, True]):
-            with mock.patch(
-                    'fab.steps.compile_fortran.file_checksum',
-                    side_effect=[mock.Mock(file_hash=123), mock.Mock(file_hash=456)]):
-                result = get_mod_hashes(analysed_files=analysed_files, config=config)
+        result = get_mod_hashes(analysed_files=analysed_files, config=config)
 
-        assert result == {'foo': 123, 'bar': 456}
+        assert result == {'foo': 3990191875, 'bar': 2746925363}

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 from typing import Dict
 from unittest.mock import Mock
-from warnings import catch_warnings
 
 from pyfakefs.fake_filesystem import FakeFilesystem
-from pytest import fixture, mark, raises
+from pytest import fixture, mark, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
 
 from fab.artefacts import ArtefactSet, ArtefactStore
@@ -208,7 +207,8 @@ class TestProcessFile:
         Path('/fab/proj/build_output/mod_def_1.mod').write_text("First module")
         Path('/fab/proj/build_output/mod_def_2.mod').write_text("Second module")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -264,7 +264,8 @@ class TestProcessFile:
             '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
         ).write_text("Object file")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -315,7 +316,8 @@ class TestProcessFile:
             '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a9.mod'
         ).write_text("Second module")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -370,7 +372,8 @@ class TestProcessFile:
             '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
         ).write_text("Second module")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -426,7 +429,8 @@ class TestProcessFile:
             '/fab/proj/build_output/_prebuild/mod_def_2.188dd00a8.mod'
         ).write_text("Second module")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -478,7 +482,8 @@ class TestProcessFile:
             '/fab/proj/build_output/_prebuild/foofile.1ff6e93b2.o'
         ).write_text("Object file")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(
@@ -536,7 +541,8 @@ class TestProcessFile:
             f'/fab/proj/build_output/_prebuild/mod_def_2.{mod_hash}.mod'
         ).write_text("Second module")
 
-        with catch_warnings():
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
             res, artefacts = process_file((analysed_file, mp_common_args))
 
         expect_object_fpath = Path(

--- a/tests/unit_tests/steps/test_grab.py
+++ b/tests/unit_tests/steps/test_grab.py
@@ -3,111 +3,98 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Test various grab implementation - folders and fcm.
-'''
-
+"""
+Validate methods to obtain source.
+"""
 from pathlib import Path
-from types import SimpleNamespace
-from unittest import mock
 
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark, warns
+from pytest_subprocess.fake_process import FakeProcess
+
+from fab.build_config import BuildConfig
 from fab.steps.grab.fcm import fcm_export
 from fab.steps.grab.folder import grab_folder
-from fab.tools import ToolBox
-
-import pytest
+from fab.tools.tool_box import ToolBox
 
 
 class TestGrabFolder:
-    '''Test grab folder functionality.'''
+    """
+    Tests file directory grabbing.
+    """
+    @mark.parametrize(
+        ['source', 'expected'],
+        [
+            ['/grab/source/', '/grab/source/'],
+            ['/grab/source', '/grab/source/']
+        ]
+    )
+    def test_source_path(self, source, expected,
+                         fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests file directory grabbery.
+        """
+        version_command = ['rsync', '--version']
+        fake_process.register(version_command, stdout='1.2.3')
+        grab_command = ['rsync', '--times', '--links', '--stats',
+                        '-ru', expected, '/fab/project/source/bar']
+        fake_process.register(grab_command)
 
-    def test_trailing_slash(self):
-        '''Test folder grabbing with a trailing slash.'''
-        with pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                             "cannot send metrics"):
-            self._common(grab_src='/grab/source/',
-                         expect_grab_src='/grab/source/')
+        config = BuildConfig('project', ToolBox(),
+                             mpi=False, openmp=False, multiprocessing=False,
+                             fab_workspace=Path('/fab'))
 
-    def test_no_trailing_slash(self):
-        '''Test folder grabbing without a trailing slash.'''
-        with pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                             "cannot send metrics"):
-            self._common(grab_src='/grab/source',
-                         expect_grab_src='/grab/source/')
-
-    def _common(self, grab_src, expect_grab_src):
-        source_root = Path('/workspace/source')
-        dst = 'bar'
-
-        mock_config = SimpleNamespace(source_root=source_root,
-                                      tool_box=ToolBox())
-        # Since is_available calls run, in order to test a single run call,
-        # we patch is_available to be always true.
-        with mock.patch('pathlib.Path.mkdir'):
-            with mock.patch('fab.tools.tool.Tool.run') as mock_run:
-                with mock.patch(
-                        'fab.tools.tool.Tool.is_available',
-                        new_callable=mock.PropertyMock) as is_available:
-                    is_available.return_value = True
-                    grab_folder(mock_config, src=grab_src, dst_label=dst)
-
-        expect_dst = mock_config.source_root / dst
-        mock_run.assert_called_once_with(
-            additional_parameters=['--times', '--links', '--stats',
-                                   '-ru', expect_grab_src, expect_dst])
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            grab_folder(config, src=source, dst_label='bar')
+        assert fake_process.call_count(grab_command) == 1
 
 
 class TestGrabFcm:
-    '''Test FCM functionality.'''
+    """
+    Tests grabbing from FCM.
+    """
+    def test_no_revision(self, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests no revision, "head of branch" grab.
+        """
+        help_command = ['fcm', 'help']
+        fake_process.register(help_command)
+        grab_command = ['fcm', 'export', '--force', '/www.example.com/bar',
+                        '/fab/project/source/bar']
+        fake_process.register(grab_command)
 
-    def test_no_revision(self):
-        '''Test FCM without specifying a revision.'''
-        source_root = Path('/workspace/source')
-        source_url = '/www.example.com/bar'
-        dst_label = 'bar'
+        config = BuildConfig('project', ToolBox(),
+                             mpi=False, openmp=False, multiprocessing=False,
+                             fab_workspace=Path('/fab'))
 
-        mock_config = SimpleNamespace(source_root=source_root,
-                                      tool_box=ToolBox())
-        with mock.patch('pathlib.Path.mkdir'):
-            with mock.patch('fab.tools.tool.Tool.is_available',
-                            new_callable=mock.PropertyMock) as is_available:
-                is_available.return_value = True
-                with mock.patch('fab.tools.tool.Tool.run') as mock_run, \
-                    pytest.warns(UserWarning,
-                                 match="_metric_send_conn not "
-                                       "set, cannot send metrics"):
-                    fcm_export(config=mock_config, src=source_url,
-                               dst_label=dst_label)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            fcm_export(config=config,
+                       src='/www.example.com/bar',
+                       dst_label='bar')
+        assert fake_process.call_count(grab_command) == 1
 
-        mock_run.assert_called_once_with(['export', '--force', source_url,
-                                          str(source_root / dst_label)],
-                                         env=None, cwd=None,
-                                         capture_output=True)
+    def test_revision(self, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+        """
+        Tests grabbing a specific revision.
+        """
+        help_command = ['fcm', 'help']
+        fake_process.register(help_command)
+        grab_command = ['fcm', 'export', '--force', '--revision', '42',
+                        'http://www.example.com/bar',
+                        '/fab/project/source/bar']
+        fake_process.register(grab_command)
 
-    def test_revision(self):
-        '''Test that the revision is passed on correctly in fcm export.'''
-        source_root = Path('/workspace/source')
-        source_url = '/www.example.com/bar'
-        dst_label = 'bar'
-        revision = '42'
+        config = BuildConfig('project', ToolBox(),
+                             mpi=False, openmp=False, multiprocessing=False,
+                             fab_workspace=Path('/fab'))
 
-        mock_config = SimpleNamespace(source_root=source_root,
-                                      tool_box=ToolBox())
-        with mock.patch('pathlib.Path.mkdir'):
-            with mock.patch('fab.tools.tool.Tool.is_available',
-                            new_callable=mock.PropertyMock) as is_available:
-                is_available.return_value = True
-                with mock.patch('fab.tools.tool.Tool.run') as mock_run, \
-                    pytest.warns(
-                        UserWarning, match="_metric_send_conn not set, "
-                                           "cannot send metrics"):
-                    fcm_export(mock_config, src=source_url,
-                               dst_label=dst_label, revision=revision)
-
-        mock_run.assert_called_once_with(
-            ['export', '--force', '--revision', '42', f'{source_url}',
-             str(source_root / dst_label)],
-            env=None, cwd=None, capture_output=True)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            fcm_export(config, src='http://www.example.com/bar',
+                       dst_label='bar', revision=42)
+        assert fake_process.call_count(grab_command) == 1
 
     # todo: test missing repo
     # def test_missing(self):

--- a/tests/unit_tests/steps/test_link.py
+++ b/tests/unit_tests/steps/test_link.py
@@ -3,73 +3,61 @@
 #  For further details please refer to the file COPYRIGHT
 #  which you should have received as part of this distribution
 # ##############################################################################
-
-'''
-Tests linking an executable.
-'''
-
+"""
+Exercises executable linkage step.
+"""
 from pathlib import Path
-from types import SimpleNamespace
-from unittest import mock
 
-from fab.artefacts import ArtefactSet, ArtefactStore
+from pytest import warns
+from pytest_subprocess.fake_process import FakeProcess
+
+from tests.conftest import call_list
+
+from fab.artefacts import ArtefactSet
+from fab.build_config import BuildConfig
 from fab.steps.link import link_exe
-from fab.tools import FortranCompiler, Linker, ToolBox
-
-import pytest
+from fab.tools.compiler import FortranCompiler
+from fab.tools.linker import Linker
+from fab.tools.tool_box import ToolBox
 
 
 class TestLinkExe:
-    '''Test class for linking an executable.
-    '''
-    def test_run(self, tool_box: ToolBox):
-        '''Ensure the command is formed correctly, with the flags at the
-        end and that environment variable FFLAGS is picked up.
-        '''
-        config = SimpleNamespace(
-            project_workspace=Path('workspace'),
-            artefact_store=ArtefactStore(),
-            tool_box=tool_box,
-            mpi=False,
-            openmp=False,
-            profile="default"
-        )
+    """
+    Tests linking an executable.
+    """
+    def test_run(self, fake_process: FakeProcess, monkeypatch) -> None:
+        """
+        Tests correct formation of command including FFLAGS.
+        """
+        monkeypatch.setenv('FFLAGS', '-L/foo1/lib -L/foo2/lib')
+
+        version_command = ['sfc', '--version']
+        fake_process.register(version_command, stdout='1.2.3')
+        link_command = ['sfc', '-L/foo1/lib', '-L/foo2/lib',
+                        'bar.o', 'foo.o',
+                        '-L/my/lib', '-lmylib', '-fooflag', '-barflag',
+                        '-o', '/fab/link_test/foo']
+        fake_process.register(link_command, stdout='abc\ndef')
+
+        compiler = FortranCompiler("some Fortran compiler", 'sfc', 'some',
+                                   r'([\d.]+)')
+        linker = Linker(compiler=compiler)
+        linker.add_lib_flags('mylib', ['-L/my/lib', '-lmylib'])
+
+        def get_tool(category, mpi, openmp):
+            return linker
+        #
+        # ToDo: Mockery of this nature is not ideal.
+        #
+        tool_box = ToolBox()
+        monkeypatch.setattr(tool_box, 'get_tool', get_tool)
+
+        config = BuildConfig('link_test', tool_box, fab_workspace=Path('/fab'),
+                             mpi=False, openmp=False, multiprocessing=False)
         config.artefact_store[ArtefactSet.OBJECT_FILES] = \
             {'foo': {'foo.o', 'bar.o'}}
 
-        with mock.patch.dict("os.environ",
-                             {"FFLAGS": "-L/foo1/lib -L/foo2/lib"}):
-            # We need to create the compiler here in order to pick
-            # up the environment
-            mock_compiler = FortranCompiler("mock_fortran_compiler",
-                                            "mock_fortran_compiler.exe",
-                                            "suite", module_folder_flag="",
-                                            version_regex="something",
-                                            syntax_only_flag=None,
-                                            compile_flag=None,
-                                            output_flag=None, openmp_flag=None)
-
-            linker = Linker(compiler=mock_compiler)
-            # Mark the linker as available so it can be added to the tool box
-            linker._is_available = True
-            mock_compiler.define_profile("default")
-            linker.define_profile("default")
-
-            # Add a custom library to the linker
-            linker.add_lib_flags('mylib', ['-L/my/lib', '-lmylib'])
-            tool_box.add_tool(linker, silent_replace=True)
-            mock_result = mock.Mock(returncode=0, stdout="abc\ndef".encode())
-            with mock.patch('fab.tools.tool.subprocess.run',
-                            return_value=mock_result) as tool_run, \
-                    pytest.warns(UserWarning,
-                                 match="_metric_send_conn not "
-                                       "set, cannot send metrics"):
-                link_exe(config, libs=['mylib'],
-                         flags=['-fooflag', '-barflag'])
-
-        tool_run.assert_called_with(
-            ['mock_fortran_compiler.exe', '-L/foo1/lib', '-L/foo2/lib',
-             'bar.o', 'foo.o',
-             '-L/my/lib', '-lmylib', '-fooflag', '-barflag',
-             '-o', 'workspace/foo'],
-            capture_output=True, env=None, cwd=None, check=False)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"):
+            link_exe(config, libs=['mylib'], flags=['-fooflag', '-barflag'])
+        assert call_list(fake_process) == [link_command]

--- a/tests/unit_tests/steps/test_link_shared_object.py
+++ b/tests/unit_tests/steps/test_link_shared_object.py
@@ -3,63 +3,45 @@
 #  For further details please refer to the file COPYRIGHT
 #  which you should have received as part of this distribution
 # ##############################################################################
+"""
+Tests linking a shared library.
+"""
+from pytest import warns
+from pytest_subprocess.fake_process import FakeProcess
 
-'''Tests linking a shared library.
-'''
+from tests.conftest import call_list
 
-from pathlib import Path
-from types import SimpleNamespace
-from unittest import mock
-
-from fab.artefacts import ArtefactSet, ArtefactStore
+from fab.artefacts import ArtefactSet
+from fab.build_config import BuildConfig
 from fab.steps.link import link_shared_object
-from fab.tools import FortranCompiler, Linker
+from fab.tools.compiler import FortranCompiler
+from fab.tools.linker import Linker
 
-import pytest
 
+def test_run(stub_configuration: BuildConfig,
+             stub_fortran_compiler: FortranCompiler,
+             fake_process: FakeProcess, monkeypatch) -> None:
+    """
+    Tests the construction of the command.
+    """
+    monkeypatch.setenv('FFLAGS', '-L/foo1/lib -L/foo2/lib')
 
-def test_run(tool_box):
-    '''Ensure the command is formed correctly, with the flags at the
-    end since they are typically libraries.'''
+    version_command = ['sfc', '-L/foo1/lib', '-L/foo2/lib', '--version']
+    fake_process.register(version_command, stdout='1.2.3')
+    link_command = ['sfc', '-L/foo1/lib', '-L/foo2/lib', 'bar.o', 'foo.o',
+                    '-fooflag', '-barflag', '-fPIC', '-shared',
+                    '-o', '/tmp/lib_my.so']
+    fake_process.register(link_command, stdout='abc\ndef')
 
-    config = SimpleNamespace(
-        project_workspace=Path('workspace'),
-        build_output=Path("workspace"),
-        artefact_store=ArtefactStore(),
-        openmp=False,
-        tool_box=tool_box,
-        profile="default"
-    )
-    config.artefact_store[ArtefactSet.OBJECT_FILES] = \
-        {None: {'foo.o', 'bar.o'}}
+    stub_configuration.artefact_store[ArtefactSet.OBJECT_FILES] = {
+        None: {'foo.o', 'bar.o'}
+    }
 
-    with mock.patch.dict("os.environ", {"FFLAGS": "-L/foo1/lib -L/foo2/lib"}):
-        # We need to create the compiler here in order to pick
-        # up the environment
-        mock_compiler = FortranCompiler("mock_fortran_compiler",
-                                        "mock_fortran_compiler.exe",
-                                        "suite", module_folder_flag="",
-                                        version_regex="something",
-                                        syntax_only_flag=None,
-                                        compile_flag=None, output_flag=None,
-                                        openmp_flag=None)
-        mock_compiler.run = mock.Mock()
-        linker = Linker(mock_compiler)
-        mock_compiler.define_profile("default")
-        linker.define_profile("default")
-        # Mark the linker as available so it can added to the tool box:
-        linker._is_available = True
-        tool_box.add_tool(linker, silent_replace=True)
-        mock_result = mock.Mock(returncode=0, stdout="abc\ndef".encode())
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run, \
-                pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                                "cannot send metrics"):
-            link_shared_object(config, "/tmp/lib_my.so",
-                               flags=['-fooflag', '-barflag'])
+    linker = Linker(compiler=stub_fortran_compiler)
+    stub_configuration.tool_box.add_tool(linker)
 
-    tool_run.assert_called_with(
-        ['mock_fortran_compiler.exe', '-L/foo1/lib', '-L/foo2/lib', 'bar.o',
-         'foo.o', '-fooflag', '-barflag', '-fPIC', '-shared',
-         '-o', '/tmp/lib_my.so'],
-        capture_output=True, env=None, cwd=None, check=False)
+    with warns(UserWarning, match="_metric_send_conn not set, "
+                                  "cannot send metrics"):
+        link_shared_object(stub_configuration, "/tmp/lib_my.so",
+                           flags=['-fooflag', '-barflag'])
+    assert call_list(fake_process) == [link_command]

--- a/tests/unit_tests/steps/test_link_shared_object.py
+++ b/tests/unit_tests/steps/test_link_shared_object.py
@@ -38,7 +38,10 @@ def test_run(stub_configuration: BuildConfig,
     }
 
     linker = Linker(compiler=stub_fortran_compiler)
-    stub_configuration.tool_box.add_tool(linker)
+    with warns(UserWarning,
+               match="Replacing existing tool 'Linker - sln: scc' "
+                     "with 'Linker - linker-some Fortran compiler: sfc'."):
+        stub_configuration.tool_box.add_tool(linker)
 
     with warns(UserWarning, match="_metric_send_conn not set, "
                                   "cannot send metrics"):

--- a/tests/unit_tests/steps/test_root_inc_files.py
+++ b/tests/unit_tests/steps/test_root_inc_files.py
@@ -1,59 +1,94 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Exercises
+"""
+from os import walk as os_walk
 from pathlib import Path
-from unittest import mock
+from typing import List
 
-import pytest
+from pytest import raises, warns
 
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps.root_inc_files import root_inc_files
-from fab.tools import ToolBox
+from fab.tools.tool_box import ToolBox
 
 
 class TestRootIncFiles:
-
-    def test_vanilla(self):
-        # ensure it copies the inc file
-        inc_files = [Path('/foo/source/bar.inc')]
+    """
+    Tests include files are handled correctly.
+    """
+    def test_vanilla(self, tmp_path: Path) -> None:
+        """
+        Tests include files is coped to work directory.
+        """
+        source_dir = tmp_path / 'source'
+        source_dir.mkdir()
+        inc_files = [source_dir / 'bar.inc']
+        inc_files[0].write_text("Some include file.")
 
         config = BuildConfig('proj', ToolBox())
         config.artefact_store[ArtefactSet.INITIAL_SOURCE] = inc_files
 
-        with mock.patch('fab.steps.root_inc_files.shutil') as mock_shutil:
-            with mock.patch('fab.steps.root_inc_files.Path.mkdir'), \
-                 pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                                 "cannot send metrics"):
-                root_inc_files(config)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"), \
+             warns(DeprecationWarning,
+                   match="RootIncFiles is deprecated as .inc files are due to be removed."):
+            root_inc_files(config)
+        assert (config.build_output / inc_files[0]).read_text() \
+            == "Some include file."
 
-        mock_shutil.copy.assert_called_once_with(inc_files[0],
-                                                 config.build_output)
+    def test_skip_output_folder(self, stub_tool_box: ToolBox, fs) -> None:
+        """
+        Tests files already in output directory not copied.
+        """
+        Path('/foo/source').mkdir(parents=True)
+        Path('/foo/source/bar.inc').write_text("An include file.")
 
-    def test_skip_output_folder(self):
-        # ensure it doesn't try to copy a file in the build output
-        config = BuildConfig('proj', ToolBox())
+        config = BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab'))
         inc_files = [Path('/foo/source/bar.inc'),
                      config.build_output / 'fab.inc']
         config.artefact_store[ArtefactSet.INITIAL_SOURCE] = inc_files
 
-        with mock.patch('fab.steps.root_inc_files.shutil') as mock_shutil:
-            with mock.patch('fab.steps.root_inc_files.Path.mkdir'), \
-                 pytest.warns(UserWarning, match="_metric_send_conn not set, "
-                                                 "cannot send metrics"):
-                root_inc_files(config)
+        with warns(UserWarning,
+                   match="_metric_send_conn not set, cannot send metrics"), \
+             warns(DeprecationWarning,
+                   match="RootIncFiles is deprecated as .inc files are due to be removed."):
+            root_inc_files(config)
+        #
+        # It's not clear why there is an unexepcted temporary directory which
+        # needs to be ignored.
+        #
+        # ToDo: Find out where /tmp is coming from and stop it.
+        #
+        filetree: List[Path] = []
+        for path, _, files in os_walk('/'):
+            for file in files:
+                if file == 'tmp':
+                    continue
+                filetree.append(Path(path) / file)
+        assert sorted(filetree) == [Path('/fab/proj/build_output/bar.inc'),
+                                    Path('/foo/source/bar.inc')]
 
-        mock_shutil.copy.assert_called_once_with(inc_files[0],
-                                                 config.build_output)
-
-    def test_name_clash(self):
-        # ensure raises an exception if there is a name clash
+    def test_name_clash(self, stub_tool_box: ToolBox, fs) -> None:
+        """
+        Tests duplicate file leaf names.
+        """
+        Path('/foo/source').mkdir(parents=True)
+        Path('/foo/source/bar.inc').write_text("The source of the Nile.")
+        Path('/foo/sauce').mkdir(parents=True)
+        Path('/foo/sauce/bar.inc').write_text("Nile sauce.")
         inc_files = [Path('/foo/source/bar.inc'), Path('/foo/sauce/bar.inc')]
 
-        config = BuildConfig('proj', ToolBox())
+        config = BuildConfig('proj', stub_tool_box)
         config.artefact_store[ArtefactSet.INITIAL_SOURCE] = inc_files
 
-        with pytest.raises(FileExistsError):
-            with mock.patch('fab.steps.root_inc_files.shutil'):
-                with mock.patch('fab.steps.root_inc_files.Path.mkdir'), \
-                     pytest.warns(DeprecationWarning,
-                                  match="RootIncFiles is deprecated as .inc "
-                                        "files are due to be removed."):
-                    root_inc_files(config)
+        with raises(FileExistsError), \
+            warns(DeprecationWarning,
+                  match="RootIncFiles is deprecated as .inc "
+                        "files are due to be removed."):
+            root_inc_files(config)

--- a/tests/unit_tests/steps/test_steps.py
+++ b/tests/unit_tests/steps/test_steps.py
@@ -1,13 +1,29 @@
-import pytest
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Exercises the multi-process error helper.
+"""
+from pytest import raises
 
 from fab.steps import check_for_errors
 
 
 class Test_check_for_errors(object):
-
+    """
+    Tests the multi-prcoess error helper.
+    """
     def test_no_error(self):
+        """
+        Tests the "all okay" situation.
+        """
         check_for_errors(['foo', 'bar'])
 
     def test_error(self):
-        with pytest.raises(RuntimeError):
+        """
+        Tests the "error present" situation.
+        """
+        with raises(RuntimeError):
             check_for_errors(['foo', MemoryError('bar')])

--- a/tests/unit_tests/test_artefacts.py
+++ b/tests/unit_tests/test_artefacts.py
@@ -65,10 +65,9 @@ def test_artefact_store_copy() -> None:
 def test_artefact_store_update_dict() -> None:
     '''Tests the update_dict function.'''
     artefact_store = ArtefactStore()
-    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, "a", [Path("AA")])
+    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, [Path("AA")], "a")
     assert artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {Path("AA")}}
-    artefact_store.update_dict(ArtefactSet.OBJECT_FILES,
-                               "b", set([Path("BB")]))
+    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, set([Path("BB")]), "b")
     assert (artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {Path("AA")},
                                                          "b": {Path("BB")}})
 

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -3,20 +3,27 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Tests the compiler implementation.
-'''
-
+"""
+Exercise compiler tools.
+"""
 import os
-from pathlib import Path, PosixPath
+from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
-import pytest
+from pytest import mark, raises, warns
+from pytest_subprocess.fake_process import FakeProcess
 
-from fab.tools import (Category, CCompiler, Compiler, Craycc, Crayftn,
-                       FortranCompiler, Gcc, Gfortran, Icc, Icx, Ifort, Ifx,
-                       Nvc, Nvfortran)
+from tests.conftest import arg_list, call_list
+
+from fab.build_config import BuildConfig
+from fab.tools.category import Category
+from fab.tools.compiler import (Compiler, CCompiler, FortranCompiler,
+                                Craycc, Crayftn,
+                                Gcc, Gfortran,
+                                Icc, Ifort,
+                                Icx, Ifx,
+                                Nvc, Nvfortran)
 
 
 def test_compiler():
@@ -114,7 +121,7 @@ def test_compiler_hash_compiler_error():
 
     # raise an error when trying to get compiler version
     with mock.patch.object(cc, 'run', side_effect=RuntimeError()):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             cc.get_hash()
         assert "Error asking for version of compiler" in str(err.value)
 
@@ -125,7 +132,7 @@ def test_compiler_hash_invalid_version():
 
     # returns an invalid compiler version string
     with mock.patch.object(cc, "run", mock.Mock(return_value='foo v1')):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             cc.get_hash()
         assert ("Unexpected version output format for compiler 'gcc'"
                 in str(err.value))
@@ -163,87 +170,104 @@ def test_compiler_syntax_only():
     assert fc._syntax_only_flag == "-fsyntax-only"
 
 
-def test_compiler_without_openmp(mock_config):
-    '''Tests that the openmp flag is not used when openmp is not enabled. '''
-    fc = FortranCompiler("gfortran", "gfortran", "gnu",
-                         version_regex="something",
-                         openmp_flag="-fopenmp",
-                         module_folder_flag="-J",
-                         syntax_only_flag="-fsyntax-only")
-    fc.set_module_output_path("/tmp")
-    fc.run = mock.Mock()
-    mock_config._openmp = False
-    fc.compile_file(Path("a.f90"), "a.o", config=mock_config, syntax_only=True)
-    fc.run.assert_called_with(cwd=Path('.'),
-                              profile='',
-                              additional_parameters=['-c', '-fsyntax-only',
-                                                     "-J", '/tmp', 'a.f90',
-                                                     '-o', 'a.o', ])
+def test_compiler_without_openmp(stub_fortran_compiler: FortranCompiler,
+                                 stub_configuration: BuildConfig,
+                                 fake_process: FakeProcess) -> None:
+    """
+    Tests that the openmp flag is not used when openmp is not enabled.
+
+    Todo: Monkeying with private state.
+    """
+    command = ['sfc', '-c', '-mods', '/tmp', 'a.f90', '-o', 'a.o', ]
+    record = fake_process.register(command)
+
+    stub_fortran_compiler.set_module_output_path(Path("/tmp"))
+    stub_configuration._openmp = False
+
+    stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
+                                       config=stub_configuration,
+                                       syntax_only=True)
+    assert call_list(fake_process) == [command]
+    assert arg_list(record)[0]['cwd'] == '.'
 
 
-def test_compiler_with_openmp(mock_config):
-    '''Tests that the openmp flag is used as expected if openmp is enabled.
-    '''
-    fc = FortranCompiler("gfortran", "gfortran", "gnu",
-                         version_regex="something",
-                         openmp_flag="-fopenmp",
-                         module_folder_flag="-J",
-                         syntax_only_flag="-fsyntax-only")
-    fc.set_module_output_path("/tmp")
-    fc.run = mock.Mock()
-    mock_config._openmp = True
-    mock_config._profile = "test_profile"
-    fc.compile_file(Path("a.f90"), "a.o", config=mock_config,
-                    syntax_only=False)
-    fc.run.assert_called_with(cwd=Path('.'),
-                              profile='test_profile',
-                              additional_parameters=['-c', '-fopenmp',
-                                                     "-J", '/tmp', 'a.f90',
-                                                     '-o', 'a.o', ])
+def test_compiler_with_openmp(stub_fortran_compiler: FortranCompiler,
+                              stub_configuration: BuildConfig,
+                              fake_process: FakeProcess) -> None:
+    """
+    Tests that the openmp flag is used as expected if openmp is enabled.
+
+    Todo: Monkeying with private state.
+    """
+    command = ['sfc', '-c', '-omp', '-mods', '/tmp', 'a.f90', '-o', 'a.o', ]
+    record = fake_process.register(command)
+
+    stub_fortran_compiler.set_module_output_path(Path("/tmp"))
+    stub_configuration._openmp = True
+
+    stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
+                                       config=stub_configuration,
+                                       syntax_only=False)
+    assert call_list(fake_process) == [command]
+    assert arg_list(record)[0]['cwd'] == '.'
 
 
-def test_compiler_module_output(mock_config):
-    '''Tests handling of module output_flags.'''
-    fc = FortranCompiler("gfortran", "gfortran", suite="gnu",
-                         version_regex="something", module_folder_flag="-J")
-    fc.set_module_output_path("/module_out")
-    assert fc._module_output_path == "/module_out"
-    fc.run = mock.MagicMock()
-    mock_config._openmp = False
-    fc.compile_file(Path("a.f90"), "a.o", config=mock_config, syntax_only=True)
-    fc.run.assert_called_with(cwd=PosixPath('.'),
-                              profile='',
-                              additional_parameters=['-c', '-J', '/module_out',
-                                                     'a.f90', '-o', 'a.o'])
+def test_compiler_module_output(stub_fortran_compiler: FortranCompiler,
+                                stub_configuration: BuildConfig,
+                                fake_process: FakeProcess) -> None:
+    """
+    Tests handling of module output_flags.
+    """
+    command = ['sfc', '-c', '-mods', '/module_out', 'a.f90', '-o', 'a.o']
+    record = fake_process.register(command)
+
+    stub_fortran_compiler.set_module_output_path(Path("/module_out"))
+    assert stub_fortran_compiler._module_output_path == "/module_out"
+
+    stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
+                                       config=stub_configuration,
+                                       syntax_only=True)
+    assert call_list(fake_process) == [command]
+    assert arg_list(record)[0]['cwd'] == '.'
 
 
-def test_compiler_with_add_args(mock_config):
-    '''Tests that additional arguments are handled as expected.'''
-    fc = FortranCompiler("gfortran", "gfortran", suite="gnu",
-                         version_regex="something",
-                         openmp_flag="-fopenmp",
-                         module_folder_flag="-J")
-    fc.set_module_output_path("/module_out")
-    assert fc._module_output_path == "/module_out"
-    fc.run = mock.MagicMock()
-    mock_config._openmp = False
-    mock_config._profile = "default"
-    with pytest.warns(UserWarning, match="Removing managed flag"):
-        fc.compile_file(Path("a.f90"), "a.o", add_flags=["-J/b", "-O3"],
-                        config=mock_config, syntax_only=True)
+def test_compiler_with_add_args(stub_configuration: BuildConfig,
+                                stub_fortran_compiler: FortranCompiler,
+                                fake_process: FakeProcess) -> None:
+    """
+    Tests that additional arguments are handled as expected.
+
+    Todo: Monkeying with private state.
+    """
+    command_nomp = ['sfc', '-c', '-O3', '-mods', '/module_out', 'a.f90', '-o', 'a.o']
+    nomp_record = fake_process.register(command_nomp)
+    command_omp = ['sfc', '-c', '-omp', '-omp', '-O3', '-mods', '/module_out', 'a.f90', '-o', 'a.o']
+    omp_record = fake_process.register(command_omp)
+
+    stub_fortran_compiler.set_module_output_path(Path("/module_out"))
+    assert stub_fortran_compiler._module_output_path == "/module_out"
+
+    stub_configuration._openmp = False
+
+    with warns(UserWarning, match="Removing managed flag"):
+        stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
+                                           add_flags=["-mods", "/b", "-O3"],
+                                           config=stub_configuration,
+                                           syntax_only=True)
     # Notice that "-J/b" has been removed
-    fc.run.assert_called_with(cwd=PosixPath('.'),
-                              profile='default',
-                              additional_parameters=['-c', '-O3',
-                                                     '-J', '/module_out',
-                                                     'a.f90', '-o', 'a.o'])
-    mock_config._openmp = True
-    with pytest.warns(UserWarning,
-                      match="explicitly provided. OpenMP should be enabled in "
-                            "the BuildConfiguration"):
-        fc.compile_file(Path("a.f90"), "a.o",
-                        add_flags=["-fopenmp", "-O3"],
-                        config=mock_config, syntax_only=True)
+    assert arg_list(nomp_record)[0]['cwd'] == '.'
+
+    stub_configuration._openmp = True
+    with warns(UserWarning,
+               match="explicitly provided. OpenMP should be enabled in "
+                     "the BuildConfiguration"):
+        stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
+                                           add_flags=["-omp", "-O3"],
+                                           config=stub_configuration,
+                                           syntax_only=True)
+    assert arg_list(omp_record)[0]['cwd'] == '.'
+
+    assert call_list(fake_process) == [command_nomp, command_omp]
 
 
 # ============================================================================
@@ -272,7 +296,7 @@ def test_get_version_1_part_version():
 
     c = Gfortran()
     with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             c.get_version()
         assert expected_error in str(err.value)
 
@@ -313,10 +337,10 @@ def test_get_version_4_part_version():
         assert c.get_version() == (19, 0, 0, 117)
 
 
-@pytest.mark.parametrize("version", ["5.15f.2",
-                                     ".0.5.1",
-                                     "0.5.1.",
-                                     "0.5..1"])
+@mark.parametrize("version", ["5.15f.2",
+                              ".0.5.1",
+                              "0.5.1.",
+                              "0.5..1"])
 def test_get_version_non_int_version_format(version):
     '''
     Tests the get_version() method with an invalid format.
@@ -332,7 +356,7 @@ def test_get_version_non_int_version_format(version):
 
     c = Gfortran()
     with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             c.get_version()
         assert expected_error in str(err.value)
 
@@ -350,7 +374,7 @@ def test_get_version_unknown_version_format():
 
     c = Gfortran()
     with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             c.get_version()
         assert expected_error in str(err.value)
 
@@ -358,7 +382,7 @@ def test_get_version_unknown_version_format():
 def test_get_version_command_failure():
     '''If the version command fails, we must raise an error.'''
     c = Gfortran(exec_name="does_not_exist")
-    with pytest.raises(RuntimeError) as err:
+    with raises(RuntimeError) as err:
         c.get_version()
     assert "Error asking for version of compiler" in str(err.value)
 
@@ -371,7 +395,7 @@ def test_get_version_unknown_command_response():
 
     c = Gfortran()
     with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             c.get_version()
         assert expected_error in str(err.value)
 
@@ -399,7 +423,7 @@ def test_get_version_bad_result_is_not_cached():
     # Set up the compiler to fail the first time
     c = Gfortran()
     with mock.patch.object(c, 'run', side_effect=RuntimeError()):
-        with pytest.raises(RuntimeError):
+        with raises(RuntimeError):
             c.get_version()
 
     # Now let the run method run successfully and we should get the version.
@@ -441,7 +465,7 @@ def test_gcc_get_version_with_icc_string():
 
     """)
     with mock.patch.object(gcc, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             gcc.get_version()
         assert "Unexpected version output format for compiler" in str(err.value)
 
@@ -547,7 +571,7 @@ def test_gfortran_get_version_with_ifort_string():
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
                            mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             gfortran.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -585,7 +609,7 @@ def test_icc_get_version_with_gcc_string():
     """)
     icc = Icc()
     with mock.patch.object(icc, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             icc.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -660,16 +684,16 @@ def test_ifort_get_version_with_icc_string():
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             ifort.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
 
 
-@pytest.mark.parametrize("version", ["5.15f.2",
-                                     ".0.5.1",
-                                     "0.5.1.",
-                                     "0.5..1"])
+@mark.parametrize("version", ["5.15f.2",
+                              ".0.5.1",
+                              "0.5.1.",
+                              "0.5..1"])
 def test_ifort_get_version_invalid_version(version):
     '''Tests the ifort class with an ifort version string that contains an
     invalid version number.'''
@@ -680,7 +704,7 @@ def test_ifort_get_version_invalid_version(version):
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             ifort.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -723,7 +747,7 @@ def test_icx_get_version_with_icc_string():
     """)
     icx = Icx()
     with mock.patch.object(icx, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             icx.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -762,7 +786,7 @@ def test_ifx_get_version_with_ifort_string():
     """)
     ifx = Ifx()
     with mock.patch.object(ifx, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             ifx.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -780,17 +804,17 @@ def test_nvc():
     assert not nvc.mpi
 
 
-def test_nvc_get_version_23_5_0():
+def test_nvc_get_version_23_5_0(fake_process: FakeProcess) -> None:
     '''Test nvc 23.5.0 version detection.'''
-    full_output = dedent("""
-
+    version_string = dedent("""
 nvc 23.5-0 64-bit target on x86-64 Linux -tp icelake-server
 NVIDIA Compilers and Tools
 Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
-    """)
+""")
+    recorder = fake_process.register(['nvc', '-V'], stdout=version_string)
     nvc = Nvc()
-    with mock.patch.object(nvc, "run", mock.Mock(return_value=full_output)):
-        assert nvc.get_version() == (23, 5)
+    assert nvc.get_version() == (23, 5)
+    assert [call.args for call in recorder.calls] == [['nvc', '-V']]
 
 
 def test_nvc_get_version_with_icc_string():
@@ -798,11 +822,10 @@ def test_nvc_get_version_with_icc_string():
     full_output = dedent("""
         icc (ICC) 2021.10.0 20230609
         Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
-
-    """)
+        """)
     nvc = Nvc()
     with mock.patch.object(nvc, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             nvc.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -820,18 +843,18 @@ def test_nvfortran():
     assert not nvfortran.mpi
 
 
-def test_nvfortran_get_version_23_5_0():
+def test_nvfortran_get_version_23_5_0(fake_process: FakeProcess) -> None:
     '''Test nvfortran 23.5 version detection.'''
-    full_output = dedent("""
-
+    version_string = dedent("""
 nvfortran 23.5-0 64-bit target on x86-64 Linux -tp icelake-server
 NVIDIA Compilers and Tools
 Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
-    """)
+""")
+    recorder = fake_process.register(['nvfortran', '-V'],
+                                     stdout=version_string)
     nvfortran = Nvfortran()
-    with mock.patch.object(nvfortran, "run",
-                           mock.Mock(return_value=full_output)):
-        assert nvfortran.get_version() == (23, 5)
+    assert nvfortran.get_version() == (23, 5)
+    assert [call.args for call in recorder.calls] == [['nvfortran', '-V']]
 
 
 def test_nvfortran_get_version_with_ifort_string():
@@ -844,7 +867,7 @@ def test_nvfortran_get_version_with_ifort_string():
     nvfortran = Nvfortran()
     with mock.patch.object(nvfortran, "run",
                            mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             nvfortran.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -910,7 +933,7 @@ def test_craycc_get_version_with_icc_string():
     """)
     craycc = Craycc()
     with mock.patch.object(craycc, "run", mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             craycc.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))
@@ -960,7 +983,7 @@ def test_crayftn_get_version_with_ifort_string():
     crayftn = Crayftn()
     with mock.patch.object(crayftn, "run",
                            mock.Mock(return_value=full_output)):
-        with pytest.raises(RuntimeError) as err:
+        with raises(RuntimeError) as err:
             crayftn.get_version()
         assert ("Unexpected version output format for compiler"
                 in str(err.value))

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -185,8 +185,7 @@ def test_compiler_without_openmp(stub_fortran_compiler: FortranCompiler,
     stub_configuration._openmp = False
 
     stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
-                                       config=stub_configuration,
-                                       syntax_only=True)
+                                       config=stub_configuration)
     assert call_list(fake_process) == [command]
     assert arg_list(record)[0]['cwd'] == '.'
 
@@ -206,8 +205,7 @@ def test_compiler_with_openmp(stub_fortran_compiler: FortranCompiler,
     stub_configuration._openmp = True
 
     stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
-                                       config=stub_configuration,
-                                       syntax_only=False)
+                                       config=stub_configuration)
     assert call_list(fake_process) == [command]
     assert arg_list(record)[0]['cwd'] == '.'
 
@@ -225,8 +223,7 @@ def test_compiler_module_output(stub_fortran_compiler: FortranCompiler,
     assert stub_fortran_compiler._module_output_path == "/module_out"
 
     stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
-                                       config=stub_configuration,
-                                       syntax_only=True)
+                                       config=stub_configuration)
     assert call_list(fake_process) == [command]
     assert arg_list(record)[0]['cwd'] == '.'
 
@@ -252,8 +249,7 @@ def test_compiler_with_add_args(stub_configuration: BuildConfig,
     with warns(UserWarning, match="Removing managed flag"):
         stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
                                            add_flags=["-mods", "/b", "-O3"],
-                                           config=stub_configuration,
-                                           syntax_only=True)
+                                           config=stub_configuration)
     # Notice that "-J/b" has been removed
     assert arg_list(nomp_record)[0]['cwd'] == '.'
 
@@ -263,8 +259,7 @@ def test_compiler_with_add_args(stub_configuration: BuildConfig,
                      "the BuildConfiguration"):
         stub_fortran_compiler.compile_file(Path("a.f90"), Path("a.o"),
                                            add_flags=["-omp", "-O3"],
-                                           config=stub_configuration,
-                                           syntax_only=True)
+                                           config=stub_configuration)
     assert arg_list(omp_record)[0]['cwd'] == '.'
 
     assert call_list(fake_process) == [command_nomp, command_omp]

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -209,6 +209,9 @@ def test_linker_add_lib_flags_overwrite_silent(stub_linker: Linker) -> None:
         """
         linker = Linker(stub_c_compiler)
         linker.remove_lib_flags("unknown")  # type: ignore[attr-defined]
+        #
+        # The test here is that no exception is thrown. Since the library
+        # was never in the list to start with no `assert` is possible.
 
 
 class TestLinkerLinking:

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -3,134 +3,144 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Tests the linker implementation.
-'''
-
+"""
+Exercises linker tooling.
+"""
 from pathlib import Path
-from unittest import mock
 import warnings
 
-import pytest
+from pytest import mark, raises, warns
+from pytest_subprocess.fake_process import FakeProcess
 
-from fab.tools import Category, CompilerWrapper, Linker, ToolRepository
+from tests.conftest import ExtendedRecorder, not_found_callback
+
+from fab.build_config import BuildConfig
+from fab.tools.category import Category
+from fab.tools.compiler import CCompiler, FortranCompiler
+from fab.tools.compiler_wrapper import CompilerWrapper, Mpif90
+from fab.tools.linker import Linker
 
 
-def test_linker(mock_c_compiler, mock_fortran_compiler):
-    '''Test the linker constructor.'''
-
-    assert mock_c_compiler.category == Category.C_COMPILER
-    assert mock_c_compiler.name == "mock_c_compiler"
-
-    linker = Linker(mock_c_compiler)
+def test_c_linker(stub_c_compiler: CCompiler) -> None:
+    """
+    Tests construction from C compiler
+    """
+    linker = Linker(stub_c_compiler)
     assert linker.category == Category.LINKER
-    assert linker.name == "linker-mock_c_compiler"
-    assert linker.exec_name == "mock_c_compiler.exe"
-    assert linker.suite == "suite"
+    assert linker.name == "linker-some C compiler"
+    assert linker.exec_name == "scc"
+    assert linker.suite == "stub"
     assert linker.get_flags() == []
     assert linker.output_flag == "-o"
 
-    assert mock_fortran_compiler.category == Category.FORTRAN_COMPILER
-    assert mock_fortran_compiler.name == "mock_fortran_compiler"
 
-    linker = Linker(mock_fortran_compiler)
+def test_fortran_linker(stub_fortran_compiler: FortranCompiler) -> None:
+    linker = Linker(stub_fortran_compiler)
     assert linker.category == Category.LINKER
-    assert linker.name == "linker-mock_fortran_compiler"
-    assert linker.exec_name == "mock_fortran_compiler.exe"
-    assert linker.suite == "suite"
+    assert linker.name == "linker-some Fortran compiler"
+    assert linker.exec_name == "sfc"
+    assert linker.suite == "stub"
     assert linker.get_flags() == []
 
 
-@pytest.mark.parametrize("mpi", [True, False])
-def test_linker_mpi(mock_c_compiler, mpi):
-    '''Test that linker wrappers handle MPI as expected.'''
-
-    mock_c_compiler._mpi = mpi
-    linker = Linker(mock_c_compiler)
+@mark.parametrize("mpi", [True, False])
+def test_linker_mpi(mpi: bool) -> None:
+    """
+    Tests linker wrappers handle MPI as expected.
+    """
+    compiler = CCompiler("some C compiler", 'scc', 'some', r'([\d.]+)',
+                         mpi=mpi)
+    linker = Linker(compiler)
     assert linker.mpi == mpi
 
-    wrapped_linker = Linker(mock_c_compiler, linker=linker)
+    wrapped_linker = Linker(compiler, linker=linker)
     assert wrapped_linker.mpi == mpi
 
 
-@pytest.mark.parametrize("openmp", [True, False])
-def test_linker_openmp(mock_c_compiler, openmp):
-    '''Test that linker wrappers handle openmp as expected. Note that
-    a compiler detects support for OpenMP by checking if an openmp flag
-    is defined.
-    '''
+@mark.parametrize("openmp", [True, False])
+def test_linker_openmp(openmp: bool) -> None:
+    """
+    Test that linker wrappers handle openmp as expected.
 
+    Note that a compiler detects support for OpenMP by checking if an openmp
+    flag is defined.
+    """
     if openmp:
-        mock_c_compiler._openmp_flag = "-some-openmp-flag"
+        compiler = CCompiler("some C compiler", 'scc', 'some', r'([\d.]+)',
+                             openmp_flag='-omp')
     else:
-        mock_c_compiler._openmp_flag = ""
-    linker = Linker(compiler=mock_c_compiler)
+        compiler = CCompiler("some C compiler", 'scc', 'some', r'([\d.]+)',
+                             openmp_flag='')
+    linker = Linker(compiler=compiler)
     assert linker.openmp == openmp
 
-    wrapped_linker = Linker(mock_c_compiler, linker=linker)
+    wrapped_linker = Linker(compiler, linker=linker)
     assert wrapped_linker.openmp == openmp
 
 
-def test_linker_gets_ldflags(mock_c_compiler):
-    """Tests that the linker retrieves env.LDFLAGS"""
-    with mock.patch.dict("os.environ", {"LDFLAGS": "-lm"}):
-        linker = Linker(compiler=mock_c_compiler)
+def test_gets_ldflags(stub_c_compiler: CCompiler, monkeypatch) -> None:
+    """
+    Tests linker retrieves LDFLAGS environment variable.
+    """
+    monkeypatch.setenv('LDFLAGS', '-lm')
+    linker = Linker(compiler=stub_c_compiler)
     assert "-lm" in linker.get_flags()
 
 
-def test_linker_check_available(mock_c_compiler):
-    '''Tests the is_available functionality.'''
-
-    # First test when a compiler is given. The linker will call the
-    # corresponding function in the compiler:
-    linker = Linker(mock_c_compiler)
-    with mock.patch('fab.tools.compiler.Compiler.get_version',
-                    return_value=(1, 2, 3)):
-        assert linker.check_available()
+def test_check_available(stub_c_compiler: CCompiler,
+                         fake_process: FakeProcess) -> None:
+    """
+    Tests the is_available functionality when compiler is present.
+    """
+    fake_process.register(['scc', '--version'], stdout='1.2.3')
+    linker = Linker(stub_c_compiler)
+    assert linker.check_available()
 
     # Then test the usage of a linker wrapper. The linker will call the
     # corresponding function in the wrapper linker:
-    wrapped_linker = Linker(mock_c_compiler, linker=linker)
-    with mock.patch('fab.tools.compiler.Compiler.get_version',
-                    return_value=(1, 2, 3)):
-        assert wrapped_linker.check_available()
+    wrapped_linker = Linker(stub_c_compiler, linker=linker)
+    assert wrapped_linker.check_available()
 
 
-def test_linker_check_unavailable(mock_c_compiler):
-    '''Tests the is_available functionality.'''
-    # assume the tool does not exist, check_available
-    # will return False (and not raise an exception)
-    linker = Linker(mock_c_compiler)
-    with mock.patch('fab.tools.compiler.Compiler.get_version',
-                    side_effect=RuntimeError("")):
-        assert linker.check_available() is False
+def test_check_unavailable(stub_c_compiler: CCompiler,
+                           fake_process: FakeProcess) -> None:
+    """
+    Tests is_available functionality when compiler is missing.
+    """
+    fake_process.register(['scc', '--version'], callback=not_found_callback)
+    linker = Linker(stub_c_compiler)
+    assert linker.check_available() is False
 
 
 # ====================
 # Managing lib flags:
 # ====================
-def test_linker_get_lib_flags(mock_linker):
-    """Linker should provide a map of library names, each leading to a list of
+def test_linker_get_lib_flags(stub_fortran_compiler: FortranCompiler) -> None:
+    """
+    Tests linker provides a map of library names, each leading to a list of
     linker flags
     """
-    # netcdf flags are built in to the mock linker
-    result = mock_linker.get_lib_flags("netcdf")
-    assert result == ["-lnetcdff", "-lnetcdf"]
+    test_unit = Linker(stub_fortran_compiler)
+    test_unit.add_lib_flags('netcdf', ['-lnetcdff', '-lnetcdf'])
+    assert test_unit.get_lib_flags("netcdf") == ["-lnetcdff", "-lnetcdf"]
 
 
-def test_linker_get_lib_flags_unknown(mock_c_compiler):
-    """Linker should raise an error if flags are requested for a library
+def test_get_lib_flags_unknown(stub_c_compiler: CCompiler) -> None:
+    """
+    Tests sinker raises an error if flags are requested for a library
     that is unknown.
     """
-    linker = Linker(compiler=mock_c_compiler)
-    with pytest.raises(RuntimeError) as err:
+    linker = Linker(compiler=stub_c_compiler)
+    with raises(RuntimeError) as err:
         linker.get_lib_flags("unknown")
-    assert "Unknown library name: 'unknown'" in str(err.value)
+    assert str(err.value) == "Unknown library name: 'unknown'"
 
 
-def test_linker_add_lib_flags(mock_c_compiler):
-    """Linker should provide a way to add a new set of flags for a library"""
-    linker = Linker(compiler=mock_c_compiler)
+def test_add_lib_flags(stub_c_compiler: CCompiler) -> None:
+    """
+    Tests linker provides a way to add a new set of flags for a library.
+    """
+    linker = Linker(compiler=stub_c_compiler)
     linker.add_lib_flags("xios", ["-L", "xios/lib", "-lxios"])
 
     # Make sure we can get it back. The order should be maintained.
@@ -138,250 +148,266 @@ def test_linker_add_lib_flags(mock_c_compiler):
     assert result == ["-L", "xios/lib", "-lxios"]
 
 
-def test_linker_add_lib_flags_overwrite_defaults(mock_linker):
-    """Linker should provide a way to replace the default flags for
-    a library"""
+def test_add_lib_flags_overwrite_defaults(
+        stub_fortran_compiler: FortranCompiler
+) -> None:
+    """
+    Linker should provide a way to replace the default flags for
+    a library.
+    """
+    test_unit = Linker(stub_fortran_compiler)
+    test_unit.add_lib_flags('netcdf', ['-lnetcdff', '-lnetcdf'])
 
-    # Initially we have the default netcdf flags
-    result = mock_linker.get_lib_flags("netcdf")
+    result = test_unit.get_lib_flags("netcdf")
     assert result == ["-lnetcdff", "-lnetcdf"]
 
     # Replace them with another set of flags.
     warn_message = 'Replacing existing flags for library netcdf'
-    with pytest.warns(UserWarning, match=warn_message):
-        mock_linker.add_lib_flags(
-            "netcdf", ["-L", "netcdf/lib", "-lnetcdf"])
+    with warns(UserWarning, match=warn_message):
+        test_unit.add_lib_flags(
+            "netcdf", ["-L", "netcdf/lib", "-lnetcdf"]
+        )
 
     # Test that we can see our custom flags
-    result = mock_linker.get_lib_flags("netcdf")
+    result = test_unit.get_lib_flags("netcdf")
     assert result == ["-L", "netcdf/lib", "-lnetcdf"]
 
 
-def test_linker_add_lib_flags_overwrite_silent(mock_linker):
-    """Linker should provide the option to replace flags for a library without
-    generating a warning
+def test_linker_add_lib_flags_overwrite_silent(stub_linker: Linker) -> None:
     """
+    Tests replacing arguments raises no warning.
+    """
+    stub_linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
+    assert stub_linker.get_lib_flags("customlib") == ["-lcustom", "-jcustom"]
 
-    # Initially we have the default netcdf flags
-    mock_linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
-    assert mock_linker.get_lib_flags("customlib") == ["-lcustom", "-jcustom"]
-
-    # Replace them with another set of flags.
+    # Replace with another set of flags.
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        mock_linker.add_lib_flags("customlib", ["-t", "-b"],
+        stub_linker.add_lib_flags("customlib", ["-t", "-b"],
                                   silent_replace=True)
 
     # Test that we can see our custom flags
-    result = mock_linker.get_lib_flags("customlib")
+    result = stub_linker.get_lib_flags("customlib")
     assert result == ["-t", "-b"]
 
+    def test_linker_remove_lib_flags(self,
+                                     stub_c_compiler: CCompiler) -> None:
+        """
+        Tests removing library not known to linker.
+        """
+        linker = Linker(stub_c_compiler)
+        linker.remove_lib_flags("netcdf")  # type: ignore[attr-defined]
 
-# ====================
-# Linking:
-# ====================
-def test_linker_c(mock_config):
-    '''Test the link command line when no additional libraries are
-    specified.'''
+        with raises(RuntimeError) as err:
+            linker.get_lib_flags("netcdf")
+        assert str(err.value).startswith("Unknown library name: 'netcdf'")
 
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)
-    # Add a library to the linker, but don't use it in the link step
+    def test_remove_lib_flags_unknown(self,
+                                      stub_c_compiler: CCompiler) -> None:
+        """
+        Tests silent removal of unknown library.
+        """
+        linker = Linker(stub_c_compiler)
+        linker.remove_lib_flags("unknown")  # type: ignore[attr-defined]
+
+
+class TestLinkerLinking:
+    def test_c(self, stub_c_compiler: CCompiler,
+               stub_configuration: BuildConfig,
+               subproc_record: ExtendedRecorder) -> None:
+        """
+        Tests linkwhen no additional libraries are specified.
+        """
+        linker = Linker(compiler=stub_c_compiler)
+        # Add a library to the linker, but don't use it in the link step
+        linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
+
+        linker.link([Path("a.o")], Path("a.out"), config=stub_configuration)
+        assert subproc_record.invocations() == [
+            ['scc', "a.o", "-o", "a.out"]
+        ]
+
+
+def test_c_with_libraries(stub_c_compiler: CCompiler,
+                          stub_configuration: BuildConfig,
+                          subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests link command line when additional libraries are specified.
+    """
+    linker = Linker(compiler=stub_c_compiler)
     linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
 
-    mock_result = mock.Mock(returncode=0)
-    mock_config._openmp = False
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        linker.link([Path("a.o")], Path("a.out"), config=mock_config)
-    tool_run.assert_called_with(
-        ["mock_c_compiler.exe", "a.o", "-o", "a.out"],
-        capture_output=True, env=None, cwd=None, check=False)
+    linker.link([Path("a.o")], Path("a.out"), libs=["customlib"],
+                config=stub_configuration)
 
-
-def test_linker_c_with_libraries(mock_config):
-    """Test the link command line when additional libraries are specified."""
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)
-    linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
-
-    mock_config._openmp = True
-    with mock.patch.object(linker, "run") as link_run:
-        linker.link(
-            [Path("a.o")], Path("a.out"), libs=["customlib"],
-            config=mock_config)
     # The order of the 'libs' list should be maintained
-    link_run.assert_called_with(
-        ["-fopenmp", "a.o", "-lcustom", "-jcustom", "-o", "a.out"])
+    assert subproc_record.invocations() == [
+        ['scc', "a.o", "-lcustom", "-jcustom", "-o", "a.out"]
+    ]
 
 
-def test_linker_c_with_libraries_and_post_flags(mock_config):
-    """Test the link command line when a library and additional flags are
-    specified."""
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)
+def test_c_with_libraries_and_post_flags(stub_c_compiler: CCompiler,
+                                         stub_configuration: BuildConfig,
+                                         subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests link command line when a library and additional flags are specified.
+    """
+    linker = Linker(compiler=stub_c_compiler)
     linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
     linker.add_post_lib_flags(["-extra-flag"])
 
-    mock_config._openmp = False
-    with mock.patch.object(linker, "run") as link_run:
-        linker.link(
-            [Path("a.o")], Path("a.out"), libs=["customlib"],
-            config=mock_config)
-    link_run.assert_called_with(
-        ["a.o", "-lcustom", "-jcustom", "-extra-flag", "-o", "a.out"])
+    linker.link([Path("a.o")], Path("a.out"),
+                libs=["customlib"], config=stub_configuration)
+    assert subproc_record.invocations() == [
+        ['scc', "a.o", "-lcustom", "-jcustom", "-extra-flag", "-o", "a.out"]
+    ]
 
 
-def test_linker_c_with_libraries_and_pre_flags(mock_config):
-    """Test the link command line when a library and additional flags are
-    specified."""
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)
+def test_c_with_libraries_and_pre_flags(stub_c_compiler: CCompiler,
+                                        stub_configuration: BuildConfig,
+                                        subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests link command line when a library and additional flags are specified.
+    """
+    linker = Linker(compiler=stub_c_compiler)
     linker.add_lib_flags("customlib", ["-lcustom", "-jcustom"])
     linker.add_pre_lib_flags(["-L", "/common/path/"])
 
-    mock_config._openmp = False
-    with mock.patch.object(linker, "run") as link_run:
-        linker.link(
-            [Path("a.o")], Path("a.out"), libs=["customlib"],
-            config=mock_config)
-    link_run.assert_called_with(
-        ["a.o", "-L", "/common/path/", "-lcustom", "-jcustom", "-o", "a.out"])
+    linker.link([Path("a.o")], Path("a.out"),
+                libs=["customlib"], config=stub_configuration)
+    assert subproc_record.invocations() == [
+        ['scc', "a.o", "-L", "/common/path/",
+         "-lcustom", "-jcustom", "-o", "a.out"]
+    ]
 
 
-def test_linker_c_with_unknown_library(mock_config):
-    """Test the link command raises an error when unknow libraries are
-    specified.
+def test_c_with_unknown_library(stub_c_compiler: CCompiler,
+                                stub_configuration: BuildConfig) -> None:
     """
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)\
+    Tests link tool raises an error when unknow libraries are specified.
+    """
+    linker = Linker(compiler=stub_c_compiler)
 
-    mock_config._openmp = True
-    with pytest.raises(RuntimeError) as err:
+    with raises(RuntimeError) as err:
         # Try to use "customlib" when we haven't added it to the linker
-        linker.link(
-            [Path("a.o")], Path("a.out"), libs=["customlib"],
-            config=mock_config)
-
-    assert "Unknown library name: 'customlib'" in str(err.value)
+        linker.link([Path("a.o")], Path("a.out"),
+                    libs=["customlib"], config=stub_configuration)
+    assert str(err.value) == "Unknown library name: 'customlib'"
 
 
-def test_compiler_linker_add_compiler_flag(mock_c_compiler, mock_config):
-    '''Test that a flag added to the compiler will be automatically
-    added to the link line (even if the flags are modified after creating the
-    linker ... in case that the user specifies additional flags after creating
-    the linker).'''
+def test_add_compiler_flag(stub_c_compiler: CCompiler,
+                           stub_configuration: BuildConfig,
+                           subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests an argument added to the compiler will appear in the link line.
 
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker = Linker(compiler=mock_c_compiler)
-    mock_c_compiler.add_flags("-my-flag")
-    mock_result = mock.Mock(returncode=0)
-    mock_config._openmp = False
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        linker.link([Path("a.o")], Path("a.out"), config=mock_config)
-    tool_run.assert_called_with(
-        ['mock_c_compiler.exe', '-my-flag', 'a.o', '-o', 'a.out'],
-        capture_output=True, env=None, cwd=None, check=False)
+    Even if the arguments are modified after creating the linker.
+    """
+    linker = Linker(compiler=stub_c_compiler)
+    stub_c_compiler.add_flags("-my-flag")
+    linker.link([Path("a.o")], Path("a.out"), config=stub_configuration)
+    assert subproc_record.invocations() == [
+        ['scc', '-my-flag', 'a.o', '-o', 'a.out']
+    ]
 
 
-def test_linker_all_flag_types(mock_config):
-    """Make sure all possible sources of linker flags are used in the right
-    order"""
+def test_linker_all_flag_types(stub_c_compiler: CCompiler,
+                               stub_configuration: BuildConfig,
+                               subproc_record: ExtendedRecorder,
+                               monkeypatch) -> None:
+    """
+    Tests linker arguments are used in the correct order.
 
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
+    Todo: Monkeying with private state.
+    """
     # Environment variables for both the linker
-    with mock.patch.dict("os.environ", {"LDFLAGS": "-ldflag"}):
-        linker = Linker(compiler=mock_c_compiler)
+    monkeypatch.setenv('LDFLAGS', '-ldflag')
 
-    mock_c_compiler.add_flags(["-compiler-flag1", "-compiler-flag2"])
+    linker = Linker(compiler=stub_c_compiler)
+
+    stub_c_compiler.add_flags(["-compiler-flag1", "-compiler-flag2"])
+
     linker.add_flags(["-linker-flag1", "-linker-flag2"])
     linker.add_pre_lib_flags(["-prelibflag1", "-prelibflag2"])
     linker.add_lib_flags("customlib1", ["-lib1flag1", "lib1flag2"])
     linker.add_lib_flags("customlib2", ["-lib2flag1", "lib2flag2"])
     linker.add_post_lib_flags(["-postlibflag1", "-postlibflag2"])
 
-    mock_result = mock.Mock(returncode=0)
-    mock_config._openmp = True
-    with mock.patch("fab.tools.tool.subprocess.run",
-                    return_value=mock_result) as tool_run:
-        linker.link([
-            Path("a.o")], Path("a.out"),
-            libs=["customlib2", "customlib1"],
-            config=mock_config)
-
-    tool_run.assert_called_with([
-        "mock_c_compiler.exe",
-        "-ldflag", "-linker-flag1", "-linker-flag2",
-        "-compiler-flag1", "-compiler-flag2",
-        "-fopenmp",
-        "a.o",
-        "-prelibflag1", "-prelibflag2",
-        "-lib2flag1", "lib2flag2",
-        "-lib1flag1", "lib1flag2",
-        "-postlibflag1", "-postlibflag2",
-        "-o", "a.out"],
-        capture_output=True, env=None, cwd=None, check=False)
+    stub_configuration._openmp = True
+    linker.link([Path("a.o")], Path("a.out"),
+                libs=["customlib2", "customlib1"], config=stub_configuration)
+    assert subproc_record.invocations() == [
+        ['scc', "-ldflag", "-linker-flag1", "-linker-flag2",
+         "-compiler-flag1", "-compiler-flag2",
+         "-omp",
+         "a.o",
+         "-prelibflag1", "-prelibflag2",
+         "-lib2flag1", "lib2flag2",
+         "-lib1flag1", "lib1flag2",
+         "-postlibflag1", "-postlibflag2",
+         "-o", "a.out"]
+    ]
 
 
-def test_linker_nesting(mock_config):
-    """Make sure all possible sources of linker flags are used in the right
-    order"""
+def test_linker_nesting(stub_c_compiler: CCompiler,
+                        stub_configuration: BuildConfig,
+                        subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests linker arguments appear in correct order.
 
-    mock_c_compiler = mock_config.tool_box[Category.C_COMPILER]
-    linker1 = Linker(compiler=mock_c_compiler)
+    Todo: Monkeying with private state.
+    """
+    linker1 = Linker(compiler=stub_c_compiler)
     linker1.add_pre_lib_flags(["pre_lib1"])
     linker1.add_lib_flags("lib_a", ["a_from_1"])
     linker1.add_lib_flags("lib_c", ["c_from_1"])
     linker1.add_post_lib_flags(["post_lib1"])
-    linker2 = Linker(mock_c_compiler, linker=linker1)
+
+    linker2 = Linker(stub_c_compiler, linker=linker1)
     linker2.add_pre_lib_flags(["pre_lib2"])
     linker2.add_lib_flags("lib_b", ["b_from_2"])
     linker2.add_lib_flags("lib_c", ["c_from_2"])
+
     linker1.add_post_lib_flags(["post_lib2"])
-    mock_config._openmp = True
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch("fab.tools.tool.subprocess.run",
-                    return_value=mock_result) as tool_run:
-        linker2.link(
-            [Path("a.o")], Path("a.out"),
-            libs=["lib_a", "lib_b", "lib_c"],
-            config=mock_config)
-    tool_run.assert_called_with(["mock_c_compiler.exe", "-fopenmp",
-                                 "a.o", "pre_lib2", "pre_lib1", "a_from_1",
-                                 "b_from_2", "c_from_2",
-                                 "post_lib1", "post_lib2", "-o", "a.out"],
-                                capture_output=True, env=None, cwd=None,
-                                check=False)
+
+    stub_configuration._openmp = True
+    linker2.link([Path("a.o")], Path("a.out"),
+                 libs=["lib_a", "lib_b", "lib_c"], config=stub_configuration)
+    assert subproc_record.invocations() == [
+        ["scc", "-omp", "a.o", "pre_lib2", "pre_lib1", "a_from_1",
+         "b_from_2", "c_from_2", "post_lib1", "post_lib2", "-o", "a.out"]
+    ]
 
 
-def test_linker_inheriting():
-    '''Make sure that libraries from a wrapper compiler will be
-    available for a wrapper.
-    '''
-    tr = ToolRepository()
-    linker_gfortran = tr.get_tool(Category.LINKER, "linker-gfortran")
-    linker_mpif90 = tr.get_tool(Category.LINKER, "linker-mpif90-gfortran")
+def test_linker_inheriting() -> None:
+    """
+    Tests library argument pass-through from compiler to wrapper.
+    """
+    compiler = FortranCompiler("some Fortran compiler", 'sfc', 'some',
+                               r'([\d.]+)')
+    compiler_linker = Linker(compiler)
+    wrapper = Mpif90(compiler)
+    wrapper_linker = Linker(wrapper)
 
-    linker_gfortran.add_lib_flags("lib_a", ["a_from_1"])
-    assert linker_mpif90.get_lib_flags("lib_a") == ["a_from_1"]
+    compiler_linker.add_lib_flags("lib_a", ["a_from_1"])
+    assert compiler_linker.get_lib_flags("lib_a") == ["a_from_1"]
 
-    with pytest.raises(RuntimeError) as err:
-        linker_mpif90.get_lib_flags("does_not_exist")
+    with raises(RuntimeError) as err:
+        wrapper_linker.get_lib_flags("does_not_exist")
     assert "Unknown library name: 'does_not_exist'" in str(err.value)
 
 
-def test_linker_profile_flags_inheriting(mock_c_compiler):
-    '''Test nested compiler and nested linker with inherited profiling flags.
-
-    '''
-    mock_c_compiler_wrapper = CompilerWrapper(name="mock_c_compiler_wrapper",
-                                              compiler=mock_c_compiler,
-                                              exec_name="exec_name")
-    linker = Linker(mock_c_compiler_wrapper)
-    linker_wrapper = Linker(mock_c_compiler_wrapper, linker=linker)
+def test_linker_profile_flags_inheriting(stub_c_compiler):
+    """
+    Tests nested compiler and nested linker with inherited profiling flags.
+    """
+    compiler_wrapper = CompilerWrapper(name="mock_c_compiler_wrapper",
+                                       compiler=stub_c_compiler,
+                                       exec_name="exec_name")
+    linker = Linker(compiler_wrapper)
+    linker_wrapper = Linker(compiler_wrapper, linker=linker)
     count = 0
-    for compiler in [mock_c_compiler, mock_c_compiler_wrapper]:
+    for compiler in [stub_c_compiler, compiler_wrapper]:
         compiler.define_profile("base")
         compiler.define_profile("derived", "base")
         compiler.add_flags(f"-f{count}", "base")
@@ -393,27 +419,31 @@ def test_linker_profile_flags_inheriting(mock_c_compiler):
             ["-f0", "-f1", "-f2", "-f3", "-f0", "-f1", "-f2", "-f3"])
 
 
-def test_linker_profile_modes(mock_linker):
-    '''Test that defining a profile mode in a linker will also define
+def test_linker_profile_modes(stub_fortran_compiler):
+    """
+    Tests defining a profile mode in a linker will also define
     the same modes in post- and pre-flags
-    '''
+
+    ToDo: Monkeying with internal state.
+    """
+    linker = Linker(stub_fortran_compiler)
 
     # Make sure that we get the expected errors at the start:
-    with pytest.raises(KeyError) as err:
-        mock_linker._pre_lib_flags["base"]
+    with raises(KeyError) as err:
+        _ = linker._pre_lib_flags["base"]
     assert "Profile 'base' is not defined" in str(err.value)
-    with pytest.raises(KeyError) as err:
-        mock_linker._post_lib_flags["base"]
+    with raises(KeyError) as err:
+        _ = linker._post_lib_flags["base"]
     assert "Profile 'base' is not defined" in str(err.value)
 
-    mock_linker.define_profile("base")
-    assert mock_linker._pre_lib_flags["base"] == []
-    assert "base" not in mock_linker._pre_lib_flags._inherit_from
-    assert mock_linker._post_lib_flags["base"] == []
-    assert "base" not in mock_linker._post_lib_flags._inherit_from
+    linker.define_profile("base")
+    assert linker._pre_lib_flags["base"] == []
+    assert "base" not in linker._pre_lib_flags._inherit_from
+    assert linker._post_lib_flags["base"] == []
+    assert "base" not in linker._post_lib_flags._inherit_from
 
-    mock_linker.define_profile("full-debug", "base")
-    assert mock_linker._pre_lib_flags["full-debug"] == []
-    assert mock_linker._pre_lib_flags._inherit_from["full-debug"] == "base"
-    assert mock_linker._post_lib_flags["full-debug"] == []
-    assert mock_linker._post_lib_flags._inherit_from["full-debug"] == "base"
+    linker.define_profile("full-debug", "base")
+    assert linker._pre_lib_flags["full-debug"] == []
+    assert linker._pre_lib_flags._inherit_from["full-debug"] == "base"
+    assert linker._post_lib_flags["full-debug"] == []
+    assert linker._post_lib_flags._inherit_from["full-debug"] == "base"

--- a/tests/unit_tests/tools/test_preprocessor.py
+++ b/tests/unit_tests/tools/test_preprocessor.py
@@ -3,80 +3,82 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Tests the tool class.
-'''
-
-
-import logging
+"""
+Tests source preprocessor tools.
+"""
+from logging import Logger
 from pathlib import Path
 
-from unittest import mock
+from tests.conftest import ExtendedRecorder
 
-from fab.tools import (Category, Cpp, CppFortran, Fpp, Preprocessor)
+from pytest import mark
+from pytest_subprocess.fake_process import FakeProcess
+
+from tests.conftest import call_list
+
+from fab.tools.category import Category
+from fab.tools.preprocessor import Cpp, CppFortran, Fpp, Preprocessor
 
 
-def test_preprocessor_constructor():
-    '''Test the constructor.'''
-    tool = Preprocessor("cpp-fortran", "cpp", Category.FORTRAN_PREPROCESSOR)
-    assert str(tool) == "Preprocessor - cpp-fortran: cpp"
-    assert tool.exec_name == "cpp"
-    assert tool.name == "cpp-fortran"
+def test_constructor() -> None:
+    """
+    Tests construction from argument list.
+    """
+    tool = Preprocessor("some preproc", "spp", Category.FORTRAN_PREPROCESSOR)
+    assert str(tool) == "Preprocessor - some preproc: spp"
+    assert tool.exec_name == "spp"
+    assert tool.name == "some preproc"
     assert tool.category == Category.FORTRAN_PREPROCESSOR
-    assert isinstance(tool.logger, logging.Logger)
+    assert isinstance(tool.logger, Logger)
 
 
-def test_preprocessor_fpp_is_available():
-    '''Test that is_available works as expected.'''
+@mark.parametrize('rc', [0, 1])
+def test_fpp_is_available(rc, fake_process: FakeProcess) -> None:
+    """
+    Tests availability check for "fpp" tool.
+    """
+    # ToDo: This is Intel FPP syntax. Does it hold for other implementations?
+    command = ['fpp', '-what']
+    fake_process.register(command, returncode=rc)
+
     fpp = Fpp()
-    mock_run = mock.Mock(side_effect=RuntimeError("not found"))
-    with mock.patch("subprocess.run", mock_run):
-        assert not fpp.is_available
-
-    # Reset the flag and pretend run returns a success:
-    fpp._is_available = None
-    mock_run = mock.Mock(returncode=0)
-    with mock.patch("fab.tools.tool.Tool.run", mock_run):
-        assert fpp.is_available
+    assert fpp.is_available is (rc == 0)
+    assert call_list(fake_process) == [command]
 
 
-def test_preprocessor_cpp():
-    '''Test cpp.'''
-    cpp = Cpp()
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
+class TestCpp:
+    def test_cpp(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Tests the CPP tool.
+        """
+        cpp = Cpp()
         cpp.run("--version")
-    tool_run.assert_called_with(["cpp", "--version"], capture_output=True,
-                                env=None, cwd=None, check=False)
+        assert subproc_record.invocations() == [['cpp', '--version']]
 
-    # Reset the flag and raise an error when executing:
-    cpp._is_available = None
-    mock_run = mock.Mock(side_effect=RuntimeError("not found"))
-    with mock.patch("fab.tools.tool.Tool.run", mock_run):
-        assert not cpp.is_available
+    def test_is_not_available(self, fake_process: FakeProcess) -> None:
+        fake_process.register(['cpp', '--version'], returncode=1)
+        cpp = Cpp()
+        assert cpp.is_available is False
+        assert call_list(fake_process) == [['cpp', '--version']]
 
 
-def test_preprocessor_cppfortran():
-    '''Test cpp for Fortran, which adds additional command line options in.'''
-    cppf = CppFortran()
-    assert cppf.is_available
-    # First create a mock object that is the result of subprocess.run.
-    # Tool will only check `returncode` of this object.
-    mock_result = mock.Mock(returncode=0)
-    # Then set this result as result of a mock run function
-    mock_run = mock.Mock(return_value=mock_result)
+class TestCppTraditional:
+    def test_is_not_available(self, fake_process: FakeProcess) -> None:
+        """
+        Tests CPP in "traditional" mode.
+        """
+        command = ['cpp', '-traditional-cpp', '-P', '--version']
+        fake_process.register(command, returncode=1)
 
-    with mock.patch("subprocess.run", mock_run):
-        # First test calling without additional flags:
+        cppf = CppFortran()
+        assert cppf.is_available is False
+        assert call_list(fake_process) == [command]
+
+    def test_preprocess(self, subproc_record: ExtendedRecorder) -> None:
+        cppf = CppFortran()
         cppf.preprocess(Path("a.in"), Path("a.out"))
-    mock_run.assert_called_with(
-        ["cpp", "-traditional-cpp", "-P", "a.in", "a.out"],
-        capture_output=True, env=None, cwd=None, check=False)
-
-    with mock.patch("subprocess.run", mock_run):
-        # Then test with added flags:
         cppf.preprocess(Path("a.in"), Path("a.out"), ["-DDO_SOMETHING"])
-    mock_run.assert_called_with(
-        ["cpp", "-traditional-cpp", "-P", "-DDO_SOMETHING", "a.in", "a.out"],
-        capture_output=True, env=None, cwd=None, check=False)
+        assert subproc_record.invocations() == [
+            ["cpp", "-traditional-cpp", "-P", "a.in", "a.out"],
+            ["cpp", "-traditional-cpp", "-P", "-DDO_SOMETHING", "a.in", "a.out"]
+        ]

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -3,311 +3,402 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Tests the PSyclone implementation.
-'''
-
+"""
+Tests the PSyclone tool.
+"""
 from importlib import reload
-from unittest import mock
+from pathlib import Path
+import typing  # Needed for monkey patching
+from typing import Tuple
+from unittest.mock import Mock
 
-import pytest
+from pytest import mark, raises, warns
+from pytest_subprocess.fake_process import FakeProcess
 
-from fab.tools import (Category, Psyclone)
+from tests.conftest import call_list, not_found_callback
 
-
-def get_mock_result(version_info: str) -> mock.Mock:
-    '''Returns a mock PSyclone object that will return
-    the specified str as version info.
-
-    :param version_info: the simulated output of psyclone --version
-        The leading "PSyclone version: " will be added automatically.
-    '''
-    # The return of subprocess run has an attribute 'stdout',
-    # that returns the stdout when its `decode` method is called.
-    # So we mock stdout, then put this mock_stdout into the mock result:
-    mock_stdout = mock.Mock(decode=lambda: f"PSyclone version: {version_info}")
-    mock_result = mock.Mock(stdout=mock_stdout, returncode=0)
-    return mock_result
+from fab.tools.category import Category
+import fab.tools.psyclone  # Needed for mockery
+from fab.tools.psyclone import Psyclone
 
 
-def test_psyclone_constructor():
-    '''Test the PSyclone constructor.'''
+def test_constructor():
+    """
+    Tests the default constructor.
+    """
     psyclone = Psyclone()
     assert psyclone.category == Category.PSYCLONE
     assert psyclone.name == "psyclone"
     assert psyclone.exec_name == "psyclone"
-    # pylint: disable=use-implicit-booleaness-not-comparison
     assert psyclone.get_flags() == []
 
 
-@pytest.mark.parametrize("version", ["2.4.0", "2.5.0", "3.0.0", "3.1.0"])
-def test_psyclone_check_available_and_version(version):
-    '''Tests the is_available functionality and version number detection
+@mark.parametrize("version", ["2.4.0", "2.5.0", "3.0.0", "3.1.0"])
+def test_check_available_and_version(version: str,
+                                     fake_process: FakeProcess) -> None:
+    """
+    Tests the is_available functionality and version number detection
     with PSyclone. Note that the version number is only used internally,
     so we test with the private attribute.
-    '''
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command,
+                          stdout='PSyclone version: ' + version)
+
     psyclone = Psyclone()
+
     version_tuple = tuple(int(i) for i in version.split("."))
-    mock_result = get_mock_result(version)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        assert psyclone.check_available()
-        assert psyclone._version == version_tuple
-
-    tool_run.assert_called_once_with(
-        ["psyclone", "--version"], capture_output=True,
-        env=None, cwd=None, check=False)
+    assert psyclone.check_available()
+    assert psyclone._version == version_tuple
+    assert call_list(fake_process) == [version_command]
 
 
-def test_psyclone_check_available_errors():
-    '''Test various errors that can happen in check_available.
-    '''
-    psyclone = Psyclone()
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    side_effect=FileNotFoundError("ERR")):
-        assert not psyclone.check_available()
+def test_check_available_errors(fake_process: FakeProcess) -> None:
+    """
+    Tests lack of availability.
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, callback=not_found_callback)
 
     psyclone = Psyclone()
-    mock_result = get_mock_result("NOT_A_NUMBER.4.0")
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result):
-        with pytest.warns(UserWarning,
-                          match="Unexpected version information for PSyclone: "
-                                "'PSyclone version: NOT_A_NUMBER.4.0'"):
-            assert not psyclone.check_available()
-    # Also check that we can't call process if PSyclone is not available.
-    psyclone._is_available = False
-    config = mock.Mock()
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file")
-    assert "PSyclone is not available" in str(err.value)
+    assert psyclone.check_available() is False
 
 
-def test_psyclone_processing_errors_without_api():
-    '''Test all processing errors in PSyclone if no API is specified.'''
+def test_not_available(fake_process: FakeProcess) -> None:
+    """
+    Tests lack of availability.
+    """
+    fake_process.register(['psyclone', '--version'],
+                          callback=not_found_callback)
 
     psyclone = Psyclone()
-    psyclone._is_available = True
-    config = mock.Mock()
 
-    # No API --> we need transformed file, but not psy or alg:
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=None, psy_file="psy_file")
-    assert ("PSyclone called without api, but psy_file is specified"
-            in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=None, alg_file="alg_file")
-    assert ("PSyclone called without api, but alg_file is specified"
-            in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=None)
-    assert ("PSyclone called without api, but transformed_file is not "
-            "specified" in str(err.value))
+    assert psyclone.check_available() is False
+    assert call_list(fake_process) == [
+        ['psyclone', '--version']
+    ]
 
 
-@pytest.mark.parametrize("api", ["dynamo0.3", "lfric"])
-def test_psyclone_processing_errors_with_api(api):
-    '''Test all processing errors in PSyclone if an API is specified.'''
+def test_check_available_bad_version(fake_process: FakeProcess) -> None:
+    """
+    Tests executable which returns an unexpected version string.
+    """
+    fake_process.register(['psyclone', '--version'],
+                          stdout='PSyclone version: NOT_A_NUMBER.4.0')
 
     psyclone = Psyclone()
-    psyclone._is_available = True
-    config = mock.Mock()
 
-    # No API --> we need transformed file, but not psy or alg:
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=api, psy_file="psy_file")
-    assert (f"PSyclone called with api '{api}', but no alg_file is specified"
-            in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=api, alg_file="alg_file")
-    assert (f"PSyclone called with api '{api}', but no psy_file is specified"
-            in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        psyclone.process(config, "x90file", api=api,
-                         psy_file="psy_file", alg_file="alg_file",
-                         transformed_file="transformed_file")
-    assert (f"PSyclone called with api '{api}' and transformed_file"
-            in str(err.value))
+    with warns(UserWarning,
+               match="Unexpected version information for PSyclone: "
+                     "'PSyclone version: NOT_A_NUMBER.4.0'"):
+        assert psyclone.check_available() is False
 
 
-@pytest.mark.parametrize("version", ["2.4.0", "2.5.0"])
-@pytest.mark.parametrize("api", [("dynamo0.3", "dynamo0.3"),
-                                 ("lfric", "dynamo0.3"),
-                                 ("gocean1.0", "gocean1.0"),
-                                 ("gocean", "gocean1.0")
-                                 ])
-def test_psyclone_process_api_old_psyclone(api, version):
-    '''Test running 'old style' PSyclone (2.5.0 and earlier) with the old API
-    names (dynamo0.3 and gocean1.0). Also check that the new API names will
-    be accepted, but are mapped to the old style names. The 'api' parameter
-    contains the input api, and expected output API.
-    '''
+def test_check_process_missing(fake_process: FakeProcess) -> None:
+    """
+    Tests processing with a missing executable.
+    """
+    fake_process.register(['psyclone', '--version'],
+                          callback=not_found_callback)
+
+    psyclone = Psyclone()
+    config = Mock()
+
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path("x90file"))
+    assert str(err.value).startswith("PSyclone is not available")
+
+
+def test_processing_errors_without_api(fake_process: FakeProcess) -> None:
+    """
+    Test all processing errors in PSyclone if no API is specified.
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
+
+    psyclone = Psyclone()
+    config = Mock()
+
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path('x90file'),
+                         api=None,
+                         psy_file=Path('psy_file'))
+    assert str(err.value) == "PSyclone called without api, but psy_file is specified."
+
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path('x90file'),
+                         api=None,
+                         alg_file=Path('alg_file'))
+    assert str(err.value) == "PSyclone called without api, but alg_file is specified."
+
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path('x90file'),
+                         api=None)
+    assert str(err.value) == "PSyclone called without api, but transformed_file is not specified."
+
+
+@mark.parametrize("api", ["dynamo0.3", "lfric"])
+def test_processing_errors_with_api(api: str,
+                                    fake_process: FakeProcess) -> None:
+    """
+    Tests potential processing errors with unspecified API.
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, stdout='PSyclone version: 2.6.0')
+
+    psyclone = Psyclone()
+    config = Mock()
+
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path("x90file"),
+                         api=api,
+                         psy_file=Path("psy_file"))
+    assert str(err.value).startswith(
+        f"PSyclone called with api '{api}', but no alg_file is specified"
+    )
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path("x90file"),
+                         api=api,
+                         alg_file=Path("alg_file"))
+    assert str(err.value).startswith(
+        f"PSyclone called with api '{api}', but no psy_file is specified"
+    )
+    with raises(RuntimeError) as err:
+        psyclone.process(config,
+                         Path("x90file"),
+                         api=api,
+                         psy_file=Path("psy_file"),
+                         alg_file=Path("alg_file"),
+                         transformed_file=Path("transformed_file"))
+    assert str(err.value).startswith(
+        f"PSyclone called with api '{api}' and transformed_file"
+    )
+
+
+@mark.parametrize("version", ["2.4.0", "2.5.0"])
+@mark.parametrize("api", [("dynamo0.3", "dynamo0.3"),
+                          ("lfric", "dynamo0.3"),
+                          ("gocean1.0", "gocean1.0"),
+                          ("gocean", "gocean1.0")
+                          ])
+def test_process_api_old_psyclone(api: Tuple[str, str], version: str,
+                                  fake_process: FakeProcess) -> None:
+    """
+    Tests old style API support with PSyclone 2.5.0 and earlier.
+    """
     api_in, api_out = api
-    psyclone = Psyclone()
-    mock_result = get_mock_result(version)
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api=api_in,
-                         x90_file="x90_file",
-                         psy_file="psy_file",
-                         alg_file="alg_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '-api', api_out, '-opsy', 'psy_file',
-         '-oalg', 'alg_file', '-l', 'all', '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
 
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command,
+                          stdout='PSyclone version: ' + version)
 
-@pytest.mark.parametrize("version", ["2.4.0", "2.5.0"])
-def test_psyclone_process_no_api_old_psyclone(version):
-    '''Test running old-style PSyclone (2.5.0 and earlier) when requesting
-    to transform existing files by not specifying an API. We need to add
-    the flags `-api nemo` in this case for older PSyclone versions.
-    '''
-    psyclone = Psyclone()
-    mock_result = get_mock_result(version)
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
-
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api="",
-                         x90_file="x90_file",
-                         transformed_file="psy_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '-api', 'nemo', '-opsy', 'psy_file', '-l', 'all',
-         '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
-
-
-@pytest.mark.parametrize("version", ["2.4.0", "2.5.0"])
-def test_psyclone_process_nemo_api_old_psyclone(version):
-    '''Test running old-style PSyclone (2.5.0 and earlier) when requesting
-    to transform existing files by specifying the nemo api.
-    '''
+    process_command = ['psyclone', '-api', api_out, '-opsy', 'psy_file',
+                       '-oalg', 'alg_file', '-l', 'all', '-s', 'script_called',
+                       '-c', 'psyclone.cfg', '-d', 'root1', '-d', 'root2',
+                       'x90_file']
+    fake_process.register(process_command)
 
     psyclone = Psyclone()
-    mock_result = get_mock_result(version)
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
+    config = Mock()
 
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api="nemo",
-                         x90_file="x90_file",
-                         transformed_file="psy_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '-api', 'nemo', '-opsy', 'psy_file', '-l', 'all',
-         '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
+    psyclone.process(config=config,
+                     api=api_in,
+                     x90_file=Path("x90_file"),
+                     psy_file=Path("psy_file"),
+                     alg_file=Path("alg_file"),
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, process_command
+    ]
 
 
-@pytest.mark.parametrize("api", [("dynamo0.3", "lfric"),
-                                 ("lfric", "lfric"),
-                                 ("gocean1.0", "gocean"),
-                                 ("gocean", "gocean")
-                                 ])
-def test_psyclone_process_api_new_psyclone(api):
-    '''Test running PSyclone 3.0.0. It uses new API names, and we need to
+@mark.parametrize("version", ["2.4.0", "2.5.0"])
+def test_process_no_api_old_psyclone(version: str,
+                                     fake_process: FakeProcess) -> None:
+    """
+    Tests unspecified API for PSyclone 2.5.0 and older.
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command,
+                          stdout='PSyclone version: ' + version)
+    process_command = ['psyclone', '-api', 'nemo', '-opsy', 'psy_file',
+                       '-l', 'all', '-s', 'script_called',
+                       '-c', 'psyclone.cfg', '-d', 'root1', '-d', 'root2',
+                       'x90_file']
+    fake_process.register(process_command)
+
+    psyclone = Psyclone()
+    config = Mock()
+
+    psyclone.process(config=config,
+                     api="",
+                     x90_file=Path("x90_file"),
+                     transformed_file=Path("psy_file"),
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, process_command
+    ]
+
+
+@mark.parametrize("version", ["2.4.0", "2.5.0"])
+def test_process_nemo_api_old_psyclone(version: str,
+                                       fake_process: FakeProcess) -> None:
+    """
+    Tests NEMO API with PSyclone 2.5.0 or earlier.
+
+    ToDo: The wierd extra bits performed for 2.5.0 look highly dubious.
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command,
+                          stdout='PSyclone version: ' + version)
+    if version == '2.5.0':
+        random_command = ['psyclone', '-api', 'nemo',
+                          fab.tools.psyclone.__file__]
+        fake_process.register(random_command, returncode=1)
+    psyclone_command = ['psyclone', '-api', 'nemo', '-opsy', 'psy_file',
+                        '-l', 'all', '-s', 'script_called',
+                        '-c', 'psyclone.cfg', '-d', 'root1', '-d', 'root2',
+                        'x90_file']
+    fake_process.register(psyclone_command)
+
+    psyclone = Psyclone()
+
+    config = Mock()
+
+    psyclone.process(config=config,
+                     api="nemo",
+                     x90_file=Path('x90_file'),
+                     transformed_file=Path('psy_file'),
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, psyclone_command
+    ]
+
+
+@mark.parametrize("api",
+                  [
+                      ("dynamo0.3", "lfric"),
+                      ("lfric", "lfric"),
+                      ("gocean1.0", "gocean"),
+                      ("gocean", "gocean")
+                  ])
+def test_process_api_new_psyclone(api: Tuple[str, str],
+                                  fake_process: FakeProcess) -> None:
+    """
+    Test running PSyclone 3.0.0. It uses new API names, and we need to
     check that the old style names are converted to the new names.
-    '''
+    """
     api_in, api_out = api
+
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
+
+    psyclone_command = ['psyclone', '--psykal-dsl', api_out,
+                        '-opsy', 'psy_file', '-oalg', 'alg_file', '-l', 'all',
+                        '-s', 'script_called', '-c', 'psyclone.cfg',
+                        '-d', 'root1', '-d', 'root2', 'x90_file']
+    fake_process.register(psyclone_command)
+
     psyclone = Psyclone()
-    mock_result = get_mock_result("3.0.0")
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api=api_in,
-                         x90_file="x90_file",
-                         psy_file="psy_file",
-                         alg_file="alg_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '--psykal-dsl', api_out, '-opsy', 'psy_file',
-         '-oalg', 'alg_file', '-l', 'all', '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
+    config = Mock()
+
+    psyclone.process(config=config,
+                     api=api_in,
+                     x90_file=Path('x90_file'),
+                     psy_file=Path('psy_file'),
+                     alg_file="alg_file",
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, psyclone_command
+    ]
 
 
-def test_psyclone_process_no_api_new_psyclone():
-    '''Test running the PSyclone 3.0.0 without an API, i.e. as transformation
+def test_process_no_api_new_psyclone(fake_process: FakeProcess) -> None:
+    """
+    Test running the PSyclone 3.0.0 without an API, i.e. as transformation
     only.
-    '''
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
+
+    psyclone_command = ['psyclone', '-o', 'psy_file', '-l', 'all',
+                        '-s', 'script_called', '-c', 'psyclone.cfg',
+                        '-d', 'root1', '-d', 'root2', 'x90_file']
+    fake_process.register(psyclone_command)
+
     psyclone = Psyclone()
-    mock_result = get_mock_result("3.0.0")
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
+    config = Mock()
 
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api="",
-                         x90_file="x90_file",
-                         transformed_file="psy_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '-o', 'psy_file', '-l', 'all',
-         '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
+    psyclone.process(config=config,
+                     api="",
+                     x90_file=Path('x90_file'),
+                     transformed_file=Path('psy_file'),
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, psyclone_command
+    ]
 
 
-def test_psyclone_process_nemo_api_new_psyclone():
-    '''Test running PSyclone 3.0.0 and test that backwards compatibility of
+def test_process_nemo_api_new_psyclone(fake_process: FakeProcess) -> None:
+    """
+    Test running PSyclone 3.0.0 and test that backwards compatibility of
     using the nemo api works, i.e. '-api nemo' is just removed.
-    '''
+    """
+    version_command = ['psyclone', '--version']
+    fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
+
+    psyclone_command = ['psyclone', '-o', 'psy_file', '-l', 'all',
+                        '-s', 'script_called', '-c', 'psyclone.cfg',
+                        '-d', 'root1', '-d', 'root2', 'x90_file']
+    fake_process.register(psyclone_command)
+
     psyclone = Psyclone()
-    mock_result = get_mock_result("3.0.0")
-    transformation_function = mock.Mock(return_value="script_called")
-    config = mock.Mock()
+    config = Mock()
 
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        psyclone.process(config=config,
-                         api="nemo",
-                         x90_file="x90_file",
-                         transformed_file="psy_file",
-                         transformation_script=transformation_function,
-                         kernel_roots=["root1", "root2"],
-                         additional_parameters=["-c", "psyclone.cfg"])
-    tool_run.assert_called_with(
-        ['psyclone', '-o', 'psy_file', '-l', 'all',
-         '-s', 'script_called', '-c',
-         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
-        capture_output=True, env=None, cwd=None, check=False)
+    psyclone.process(config=config,
+                     api="nemo",
+                     x90_file=Path('x90_file'),
+                     transformed_file=Path('psy_file'),
+                     transformation_script=lambda x, y: Path('script_called'),
+                     kernel_roots=["root1", "root2"],
+                     additional_parameters=["-c", "psyclone.cfg"])
+
+    assert call_list(fake_process) == [
+        version_command, psyclone_command
+    ]
 
 
-def test_type_checking_import():
-    '''PSyclone contains an import of TYPE_CHECKING to break a circular
+def test_type_checking_import(monkeypatch) -> None:
+    """
+    PSyclone contains an import of TYPE_CHECKING to break a circular
     dependency. In order to reach 100% coverage of PSyclone, we set
     mock TYPE_CHECKING to be true and force a re-import of the module.
     TODO 314: This test can be removed once #314 is fixed.
-    '''
-    with mock.patch('typing.TYPE_CHECKING', True):
-        # This import will not actually re-import, since the module
-        # is already imported. But we need this in order to call reload:
-        # pylint: disable=import-outside-toplevel
-        import fab.tools.psyclone
-        reload(fab.tools.psyclone)
+    """
+    monkeypatch.setattr(typing, 'TYPE_CHECKING', True)
+    # This import will not actually re-import, since the module
+    # is already imported. But we need this in order to call reload:
+    # pylint: disable=import-outside-toplevel
+    import fab.tools.psyclone
+    reload(fab.tools.psyclone)

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -9,7 +9,7 @@ Tests the PSyclone tool.
 from importlib import reload
 from pathlib import Path
 import typing  # Needed for monkey patching
-from typing import Tuple
+from typing import Optional, Tuple
 from unittest.mock import Mock
 
 from pytest import mark, raises, warns
@@ -221,39 +221,9 @@ def test_process_api_old_psyclone(api: Tuple[str, str], version: str,
     ]
 
 
-@mark.parametrize("version", ["2.4.0", "2.5.0"])
-def test_process_no_api_old_psyclone(version: str,
-                                     fake_process: FakeProcess) -> None:
-    """
-    Tests unspecified API for PSyclone 2.5.0 and older.
-    """
-    version_command = ['psyclone', '--version']
-    fake_process.register(version_command,
-                          stdout='PSyclone version: ' + version)
-    process_command = ['psyclone', '-api', 'nemo', '-opsy', 'psy_file',
-                       '-l', 'all', '-s', 'script_called',
-                       '-c', 'psyclone.cfg', '-d', 'root1', '-d', 'root2',
-                       'x90_file']
-    fake_process.register(process_command)
-
-    psyclone = Psyclone()
-    config = Mock()
-
-    psyclone.process(config=config,
-                     api="",
-                     x90_file=Path("x90_file"),
-                     transformed_file=Path("psy_file"),
-                     transformation_script=lambda x, y: Path('script_called'),
-                     kernel_roots=["root1", "root2"],
-                     additional_parameters=["-c", "psyclone.cfg"])
-
-    assert call_list(fake_process) == [
-        version_command, process_command
-    ]
-
-
-@mark.parametrize("version", ["2.4.0", "2.5.0"])
-def test_process_nemo_api_old_psyclone(version: str,
+@mark.parametrize('version', ['2.4.0', '2.5.0'])
+@mark.parametrize('api', [None, 'nemo'])
+def test_process_nemo_api_old_psyclone(version: str, api: Optional[str],
                                        fake_process: FakeProcess) -> None:
     """
     Tests NEMO API with PSyclone 2.5.0 or earlier.
@@ -278,7 +248,7 @@ def test_process_nemo_api_old_psyclone(version: str,
     config = Mock()
 
     psyclone.process(config=config,
-                     api="nemo",
+                     api=api,
                      x90_file=Path('x90_file'),
                      transformed_file=Path('psy_file'),
                      transformation_script=lambda x, y: Path('script_called'),

--- a/tests/unit_tests/tools/test_rsync.py
+++ b/tests/unit_tests/tools/test_rsync.py
@@ -3,17 +3,23 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
+"""
+Tests RSync file tree synchronisation tool.
+"""
+from pathlib import Path
 
-'''Tests the rsync implementation.
-'''
+from pytest_subprocess.fake_process import FakeProcess
 
-from unittest import mock
+from tests.conftest import call_list, not_found_callback
 
-from fab.tools import (Category, Rsync)
+from fab.tools.category import Category
+from fab.tools.rsync import Rsync
 
 
-def test_ar_constructor():
-    '''Test the rsync constructor.'''
+def test_constructor():
+    """
+    Tests default constructor
+    """
     rsync = Rsync()
     assert rsync.category == Category.RSYNC
     assert rsync.name == "rsync"
@@ -21,39 +27,42 @@ def test_ar_constructor():
     assert rsync.get_flags() == []
 
 
-def test_rsync_check_available():
-    '''Tests the is_available functionality.'''
+def test_check_available(fake_process: FakeProcess) -> None:
+    """
+    Tests availability checking functionality.
+    """
+    fake_process.register(['rsync', '--version'], stdout='1.2.3')
+    fake_process.register(['rsync', '--version'], callback=not_found_callback)
+
     rsync = Rsync()
-    with mock.patch("fab.tools.tool.Tool.run") as tool_run:
-        assert rsync.check_available()
-    tool_run.assert_called_once_with("--version")
+    assert rsync.check_available()
 
     # Test behaviour if a runtime error happens:
-    with mock.patch("fab.tools.tool.Tool.run",
-                    side_effect=RuntimeError("")) as tool_run:
-        assert not rsync.check_available()
+    assert not rsync.check_available()
+
+    assert call_list(fake_process) == [
+        ['rsync', '--version'],
+        ['rsync', '--version']
+    ]
 
 
-def test_rsync_create():
-    '''Test executing an rsync, and also make sure that src always
-    end on a '/'.
-    '''
+def test_rsync_create(fake_process: FakeProcess) -> None:
+    """
+    Tests performing a sync. Ensure source always ends with a '/'.
+    """
+    with_command = ['rsync', '--times', '--links', '--stats', '-ru', '/src/', '/dst']
+    fake_process.register(with_command)
+    without_command = ['rsync', '--times', '--links', '--stats', '-ru', '/src/', '/dst']
+    fake_process.register(without_command)
+
     rsync = Rsync()
 
     # Test 1: src with /
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        rsync.execute(src="/src/", dst="/dst")
-    tool_run.assert_called_with(
-        ['rsync', '--times', '--links', '--stats', '-ru', '/src/', '/dst'],
-        capture_output=True, env=None, cwd=None, check=False)
+    rsync.execute(src=Path("/src/"), dst=Path("/dst"))
 
     # Test 2: src without /
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        rsync.execute(src="/src", dst="/dst")
-    tool_run.assert_called_with(
-        ['rsync', '--times', '--links', '--stats', '-ru', '/src/', '/dst'],
-        capture_output=True, env=None, cwd=None, check=False)
+    rsync.execute(src=Path("/src"), dst=Path("/dst"))
+
+    assert call_list(fake_process) == [
+        with_command, without_command
+    ]

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -3,22 +3,26 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-'''Tests the tool class.
-'''
-
-
+"""
+Tests tooling base classes.
+"""
 import logging
 from pathlib import Path
-from unittest import mock
 
-import pytest
+from pytest import raises
+from pytest_subprocess.fake_process import FakeProcess
 
-from fab.tools import Category, CompilerSuiteTool, ProfileFlags, Tool
+from tests.conftest import ExtendedRecorder, call_list, not_found_callback
+
+from fab.tools.category import Category
+from fab.tools.flags import ProfileFlags
+from fab.tools.tool import Tool
 
 
-def test_tool_constructor():
-    '''Test the constructor.'''
+def test_constructor() -> None:
+    """
+    Tests comstruction from argument list.
+    """
     tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
     assert str(tool) == "Tool - gnu: gfortran"
     assert tool.exec_name == "gfortran"
@@ -50,50 +54,54 @@ def test_tool_constructor():
     assert misc.category == Category.MISC
 
 
-def test_tool_chance_exec_name():
-    '''Test that we can change the name of the executable.
-    '''
+def test_chance_exec_name() -> None:
+    """
+    Tests changing the executable.
+
+    ToDo: Shouldn't the executable be inviolable?
+    """
     tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
     assert tool.exec_name == "gfortran"
     tool.change_exec_name("start_me_instead")
     assert tool.exec_name == "start_me_instead"
 
 
-def test_tool_is_available():
-    '''Test that is_available works as expected.'''
+def test_is_available(fake_process: FakeProcess) -> None:
+    """
+    Tests tool availability checking.
+    """
+    fake_process.register(['gfortran', '--version'], stdout="1.2.3")
     tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
-    with mock.patch.object(tool, "check_available", return_value=True):
-        assert tool.is_available
-    tool._is_available = False
+    assert tool.is_available
 
-    # Test the exception when trying to use in a non-existent tool:
-    with pytest.raises(RuntimeError) as err:
-        tool.run("--ops")
-    assert ("Tool 'gfortran' is not available to run '['gfortran', '--ops']'"
-            in str(err.value))
 
-    # Test setting the option and the getter
-    tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER,
+def test_availability_argument() -> None:
+    """
+    Tests setting the argument used to detect availability.
+    """
+    tool = Tool("ftool", "ftool", Category.FORTRAN_COMPILER,
                 availability_option="am_i_here")
     assert tool.availability_option == "am_i_here"
 
-    # Test that the actual check_available function works. Return 0 to
-    # indicate no error when running the tool:
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        assert tool.check_available()
-    tool_run.assert_called_once_with(['gfortran', 'am_i_here'],
-                                     capture_output=True, env=None,
-                                     cwd=None, check=False)
-    with mock.patch.object(tool, "run", side_effect=RuntimeError("")):
-        assert not tool.check_available()
+
+def test_run_missing(fake_process: FakeProcess) -> None:
+    """
+    Tests attempting to run an missing tool.
+    """
+    fake_process.register(['stool', '--ops'], callback=not_found_callback)
+    tool = Tool("some tool", "stool", Category.MISC)
+    with raises(RuntimeError) as err:
+        tool.run("--ops")
+    assert str(err.value).startswith(
+        "Unable to execute command: ['stool', '--ops']"
+    )
 
 
-def test_tool_flags_no_profile():
-    '''Test that flags without using a profile work as expected.'''
-    tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
-    # pylint: disable-next=use-implicit-booleaness-not-comparison
+def test_arguments():
+    """
+    Tests tool arguments.
+    """
+    tool = Tool("some tool", "stool", Category.MISC)
     assert tool.get_flags() == []
     tool.add_flags("-a")
     assert tool.get_flags() == ["-a"]
@@ -126,76 +134,56 @@ def test_tool_profiles():
 
 
 class TestToolRun:
-    '''Test the run method of Tool.'''
+    """
+    Tests tool run method.
+    """
+    def test_no_error_no_args(self, fake_process: FakeProcess) -> None:
+        """
+        Tests run with no aruments.
+        """
+        fake_process.register(['stool'], stdout="123")
+        fake_process.register(['stool'], stdout="123")
+        tool = Tool("some tool", "stool", Category.MISC)
+        assert tool.run(capture_output=True) == "123"
+        assert tool.run(capture_output=False) == ""
+        assert call_list(fake_process) == [['stool'], ['stool']]
 
-    def test_no_error_no_args(self,):
-        '''Test usage of `run` without any errors when no additional
-        command line argument is provided.'''
-        tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
-        mock_result = mock.Mock(returncode=0, return_value=123)
-        mock_result.stdout.decode = mock.Mock(return_value="123")
+    def test_run_with_single_args(self,
+                                  subproc_record: ExtendedRecorder) -> None:
+        """
+        Tets run with single argument.
+        """
+        tool = Tool("some tool", "tool", Category.MISC)
+        tool.run("a")
+        assert subproc_record.invocations() == [['tool', 'a']]
 
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result):
-            assert tool.run(capture_output=True) == "123"
-            assert tool.run(capture_output=False) == ""
+    def test_run_with_multiple_args(self,
+                                    subproc_record: ExtendedRecorder) -> None:
+        """
+        Tests run with multiple arguments.
+        """
+        tool = Tool("some tool", "tool", Category.MISC)
+        tool.run(["a", "b"])
+        assert subproc_record.invocations() == [['tool', 'a', 'b']]
 
-    def test_no_error_with_single_args(self):
-        '''Test usage of `run` without any errors when a single
-        command line argument is provided as string.'''
-        tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            tool.run("a")
-        tool_run.assert_called_once_with(
-            ["gfortran", "a"], capture_output=True, env=None,
-            cwd=None, check=False)
+    def test_error(self, fake_process: FakeProcess) -> None:
+        """
+        Tests running a failing tool.
+        """
+        fake_process.register(['tool'], returncode=1)
+        tool = Tool("some tool", "tool", Category.MISC)
+        with raises(RuntimeError) as err:
+            tool.run()
+        assert str(err.value).startswith("Command failed with return code 1")
+        assert call_list(fake_process) == [['tool']]
 
-    def test_no_error_with_multiple_args(self):
-        '''Test usage of `run` without any errors when more than
-        one command line argument is provided as a list.'''
-        tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            tool.run(["a", "b"])
-        tool_run.assert_called_once_with(
-            ["gfortran", "a", "b"], capture_output=True, env=None,
-            cwd=None, check=False)
-
-    def test_error(self):
-        '''Tests the error handling of `run`. '''
-        tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
-        result = mock.Mock(returncode=1)
-        mocked_error_message = 'mocked error message'
-        result.stderr.decode = mock.Mock(return_value=mocked_error_message)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=result):
-            with pytest.raises(RuntimeError) as err:
-                tool.run()
-            assert mocked_error_message in str(err.value)
-            assert "Command failed with return code 1" in str(err.value)
-
-    def test_error_file_not_found(self):
-        '''Tests the error handling of `run`. '''
-        tool = Tool("does_not_exist", "does_not_exist",
-                    Category.FORTRAN_COMPILER)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        side_effect=FileNotFoundError("not found")):
-            with pytest.raises(RuntimeError) as err:
-                tool.run()
-            assert ("Command '['does_not_exist']' could not be executed."
-                    in str(err.value))
-
-
-def test_suite_tool():
-    '''Test the constructor.'''
-    tool = CompilerSuiteTool("gnu", "gfortran", "gnu",
-                             Category.FORTRAN_COMPILER)
-    assert str(tool) == "CompilerSuiteTool - gnu: gfortran"
-    assert tool.exec_name == "gfortran"
-    assert tool.name == "gnu"
-    assert tool.suite == "gnu"
-    assert tool.category == Category.FORTRAN_COMPILER
-    assert isinstance(tool.logger, logging.Logger)
+    def test_error_file_not_found(self, fake_process: FakeProcess) -> None:
+        """
+        Tests running a missing tool.
+        """
+        fake_process.register(['tool'], callback=not_found_callback)
+        tool = Tool('some tool', 'tool', Category.MISC)
+        with raises(RuntimeError) as err:
+            tool.run()
+        assert str(err.value) == "Unable to execute command: ['tool']"
+        assert call_list(fake_process) == [['tool']]

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -54,7 +54,7 @@ def test_constructor() -> None:
     assert misc.category == Category.MISC
 
 
-def test_chance_exec_name() -> None:
+def test_change_exec_name() -> None:
     """
     Tests changing the executable.
 

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -86,15 +86,13 @@ def test_availability_argument() -> None:
 
 def test_run_missing(fake_process: FakeProcess) -> None:
     """
-    Tests attempting to run an missing tool.
+    Tests attempting to run a missing tool.
     """
     fake_process.register(['stool', '--ops'], callback=not_found_callback)
     tool = Tool("some tool", "stool", Category.MISC)
     with raises(RuntimeError) as err:
         tool.run("--ops")
-    assert str(err.value).startswith(
-        "Unable to execute command: ['stool', '--ops']"
-    )
+    assert str(err.value) == ("Unable to execute command: ['stool', '--ops']")
 
 
 def test_arguments():
@@ -170,11 +168,12 @@ class TestToolRun:
         """
         Tests running a failing tool.
         """
-        fake_process.register(['tool'], returncode=1)
+        fake_process.register(['tool'], returncode=1, stdout="Beef.")
         tool = Tool("some tool", "tool", Category.MISC)
         with raises(RuntimeError) as err:
             tool.run()
-        assert str(err.value).startswith("Command failed with return code 1")
+        assert str(err.value) == ("Command failed with return code 1:\n"
+                                  "['tool']\nBeef.")
         assert call_list(fake_process) == [['tool']]
 
     def test_error_file_not_found(self, fake_process: FakeProcess) -> None:

--- a/tests/unit_tests/tools/test_tool_repository.py
+++ b/tests/unit_tests/tools/test_tool_repository.py
@@ -3,15 +3,18 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
+"""
+Tests ToolBox class.
+"""
+from pytest import mark, raises
+from pytest_subprocess.fake_process import FakeProcess
 
-'''This module tests the ToolRepository.
-'''
+from tests.conftest import ExtendedRecorder
 
-from unittest import mock
-import pytest
-
-from fab.tools import (Ar, Category, FortranCompiler, Gcc, Gfortran, Ifort,
-                       ToolRepository)
+from fab.tools.ar import Ar
+from fab.tools.category import Category
+from fab.tools.compiler import Gcc, Gfortran, FortranCompiler, Ifort
+from fab.tools.tool_repository import ToolRepository
 
 
 def test_tool_repository_get_singleton_new():
@@ -42,20 +45,22 @@ def test_tool_repository_get_tool():
     assert isinstance(ifort, Ifort)
 
 
-def test_tool_repository_get_tool_error():
-    '''Tests error handling during tet_tool.'''
+def test_get_tool_error():
+    """
+    Tests error handling during tet_tool.
+    """
     tr = ToolRepository()
-    with pytest.raises(KeyError) as err:
+    with raises(KeyError) as err:
         tr.get_tool("unknown-category", "something")
     assert "Unknown category 'unknown-category'" in str(err.value)
 
-    with pytest.raises(KeyError) as err:
+    with raises(KeyError) as err:
         tr.get_tool(Category.C_COMPILER, "something")
     assert ("Unknown tool 'something' in category 'C_COMPILER'"
             in str(err.value))
 
 
-def test_tool_repository_get_default():
+def test_get_default() -> None:
     '''Tests get_default.'''
     tr = ToolRepository()
     gfortran = tr.get_default(Category.FORTRAN_COMPILER, mpi=False,
@@ -70,113 +75,151 @@ def test_tool_repository_get_default():
     assert isinstance(ar, Ar)
 
 
-def test_tool_repository_get_default_error_invalid_category():
-    '''Tests error handling in get_default, the category
-    must be a Category, not e.g. a string.'''
+def test_get_default_error_invalid_category(
+        subproc_record: ExtendedRecorder
+) -> None:
+    """
+    Tests error handling in get_default, the category must be a Category,
+    not e.g. a string.
+    """
     tr = ToolRepository()
-    with pytest.raises(RuntimeError) as err:
-        tr.get_default("unknown-category-type")
+    with raises(RuntimeError) as err:
+        tr.get_default("unknown-category-type")  # type: ignore[arg-type]
     assert "Invalid category type 'str'." in str(err.value)
 
 
-def test_tool_repository_get_default_error_missing_mpi():
-    '''Tests error handling in get_default when the optional MPI
-    parameter is missing (which is required for a compiler).'''
+def test_get_default_error_missing_mpi(subproc_record: ExtendedRecorder)\
+        -> None:
+    """
+    Tests error handling in get_default when the optional MPI
+    parameter is missing (which is required for a compiler).
+    """
     tr = ToolRepository()
-    with pytest.raises(RuntimeError) as err:
+    with raises(RuntimeError) as err:
         tr.get_default(Category.FORTRAN_COMPILER, openmp=True)
-    assert ("Invalid or missing mpi specification for 'FORTRAN_COMPILER'"
-            in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        tr.get_default(Category.FORTRAN_COMPILER, mpi="123")
-    assert ("Invalid or missing mpi specification for 'FORTRAN_COMPILER'"
-            in str(err.value))
+    assert str(err.value) == ("Invalid or missing mpi specification "
+                              "for 'FORTRAN_COMPILER'.")
+
+    with raises(RuntimeError) as err:
+        tr.get_default(Category.FORTRAN_COMPILER, mpi=True)
+    assert str(err.value) == ("Invalid or missing openmp specification "
+                              "for 'FORTRAN_COMPILER'.")
 
 
-def test_tool_repository_get_default_error_missing_openmp():
-    '''Tests error handling in get_default when the optional openmp
-    parameter is missing (which is required for a compiler).'''
+def test_get_default_error_missing_openmp(
+        subproc_record: ExtendedRecorder
+) -> None:
+    """
+    Tests error handling in get_default when the optional openmp
+    parameter is missing (which is required for a compiler).
+    """
     tr = ToolRepository()
-    with pytest.raises(RuntimeError) as err:
+
+    with raises(RuntimeError) as err:
         tr.get_default(Category.FORTRAN_COMPILER, mpi=True)
     assert ("Invalid or missing openmp specification for 'FORTRAN_COMPILER'"
             in str(err.value))
-    with pytest.raises(RuntimeError) as err:
-        tr.get_default(Category.FORTRAN_COMPILER, mpi=True, openmp="123")
-    assert ("Invalid or missing openmp specification for 'FORTRAN_COMPILER'"
-            in str(err.value))
+    with raises(RuntimeError) as err:
+        tr.get_default(Category.FORTRAN_COMPILER, mpi=True, openmp='123')  # type: ignore[arg-type]
+    assert str(err.value) == ("Invalid or missing openmp specification "
+                              "for 'FORTRAN_COMPILER'.")
 
 
-@pytest.mark.parametrize("mpi, openmp, message",
-                         [(False, False, "any 'FORTRAN_COMPILER'."),
-                          (False, True,
-                           "'FORTRAN_COMPILER' that supports OpenMP"),
-                          (True, False,
-                           "'FORTRAN_COMPILER' that supports MPI"),
-                          (True, True, "'FORTRAN_COMPILER' that supports MPI "
-                                       "and OpenMP.")])
-def test_tool_repository_get_default_error_missing_compiler(mpi, openmp,
-                                                            message):
-    '''Tests error handling in get_default when there is no compiler
-    that fulfils the requirements with regards to OpenMP and MPI.'''
+@mark.parametrize("mpi, openmp, message",
+                  [(False, False, "any 'FORTRAN_COMPILER'."),
+                   (False, True,
+                    "'FORTRAN_COMPILER' that supports OpenMP."),
+                   (True, False,
+                    "'FORTRAN_COMPILER' that supports MPI."),
+                   (True, True, "'FORTRAN_COMPILER' that supports MPI "
+                    "and OpenMP.")])
+def test_get_default_error_missing_compiler(mpi, openmp, message,
+                                            subproc_record: ExtendedRecorder,
+                                            monkeypatch) -> None:
+    """
+    Tests error handling in get_default when there is no compiler
+    that fulfils the requirements with regards to OpenMP and MPI.
+    """
     tr = ToolRepository()
-    with mock.patch.dict(tr, {Category.FORTRAN_COMPILER: []}), \
-            pytest.raises(RuntimeError) as err:
+    monkeypatch.setitem(tr, Category.FORTRAN_COMPILER, [])
+
+    with raises(RuntimeError) as err:
         tr.get_default(Category.FORTRAN_COMPILER, mpi=mpi, openmp=openmp)
+    assert str(err.value) == f"Could not find {message}"
 
-    assert f"Could not find {message}" in str(err.value)
 
-
-def test_tool_repository_get_default_error_missing_openmp_compiler():
-    '''Tests error handling in get_default when there is a compiler, but it
+def test_get_default_error_missing_openmp_compiler(monkeypatch) -> None:
+    """
+    Tests error handling in get_default when there is a compiler, but it
     does not support OpenMP (which triggers additional tests in the
-    ToolRepository.'''
-    tr = ToolRepository()
-    fc = FortranCompiler("gfortran", "gfortran", "gnu", openmp_flag=None,
-                         module_folder_flag="-J", version_regex=None)
+    ToolRepository.
 
-    with mock.patch.dict(tr, {Category.FORTRAN_COMPILER: [fc]}), \
-            pytest.raises(RuntimeError) as err:
+    Todo: Monkeying with internal state is bad.
+    """
+    fc = FortranCompiler("Simply Fortran", 'sfc', 'simply', openmp_flag=None,
+                         module_folder_flag="-mods", version_regex=r'([\d.]+]')
+
+    tr = ToolRepository()
+    monkeypatch.setitem(tr, Category.FORTRAN_COMPILER, [fc])
+
+    with raises(RuntimeError) as err:
         tr.get_default(Category.FORTRAN_COMPILER, mpi=False, openmp=True)
-
-    assert ("Could not find 'FORTRAN_COMPILER' that supports OpenMP."
-            in str(err.value))
+    assert str(err.value) == "Could not find 'FORTRAN_COMPILER' that supports OpenMP."
 
 
-def test_tool_repository_default_compiler_suite():
-    '''Tests the setting of default suite for compiler and linker.'''
+@mark.parametrize('category', [Category.C_COMPILER,
+                               Category.FORTRAN_COMPILER,
+                               Category.LINKER])
+def test_default_gcc_suite(category, fake_process: FakeProcess) -> None:
+    """
+    Tests setting default suite to "GCC" produces correct tools.
+    """
+    fake_process.register(['gcc', '--version'], stdout='gcc (foo) 1.2.3')
+    fake_process.register(['gfortran', '--version'],
+                          stdout='GNU Fortran (foo) 1.2.3')
+
+    tr = ToolRepository()
+    tr.set_default_compiler_suite('gnu')
+    def_tool = tr.get_default(category, mpi=False, openmp=False)
+    assert def_tool.suite == 'gnu'
+
+
+@mark.parametrize('category', [Category.C_COMPILER,
+                               Category.FORTRAN_COMPILER,
+                               Category.LINKER])
+def test_default_intel_suite(category, fake_process: FakeProcess) -> None:
+    """
+    Tests setting default suite to "classic-intel" produces correct tools.
+    """
+    fake_process.register(['icc', '-V'], stdout='icc (ICC) 1.2.3 foo')
+    fake_process.register(['ifort', '-V'], stdout='ifort (IFORT) 1.2.3 foo')
+
+    tr = ToolRepository()
+    tr.set_default_compiler_suite('intel-classic')
+    def_tool = tr.get_default(category, mpi=False, openmp=False)
+    assert def_tool.suite == 'intel-classic'
+
+
+def test_default_suite_unknown(subproc_record: ExtendedRecorder) -> None:
+    repo = ToolRepository()
+    with raises(RuntimeError) as err:
+        repo.set_default_compiler_suite("does-not-exist")
+    assert str(err.value) == ("Cannot find 'FORTRAN_COMPILER' in "
+                              "the suite 'does-not-exist'.")
+
+
+def test_no_tool_available(fake_process: FakeProcess) -> None:
+    """
+    Tests error handling if no tool is available.
+    """
+    # All attempted subprocesses fail.
+    #
+    fake_process.register([FakeProcess.any()], returncode=1)
+
     tr = ToolRepository()
     tr.set_default_compiler_suite("gnu")
 
-    # Mark all compiler and linker as available.
-    with mock.patch('fab.tools.tool.Tool.is_available',
-                    new_callable=mock.PropertyMock) as is_available:
-        is_available.return_value = True
-        for cat in [Category.C_COMPILER, Category.FORTRAN_COMPILER,
-                    Category.LINKER]:
-            def_tool = tr.get_default(cat, mpi=False, openmp=False)
-            assert def_tool.suite == "gnu"
-
-        tr.set_default_compiler_suite("intel-classic")
-        for cat in [Category.C_COMPILER, Category.FORTRAN_COMPILER,
-                    Category.LINKER]:
-            def_tool = tr.get_default(cat, mpi=False, openmp=False)
-            assert def_tool.suite == "intel-classic"
-        with pytest.raises(RuntimeError) as err:
-            tr.set_default_compiler_suite("does-not-exist")
-        assert ("Cannot find 'FORTRAN_COMPILER' in the suite 'does-not-exist'"
-                in str(err.value))
-
-
-def test_tool_repository_no_tool_available():
-    '''Tests error handling if no tool is available.'''
-
-    tr = ToolRepository()
-    tr.set_default_compiler_suite("gnu")
-    with mock.patch('fab.tools.tool.Tool.is_available',
-                    new_callable=mock.PropertyMock) as is_available:
-        is_available.return_value = False
-        with pytest.raises(RuntimeError) as err:
-            tr.get_default(Category.SHELL)
-        assert ("Can't find available 'SHELL' tool. Tools are 'sh'"
-                in str(err.value))
+    with raises(RuntimeError) as err:
+        tr.get_default(Category.SHELL)
+    assert str(err.value) == "Can't find available 'SHELL' tool. Tools are " \
+                             "'sh'."

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -9,14 +9,18 @@ Tests version control interfaces.
 from filecmp import cmpfiles, dircmp
 from pathlib import Path
 from shutil import which
-from unittest import mock
 from subprocess import Popen, run
 from time import sleep
 from typing import List, Tuple
 
 from pytest import TempPathFactory, fixture, mark, raises
+from pytest_subprocess.fake_process import FakeProcess
 
-from fab.tools import Category, Fcm, Git, Subversion
+from tests.conftest import (ExtendedRecorder,
+                            arg_list, call_list, not_found_callback)
+
+from fab.tools.category import Category
+from fab.tools.versioning import Fcm, Git, Subversion
 
 
 class TestGit:
@@ -29,164 +33,196 @@ class TestGit:
         assert git.category == Category.GIT
         assert git.get_flags() == []
 
-    def test_git_check_available(self):
-        '''Check if check_available works as expected.
-        '''
+    def test_git_check_available(self, fake_process: FakeProcess) -> None:
+        """
+        Tests availability check.
+        """
+        fake_process.register(['git', 'help'], stdout='1.2.3')
+
         git = Git()
-        with mock.patch.object(git, "run", return_value=0):
-            assert git.check_available()
+        assert git.check_available()
 
-        # Now test if run raises an error
-        with mock.patch.object(git, "run", side_effect=RuntimeError("")):
-            assert not git.check_available()
+        fake_process.register(['git', 'help'], callback=not_found_callback)
+        assert not git.check_available()
 
-    def test_git_current_commit(self):
-        '''Check current_commit functionality. The tests here will actually
+        assert call_list(fake_process) == [
+            ['git', 'help'], ['git', 'help']
+        ]
+
+    def test_git_current_commit(self, fake_process: FakeProcess) -> None:
+        """
+        Check current_commit functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
-
+        The system_tests will test an actual check out etc.
+        """
+        commit_record = fake_process.register(
+            ['git', 'log', '--oneline', '-n', '1'], stdout='abc\ndef'
+        )
         git = Git()
-        # Note that only the first line will be returned, and stdout of the
-        # subprocess run method must be encoded (i.e. decode is called later)
-        mock_result = mock.Mock(returncode=0, stdout="abc\ndef".encode())
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            assert "abc" == git.current_commit()
+        assert "abc" == git.current_commit()
+        assert call_list(fake_process) == [
+            ['git', 'log', '--oneline', '-n', '1']
+        ]
+        #
+        # ToDo: Current directory? Surely this should be an absolute path?
+        #       The chances for unexpected behaviour seem too great.
+        #
+        assert arg_list(commit_record)[0]['cwd'] == '.'
 
-        tool_run.assert_called_once_with(
-            ['git', 'log', '--oneline', '-n', '1'], capture_output=True,
-            env=None, cwd='.', check=False)
+    def test_get_commit(self, fake_process: FakeProcess) -> None:
+        """
+        Tests commit when specifying a path.
+        """
+        commit_record = fake_process.register(
+            ['git', 'log', '--oneline', '-n', '1'], stdout='abc\ndef'
+        )
+        git = Git()
+        assert "abc" == git.current_commit("/not-exist")
+        assert call_list(fake_process) == [
+            ['git', 'log', '--oneline', '-n', '1']
+        ]
+        assert arg_list(commit_record)[0]['cwd'] == '/not-exist'
 
-        # Test if we specify a path
-        mock_result = mock.Mock(returncode=0, stdout="abc\ndef".encode())
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            assert "abc" == git.current_commit("/not-exist")
-
-        tool_run.assert_called_once_with(
-            ['git', 'log', '--oneline', '-n', '1'], capture_output=True,
-            env=None, cwd="/not-exist", check=False)
-
-    def test_git_init(self):
-        '''Check init functionality. The tests here will actually
+    def test_git_init(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check init functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
-
+        The system_tests will test an actual check out etc.
+        """
         git = Git()
-        # Note that only the first line will be returned
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            git.init("/src")
-        tool_run.assert_called_once_with(
-            ['git', 'init', '.'], capture_output=True, env=None,
-            cwd='/src', check=False)
+        git.init("/src")
+        assert subproc_record.invocations() == [
+            ['git', 'init', '.']
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/src'
 
-    def test_git_clean(self):
-        '''Check clean functionality. The tests here will actually
+    def test_git_clean(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check clean functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
-
+        The system_tests will test an actual check out etc.
+        """
         git = Git()
-        # Note that only the first line will be returned
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            git.clean('/src')
-        tool_run.assert_called_once_with(
-            ['git', 'clean', '-f'], capture_output=True, env=None,
-            cwd='/src', check=False)
+        git.clean('/src')
+        assert subproc_record.invocations() == [
+            ['git', 'clean', '-f']
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/src'
 
-    def test_git_fetch(self):
-        '''Check getch functionality. The tests here will actually
+    def test_git_fetch(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check fetch functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
-
+        The system_tests will test an actual check out etc.
+        """
         git = Git()
-        # Note that only the first line will be returned
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
+        git.fetch("/src", "/dst", revision="revision")
+        assert subproc_record.invocations() == [
+            ['git', 'fetch', "/src", "revision"]
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/dst'
+
+    def test_git_fetch_error(self, fake_process: FakeProcess) -> None:
+        """
+        Tests error causing fetch.
+        """
+        fetch_record = fake_process.register(
+            ['git', 'fetch', '/src', 'revision'], returncode=1
+        )
+        git = Git()
+        with raises(RuntimeError) as err:
             git.fetch("/src", "/dst", revision="revision")
-        tool_run.assert_called_once_with(
-            ['git', 'fetch', "/src", "revision"], capture_output=False,
-            env=None, cwd='/dst', check=False)
+        assert str(err.value).startswith("Command failed with return code 1:")
+        assert call_list(fake_process) == [
+            ['git', 'fetch', "/src", "revision"]
+        ]
+        assert arg_list(fetch_record)[0]['cwd'] == '/dst'
 
-        with mock.patch.object(git, "run",
-                               side_effect=RuntimeError("ERR")) as run:
-            with raises(RuntimeError) as err:
-                git.fetch("/src", "/dst", revision="revision")
-            assert "ERR" in str(err.value)
-        run.assert_called_once_with(['fetch', "/src", "revision"], cwd="/dst",
-                                    capture_output=False)
-
-    def test_git_checkout(self):
-        '''Check checkout functionality. The tests here will actually
+    def test_git_checkout(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check checkout functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
+        The system_tests will test an actual check out etc.
+        """
+        git = Git()
+        git.checkout("/src", "/dst", revision="revision")
+        assert subproc_record.invocations() == [
+            ['git', 'fetch', "/src", "revision"],
+            ['git', 'checkout', "FETCH_HEAD"]
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/dst'
+        assert subproc_record.extras()[1]['cwd'] == '/dst'
+
+    def test_git_checkout_error(self, fake_process: FakeProcess) -> None:
+        """
+        Tests error causing checkout.
+        """
+        fetch_record = fake_process.register(
+            ['git', 'fetch', '/src', 'revision'], returncode=1
+        )
 
         git = Git()
-        # Note that only the first line will be returned
-
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
+        with raises(RuntimeError) as err:
             git.checkout("/src", "/dst", revision="revision")
-        tool_run.assert_any_call(['git', 'fetch', "/src", "revision"],
-                                 cwd='/dst', capture_output=False, env=None,
-                                 check=False)
-        tool_run.assert_called_with(['git', 'checkout', "FETCH_HEAD"],
-                                    cwd="/dst", capture_output=False,
-                                    env=None, check=False)
+        assert str(err.value).startswith("Command failed with return code 1:")
+        assert call_list(fake_process) == [
+            ['git', 'fetch', "/src", "revision"]
+        ]
+        assert arg_list(fetch_record)[0]['cwd'] == '/dst'
 
-        with mock.patch.object(git, "run",
-                               side_effect=RuntimeError("ERR")) as run:
-            with raises(RuntimeError) as err:
-                git.checkout("/src", "/dst", revision="revision")
-            assert "ERR" in str(err.value)
-        run.assert_called_with(['fetch', "/src", "revision"], cwd="/dst",
-                               capture_output=False)
-
-    def test_git_merge(self):
-        '''Check merge functionality. The tests here will actually
+    def test_git_merge(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check merge functionality. The tests here will actually
         mock the git results, so they will work even if git is not installed.
-        The system_tests will test an actual check out etc. '''
+        The system_tests will test an actual check out etc.
+        """
+        git = Git()
+        git.merge("/dst", revision="revision")
+        assert subproc_record.invocations() == [
+            ['git', 'merge', 'FETCH_HEAD']
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/dst'
+
+    def test_git_merge_error(self, fake_process: FakeProcess) -> None:
+        """
+        Tests failing merger. This should cause the merge to be rolled back.
+        """
+        merge_record = fake_process.register(['git', 'merge', 'FETCH_HEAD'],
+                                             returncode=1)
+        abort_record = fake_process.register(['git', 'merge', '--abort'])
 
         git = Git()
-        # Note that only the first line will be returned
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
+        with raises(RuntimeError) as err:
             git.merge("/dst", revision="revision")
-        tool_run.assert_called_once_with(
-            ['git', 'merge', 'FETCH_HEAD'], capture_output=False,
-            env=None, cwd='/dst', check=False)
+        assert str(err.value).startswith(
+            "Error merging revision. Merge aborted."
+        )
+        assert call_list(fake_process) == [
+            ['git', 'merge', 'FETCH_HEAD'],
+            ['git', 'merge', '--abort']
+        ]
+        assert arg_list(merge_record)[0]['cwd'] == '/dst'
+        assert arg_list(abort_record)[0]['cwd'] == '/dst'
 
-        # Test the behaviour if merge fails, but merge --abort works:
-        # Simple function that raises an exception only the first time
-        # it is called.
-        def raise_1st_time():
-            yield RuntimeError
-            yield 0
+    def test_git_merge_collapse(self, fake_process: FakeProcess) -> None:
+        """
+        Tests failing merge where both merge and abort fail.
+        """
+        merge_record = fake_process.register(['git', 'merge', 'FETCH_HEAD'],
+                                             returncode=1)
+        abort_record = fake_process.register(['git', 'merge', '--abort'],
+                                             returncode=1)
 
-        with mock.patch.object(git, "run",
-                               side_effect=raise_1st_time()) as run:
-            with raises(RuntimeError) as err:
-                git.merge("/dst", revision="revision")
-            assert "Error merging revision. Merge aborted." in str(err.value)
-        run.assert_any_call(['merge', "FETCH_HEAD"], cwd="/dst",
-                            capture_output=False)
-        run.assert_any_call(['merge', "--abort"], cwd="/dst",
-                            capture_output=False)
-
-        # Test behaviour if both merge and merge --abort fail
-        with mock.patch.object(git, "run",
-                               side_effect=RuntimeError("ERR")) as run:
-            with raises(RuntimeError) as err:
-                git.merge("/dst", revision="revision")
-            assert "ERR" in str(err.value)
-        run.assert_called_with(['merge', "--abort"], cwd="/dst",
-                               capture_output=False)
+        git = Git()
+        with raises(RuntimeError) as err:
+            git.merge("/dst", revision="revision")
+        assert str(err.value).startswith("Command failed with return code 1:")
+        assert call_list(fake_process) == [
+            ['git', 'merge', 'FETCH_HEAD'],
+            ['git', 'merge', '--abort']
+        ]
+        assert arg_list(merge_record)[0]['cwd'] == '/dst'
+        assert arg_list(abort_record)[0]['cwd'] == '/dst'
 
 
 # ============================================================================
@@ -204,7 +240,7 @@ class TestSubversion:
         assert svn.name == "Subversion"
         assert svn.exec_name == "svn"
 
-    def test_svn_export(self):
+    def test_svn_export(self, subproc_record: ExtendedRecorder) -> None:
         """
         Ensures an export from repository works.
 
@@ -212,77 +248,64 @@ class TestSubversion:
         Testing with happens below in TestSubversionReal.
         """
         svn = Subversion()
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.export("/src", "/dst", revision="123")
-
-        tool_run.assert_called_once_with(
+        #
+        # With revision
+        #
+        svn.export("/src", "/dst", revision="123")
+        #
+        # Without revision
+        #
+        svn.export("/src", "/dst")
+        assert subproc_record.invocations() == [
             ["svn", "export", "--force", "--revision", "123", "/src", "/dst"],
-            env=None, cwd=None, capture_output=True, check=False)
+            ["svn", "export", "--force", "/src", "/dst"]
+        ]
 
-        # Test if we don't specify a revision
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.export("/src", "/dst")
-        tool_run.assert_called_once_with(
-            ["svn", "export", "--force", "/src", "/dst"],
-            env=None, cwd=None, capture_output=True, check=False)
-
-    def test_svn_checkout(self):
-        '''Check checkout svn functionality. The tests here will actually
+    def test_svn_checkout(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check checkout svn functionality. The tests here will actually
         mock the git results, so they will work even if subversion is not
-        installed. The system_tests will test an actual check out etc. '''
-
+        installed. The system_tests will test an actual check out etc.
+        """
         svn = Subversion()
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.checkout("/src", "/dst", revision="123")
-
-        tool_run.assert_called_once_with(
+        #
+        # Test with a revision.
+        #
+        svn.checkout("/src", "/dst", revision="123")
+        #
+        # Test without a revision.
+        #
+        svn.checkout("/src", "/dst")
+        assert subproc_record.invocations() == [
             ["svn", "checkout", "--revision", "123", "/src", "/dst"],
-            env=None, cwd=None, capture_output=True, check=False)
+            ["svn", "checkout", "/src", "/dst"]
+        ]
 
-        # Test if we don't specify a revision
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.checkout("/src", "/dst")
-        tool_run.assert_called_once_with(
-            ["svn", "checkout", "/src", "/dst"],
-            env=None, cwd=None, capture_output=True, check=False)
-
-    def test_svn_update(self):
-        '''Check update svn functionality. The tests here will actually
+    def test_svn_update(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check update svn functionality. The tests here will actually
         mock the git results, so they will work even if subversion is not
-        installed. The system_tests will test an actual check out etc. '''
-
+        installed. The system_tests will test an actual check out etc.
+        """
         svn = Subversion()
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.update("/dst", revision="123")
+        svn.update("/dst", revision="123")
+        assert subproc_record.invocations() == [
+            ["svn", "update", "--revision", "123"]
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/dst'
 
-        tool_run.assert_called_once_with(
-            ["svn", "update", "--revision", "123"],
-            env=None, cwd="/dst", capture_output=True, check=False)
-
-    def test_svn_merge(self):
-        '''Check merge svn functionality. The tests here will actually
-        mock the git results, so they will work even if subversion is not
-        installed. The system_tests will test an actual check out etc. '''
-
+    def test_svn_merge(self, subproc_record: ExtendedRecorder) -> None:
+        """
+        Check merge svn functionality. The tests here will actually
+        mock the subversion results, so they will work even if subversion is
+        not installed. The system_tests will test an actual check out etc.
+        """
         svn = Subversion()
-        mock_result = mock.Mock(returncode=0)
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        return_value=mock_result) as tool_run:
-            svn.merge("/src", "/dst", "123")
-
-        tool_run.assert_called_once_with(
-            ["svn", "merge", "--non-interactive", "/src@123"],
-            env=None, cwd="/dst", capture_output=True, check=False)
+        svn.merge("/src", "/dst", "123")
+        assert subproc_record.invocations() == [
+            ["svn", "merge", "--non-interactive", "/src@123"]
+        ]
+        assert subproc_record.extras()[0]['cwd'] == '/dst'
 
 
 def _tree_compare(first: Path, second: Path) -> None:

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -284,7 +284,7 @@ class TestSubversion:
     def test_svn_update(self, subproc_record: ExtendedRecorder) -> None:
         """
         Check update svn functionality. The tests here will actually
-        mock the git results, so they will work even if subversion is not
+        mock the svn results, so they will work even if subversion is not
         installed. The system_tests will test an actual check out etc.
         """
         svn = Subversion()

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -264,7 +264,7 @@ class TestSubversion:
     def test_svn_checkout(self, subproc_record: ExtendedRecorder) -> None:
         """
         Check checkout svn functionality. The tests here will actually
-        mock the git results, so they will work even if subversion is not
+        mock the svn results, so they will work even if subversion is not
         installed. The system_tests will test an actual check out etc.
         """
         svn = Subversion()


### PR DESCRIPTION
Brings the use of the pytest mock subprocess support to trunk.

It also restyles the doc-strings in places, to be more in line with common usage.