### PR TITLE
Fix archive containing multiple versions of the same file.

### DIFF
--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -103,7 +103,9 @@ def archive_objects(config: BuildConfig,
     # to the proj folder
 
     source_getter = source or DEFAULT_SOURCE_GETTER
+    config.tool_box.add_tool(Ar(), silent_replace=True)
     ar = config.tool_box[Category.AR]
+    
     if not isinstance(ar, Ar):
         raise RuntimeError(f"Unexpected tool '{ar.name}' of type "
                            f"'{type(ar)}' instead of Ar")


### PR DESCRIPTION
This pull request aims to tackle #310 by implementing a one line fix to the archive objects step, which creates a new instance of the AR tool every time the archive step is run and add it to the configs toolbox through the `add_tool` function.  This will ensure that if a instance of the AR tool already exists it is replaced to avoid using the same instance of AR again. 