### PR TITLE
Fix multiple versions of the same file in archive 

### DIFF
--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,12 +30,8 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        if isinstance(output_fpath, Path):
-            output_fpath.unlink(missing_ok=True)
-        elif isinstance(output_fpath, str):
-            Path(output_fpath).unlink(missing_ok=True)
-        else:
-            raise TypeError("output_fpath must be a Path or str")
+        output_fpath = Path(output_fpath)
+        output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,12 +30,7 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        if isinstance(output_fpath, Path):
-            output_fpath.unlink(missing_ok=True)
-        elif isinstance(output_fpath, str):
-            Path(output_fpath).unlink(missing_ok=True)
-        else:
-            raise TypeError("output_fpath must be a Path or str")
+        output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,7 +30,12 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        output_fpath.unlink(missing_ok=True)
+        if isinstance(output_fpath, Path):
+            output_fpath.unlink(missing_ok=True)
+        elif isinstance(output_fpath, str):
+            Path(output_fpath).unlink(missing_ok=True)
+        else:
+            raise TypeError("output_fpath must be a Path or str")
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,6 +30,12 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
+        if isinstance(output_fpath, Path):
+            output_fpath.unlink(missing_ok=True)
+        elif isinstance(output_fpath, str):
+            Path(output_fpath).unlink(missing_ok=True)
+        else:
+            raise TypeError("output_fpath must be a Path or str")
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,6 +30,8 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
+        print(f"Creating archive {output_fpath} with members: {members}")
+        print(f"The type of output_fpath is {type(output_fpath)}")
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,8 +30,6 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        print(f"Creating archive {output_fpath} with members: {members}")
-        print(f"The type of output_fpath is {type(output_fpath)}")
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))


### PR DESCRIPTION
This pull request aims to tackle https://github.com/MetOffice/fab/issues/310 by unlinking the `output_fpath` variable in the `Ar` class by using an instance of the `Path`  class. This ensures that if an archive file already exists that it is deleted before the new archive file is created. 