### PR TITLE
Create a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+All contributors to Fab must follow the [Met Office Simulation Systems Code of Conduct](https://metoffice.github.io/simulation-systems/FurtherDetails/code_of_conduct).


### PR DESCRIPTION
Add a Code of Conduct that references the Met Office Simulation Systems guidance to ensure consistency across projects.