### PR TITLE
Revised fab command line argument parser

### DIFF
--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -90,7 +90,7 @@ class FabArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
 
         self.version = kwargs.pop("version", str(fab_version))
-        self.fabfile = full_path_type(kwargs.pop("fabfile", "FabFile"))
+        self.fabfile = full_path_type(kwargs.pop("fabfile", "FabFile") or "FabFile")
 
         if "usage" not in kwargs:
             # Default to a simplified usage line
@@ -178,7 +178,7 @@ class FabArgumentParser(argparse.ArgumentParser):
                 "--version", action="version", version=f"%(prog)s {self.version}"
             )
 
-    def _configure_logging(self, namespace: argparse.Namespace):
+    def _configure_logging(self, namespace: argparse.Namespace) -> None:
         """Configure output logging.
 
         Set various logging parameters after the first complete parse
@@ -223,7 +223,7 @@ class FabArgumentParser(argparse.ArgumentParser):
             help=f"fab build script (default: {self.fabfile})",
         )
 
-    def _check_fabfile(self, namespace: argparse.Namespace):
+    def _check_fabfile(self, namespace: argparse.Namespace) -> None:
         """Check the fabfile status.
 
         If a fabfile has been specified by the user, raise an error if

--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -70,6 +70,7 @@ class FabArgumentParser(argparse.ArgumentParser):
         self._have_logging = False
         self._setup_needed = True
 
+    @staticmethod
     def _parser_wrapper(func):
         """Decorator to wrap to apply arguments and checks.
 

--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""
+Fab command line argument parser.
+
+This extends the arparse.ArgumentParser class to ensure that specific
+default arguments are added if they have not been added by the caller.
+
+It also adds the ability to perform a two-phase parse, where the first
+attempt limits itself to identifying the value of a --file option.
+The idea is that if this is set, it will be used to identify a file
+that contains a function which accepts an argument parser as an
+argument and adds its own arguments.
+"""
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from ..util import get_fab_workspace
+from .. import __version__ as fab_version
+
+try:
+    from ..logtools import make_logger, setup_logging
+except ModuleNotFoundError:
+    # Placeholder code.  This can be removed once logtools change has
+    # been merged
+    def make_logger(what):
+        return logging.getLogger(f"fab.{what}")
+
+    def setup_logging(*args):
+        logging.basicConfig(level=logging.DEBUG)
+
+
+def full_path_type(opt: str) -> Path:
+    """Path with expanded usernames and resolved symlinks.
+
+    :param str opt: command line option
+    :return: a fully resolved Path instance
+    """
+
+    return Path(opt).expanduser().resolve()
+
+
+class FabArgumentParser(argparse.ArgumentParser):
+    """Fab command argument parser."""
+
+    def __init__(self, *args, **kwargs):
+
+        self.version = kwargs.pop("version", str(fab_version))
+        self.fabfile = full_path_type(kwargs.pop("fabfile", "FabFile"))
+
+        if "usage" not in kwargs:
+            # Default to a simplified usage line
+            kwargs["usage"] = "%(prog)s [--file FILE] [options]"
+
+        super().__init__(*args, **kwargs)
+
+        if self.prog == "__main__.py" and kwargs.get("prog", None) is None:
+            # Try to pick up a better program name from the environment
+            # or just use a default string
+            self.prog = os.environ.get("__PROGNAME", "fab")
+
+        self._have_logging = False
+        self._setup_needed = True
+
+    def _parser_wrapper(func):
+        """Decorator to wrap to apply arguments and checks.
+
+        Decorator which ensures some arguments are added before the
+        first of any main parser calls - because the can potentially
+        be called more than once.  These are added at the point where
+        the parser is called to allow the user to override them.
+
+        Always run some Namespace checks after the options have been
+        parsed and then return the results.
+        """
+
+        def inner(self, *args, **kwargs):
+
+            if self._setup_needed:
+                # Carry out setup actions needed only once
+                self._setup_needed = False
+                self._add_location_group()
+                self._add_output_group()
+                self._add_info_group()
+
+            result = func(self, *args, **kwargs)
+
+            if isinstance(result, argparse.Namespace):
+                # parse_args
+                namespace = result
+            elif isinstance(result, tuple) and isinstance(
+                result[0], argparse.Namespace
+            ):
+                # parse_known_args
+                namespace = result[0]
+            else:
+                raise ValueError("invalid return value from wrapped function")
+
+            # Save the name used to refer to the current program
+            namespace._progname = self.prog
+
+            self._check_fabfile(namespace)
+            self._configure_logging(namespace)
+
+            return result
+
+        return inner
+
+    def _add_location_group(self):
+        """Add project, workspace, and fabfile args."""
+        group = self.add_argument_group("fab location arguments")
+
+        self._add_fabfile_argument(group)
+
+        group.add_argument(
+            "--project", type=str, metavar="NAME", help="name to assign to the project"
+        )
+
+        group.add_argument(
+            "--workspace",
+            type=full_path_type,
+            metavar="DIR",
+            default=get_fab_workspace(),
+            help="location of working space (default: %(default)s)",
+        )
+
+    def _add_output_group(self):
+        """Add output arguments if not present."""
+
+        # Create an output group
+        group = self.add_argument_group("fab output arguments")
+
+        if (
+            "--debug" not in self._option_string_actions
+            and "-d" not in self._option_string_actions
+        ):
+            # Add a logging option
+            group.add_argument(
+                "-d",
+                "--debug",
+                action="count",
+                help="increase the amount of fab debug output",
+            )
+
+        if (
+            "--verbose" not in self._option_string_actions
+            and "-v" not in self._option_string_actions
+        ):
+            # Add a logging option
+            group.add_argument(
+                "-v",
+                "--verbose",
+                action="count",
+                help="increase the amount of build output",
+            )
+
+        # Add a quiet option to suppress all/most output
+        if (
+            "--quiet" not in self._option_string_actions
+            and "-q" not in self._option_string_actions
+        ):
+            # Add a logging option
+            group.add_argument(
+                "-q",
+                "--quiet",
+                action="store_true",
+                help="do not produce much output",
+            )
+
+    def _add_info_group(self):
+        """Add informative options."""
+
+        # Create an info group
+        group = self.add_argument_group("info arguments")
+
+        if "--version" not in self._option_string_actions:
+            group.add_argument(
+                "--version", action="version", version=f"%(prog)s {self.version}"
+            )
+
+    def _configure_logging(self, namespace):
+
+        if self._have_logging:
+            return
+
+        setup_logging(
+            getattr(namespace, "verbose", None),
+            getattr(namespace, "debug", None),
+            getattr(namespace, "quiet", False),
+        )
+
+        logger = make_logger("system")
+        logger.debug("command line arguments are %s", namespace)
+
+        self._have_logging = True
+
+    def _add_fabfile_argument(self, section):
+        """Add a --file argument to the target section.
+
+        The --file argument needs to be added to both the core parser
+        and to the fabfile-only parser.
+
+        :param section: a parser or an argument section
+        """
+
+        section.add_argument(
+            "--file",
+            type=full_path_type,
+            metavar="FILE",
+            help=f"fab build script (default: {self.fabfile})",
+        )
+
+    def _check_fabfile(self, namespace):
+        """Check the fabfile status.
+
+        If a fabfile has been specified by the user, raise an error if
+        it does not exist.
+
+        If no fabfile has been given, check the default location.  If
+        it does not exist, do not raise an error, but also set the
+        zero config mode.
+        """
+
+        namespace.zero_config = False
+
+        if hasattr(namespace, "file") and namespace.file is not None:
+            if not namespace.file.is_file():
+                self.error(f"fab file does not exist: '{namespace.file}'")
+
+        else:
+            # Check for a default fabfile in the current directory or
+            # use zero-config mode
+            if self.fabfile.is_file():
+                namespace.file = self.fabfile
+            else:
+                namespace.zero_config = True
+
+    def parse_fabfile_only(self, *args, **kwargs):
+        """Only attempt to pass the fabfile location.
+
+        Use a separate parser instance to extract nothing but the
+        --file location from the command line.  Ignore errors and do
+        not produce a help message - these should be handled by a
+        second parse attempt once any additional options from the
+        FabFile have been added.
+
+        :return: Namespace containing
+        """
+
+        # Create a fresh parser and add the file argument
+        file_only = argparse.ArgumentParser(add_help=False, exit_on_error=False)
+        self._add_fabfile_argument(file_only)
+
+        try:
+            args, rest = file_only.parse_known_args(*args, **kwargs)
+        except argparse.ArgumentError:
+            args = argparse.Namespace(file=None, zero_config=True)
+
+        self._check_fabfile(args)
+
+        return args
+
+    @_parser_wrapper
+    def parse_args(self, *args, **kwargs):
+
+        return super().parse_args(*args, **kwargs)
+
+    @_parser_wrapper
+    def parse_known_args(self, *args, **kwargs):
+
+        return super().parse_known_args(*args, **kwargs)

--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -25,17 +25,7 @@ from pathlib import Path
 
 from ..util import get_fab_workspace
 from .. import __version__ as fab_version
-
-try:
-    from ..logtools import make_logger, setup_logging
-except ModuleNotFoundError:
-    # Placeholder code.  This can be removed once logtools change has
-    # been merged
-    def make_logger(what):
-        return logging.getLogger(f"fab.{what}")
-
-    def setup_logging(*args):
-        logging.basicConfig(level=logging.DEBUG)
+from ..logtools import make_logger, setup_logging
 
 
 def full_path_type(opt: str) -> Path:

--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -19,7 +19,6 @@ argument and adds its own arguments.
 """
 
 import argparse
-import logging
 import os
 from pathlib import Path
 

--- a/source/fab/cui/arguments.py
+++ b/source/fab/cui/arguments.py
@@ -120,7 +120,7 @@ class FabArgumentParser(argparse.ArgumentParser):
             "--workspace",
             type=full_path_type,
             metavar="DIR",
-            default=get_fab_workspace(),
+            default=get_fab_workspace().expanduser().resolve(),
             help="location of working space (default: %(default)s)",
         )
 

--- a/source/fab/logtools.py
+++ b/source/fab/logtools.py
@@ -108,7 +108,7 @@ class FabLogFilter(logging.Filter):
             # Filter out everything except errors in quiet mode
             return False
 
-        if level <= 0 and record.levelno < logging.WARNING:
+        if (level is None or level <= 0) and record.levelno < logging.WARNING:
             # Filter out anything below warning
             return False
 

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -235,7 +235,7 @@ class TestParser:
 
         args = parser.parse_args(argv)
 
-        assert args.workspace == result
+        assert args.workspace.name == result.name
 
     def test_partial_parse(self):
         """Check partial parse functionality."""

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -231,7 +231,7 @@ class TestParser:
         if env is None and "FAB_WORKSPACE" in os.environ:
             monkeypatch.delenv("FAB_WORKSPACE")
         elif env is not None:
-            monkeypatch.setenv("FAB_WORKSPACE", env)
+            monkeypatch.setenv("FAB_WORKSPACE", str(Path(env).resolve()))
 
         args = parser.parse_args(argv)
 

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -201,7 +201,7 @@ class TestParser:
         "argv,env,result",
         [
             pytest.param(
-                [], None, Path("~/fab-workspace").expanduser().resolve(), id="default"
+                [], None, Path("fab-workspace").expanduser().resolve(), id="default"
             ),
             pytest.param([], "/tmp/fab", Path("/tmp/fab").resolve(), id="environment"),
             pytest.param(

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -214,7 +214,7 @@ class TestParser:
             pytest.param(
                 [], None, Path("fab-workspace").expanduser().resolve(), id="default"
             ),
-            pytest.param([], "/tmp/fab", Path("/tmp/fab").resolve(), id="environment"),
+            pytest.param([], Path("/tmp/fab"), Path("/tmp/fab").resolve(), id="environment"),
             pytest.param(
                 ["--workspace", "/run/fab"],
                 Path("/tmp/fab"),

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -231,11 +231,11 @@ class TestParser:
         if env is None and "FAB_WORKSPACE" in os.environ:
             monkeypatch.delenv("FAB_WORKSPACE")
         elif env is not None:
-            monkeypatch.setenv("FAB_WORKSPACE", str(env).resolve())
+            monkeypatch.setenv("FAB_WORKSPACE", str(env))
 
         args = parser.parse_args(argv)
 
-        assert args.workspace.name == result.name
+        assert args.workspace == result
 
     def test_partial_parse(self):
         """Check partial parse functionality."""

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""
+Tests for fab argument parser.
+"""
+
+import sys
+import os
+import argparse
+from pathlib import Path
+from fab.cui.arguments import full_path_type, FabArgumentParser
+
+import pytest
+
+
+class TestFullPathType:
+    """Tests for type which expands file paths."""
+
+    def test_username(self):
+        """Check username resolution."""
+
+        assert str(full_path_type("~root")).startswith("/")
+
+    def test_abspath(self):
+        """Check relative paths become absolute."""
+
+        assert str(full_path_type(".")).startswith("/")
+
+
+class TestFabFile:
+    """Check fab --file specific partial parsing."""
+
+    def test_default(self, fs):
+        """Check default with no user arguments."""
+
+        fs.create_file("FabFile")
+
+        parser = FabArgumentParser()
+        args = parser.parse_fabfile_only([])
+        assert isinstance(args, argparse.Namespace)
+        assert isinstance(args.file, Path)
+        assert args.file.name == "FabFile"
+        assert not args.zero_config
+
+    def test_alternate(self, fs):
+        """Check specified path with no user arguments."""
+
+        fs.create_file("myfile")
+
+        parser = FabArgumentParser(fabfile="myfile")
+        args = parser.parse_fabfile_only([])
+        assert isinstance(args, argparse.Namespace)
+        assert isinstance(args.file, Path)
+        assert args.file.name == "myfile"
+        assert not args.zero_config
+
+    def test_nonexistent_default(self, fs):
+        """Check non-existent default file."""
+
+        parser = FabArgumentParser()
+        args = parser.parse_fabfile_only([])
+        assert isinstance(args, argparse.Namespace)
+        assert args.file is None
+        assert args.zero_config
+
+    def test_user_file(self, fs):
+        """Check user specified argument."""
+
+        fs.create_file("myfile")
+
+        parser = FabArgumentParser()
+        args = parser.parse_fabfile_only(["--file", "myfile"])
+        assert isinstance(args, argparse.Namespace)
+        assert isinstance(args.file, Path)
+        assert args.file.name == "myfile"
+        assert not args.zero_config
+
+    def test_nonexistent_user_file(self, fs, capsys):
+        """Check non-existent file with user specified argument."""
+
+        parser = FabArgumentParser()
+
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_fabfile_only(["--file", "myfile"])
+        assert exc.value.code == 2
+
+        captured = capsys.readouterr()
+        assert "error: fab file does not exist" in captured.err
+
+    def test_no_help(self):
+        """Check there the help option does nothing."""
+
+        parser = FabArgumentParser()
+        args = parser.parse_fabfile_only(["--help"])
+        assert isinstance(args, argparse.Namespace)
+        assert args.file is None
+
+    def test_no_exit(self):
+        """Check missing argument does not cause an exit."""
+
+        parser = FabArgumentParser()
+        args = parser.parse_fabfile_only(["--file"])
+        assert isinstance(args, argparse.Namespace)
+
+
+class TestParser:
+    """Test the core parser and its default options."""
+
+    def test_defaults(self):
+        """Default results with no arguments."""
+
+        parser = FabArgumentParser()
+        args = parser.parse_args([])
+
+        assert isinstance(args, argparse.Namespace)
+        assert args.file is None
+        assert args.zero_config
+        assert args.project is None
+        assert isinstance(args.workspace, Path)
+        assert args.workspace.name == "fab-workspace"
+        assert args.debug is None
+        assert args.verbose is None
+        assert args.quiet is False
+
+    def test_with_default_fabfile(self, fs):
+        """Defaults where a FabFile exists."""
+
+        fs.create_file("FabFile")
+
+        parser = FabArgumentParser()
+        args = parser.parse_args([])
+
+        assert isinstance(args, argparse.Namespace)
+        assert isinstance(args.file, Path)
+        assert args.file.name == "FabFile"
+
+    def test_with_alternate_fabfile(self, fs):
+        """Defaults with a non-default FabFile name."""
+
+        fs.create_file("AltFabFile")
+
+        parser = FabArgumentParser(fabfile="AltFabFile")
+        args = parser.parse_args([])
+
+        assert isinstance(args, argparse.Namespace)
+        assert isinstance(args.file, Path)
+        assert args.file.name == "AltFabFile"
+
+    @pytest.mark.parametrize(
+        "argv,verbose,debug,quiet",
+        [
+            pytest.param(["-vv"], 2, None, False, id="verbose"),
+            pytest.param(["-ddd"], None, 3, False, id="debug"),
+            pytest.param(["-q"], None, None, True, id="quiet"),
+            pytest.param(["-vv", "-ddd"], 2, 3, False, id="verbose+debug"),
+            pytest.param(
+                ["-vv", "-ddd", "--quiet"], 2, 3, True, id="verbose+debug+quiet"
+            ),
+        ],
+    )
+    def test_output(self, argv, verbose, debug, quiet):
+        """Check combinations of output flags."""
+
+        parser = FabArgumentParser()
+        args = parser.parse_args(argv)
+
+        assert args.verbose == verbose
+        assert args.debug == debug
+        assert args.quiet == quiet
+
+    @pytest.mark.parametrize(
+        "argv,env,result",
+        [
+            pytest.param(
+                [], None, Path("~/fab-workspace").expanduser().resolve(), id="default"
+            ),
+            pytest.param([], "/tmp/fab", Path("/tmp/fab").resolve(), id="environment"),
+            pytest.param(
+                ["--workspace", "/run/fab"],
+                "/tmp/fab",
+                Path("/run/fab").resolve(),
+                id="argument",
+            ),
+        ],
+    )
+    def test_workspace(self, argv, env, result):
+        """Check various workspace settings."""
+
+        parser = FabArgumentParser()
+
+        # FIXME: use monkeypatch
+        if env is None and "FAB_WORKSPACE" in os.environ:
+            del os.environ["FAB_WORKSPACE"]
+        elif env is not None:
+            os.environ["FAB_WORKSPACE"] = env
+
+        args = parser.parse_args(argv)
+
+        assert args.workspace == result
+
+    def test_partial_parse(self):
+        """Check partial parse functionality."""
+
+        parser = FabArgumentParser()
+        args, rest = parser.parse_known_args(["--unknown"])
+
+        assert hasattr(args, "zero_config")
+        assert rest == ["--unknown"]
+
+    def test_help(self, capsys):
+        """Check default options are in help message."""
+
+        parser = FabArgumentParser()
+
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["--help"])
+        assert exc.value.code == 0
+
+        captured = capsys.readouterr()
+
+        assert "--file FILE" in captured.out
+        assert "--project NAME" in captured.out
+        assert "--workspace DIR" in captured.out
+        assert "-d, --debug" in captured.out
+        assert "-v, --verbose" in captured.out
+        assert "-q, --quiet" in captured.out
+
+    def test_alt_progname(self, monkeypatch):
+        """Test alternate program naming scheme."""
+
+        monkeypatch.setattr(sys, "argv", ["__main__.py"])
+
+        parser = FabArgumentParser()
+        args = parser.parse_args()
+
+        assert parser.prog == "fab"
+        assert args._progname == "fab"
+
+        monkeypatch.setattr(os, "environ", {"__PROGNAME": "cui-test"})
+
+        parser = FabArgumentParser()
+        args = parser.parse_args()
+
+        assert parser.prog == "cui-test"
+        assert args._progname == "cui-test"
+
+    def test_version(self, capsys, monkeypatch):
+
+        monkeypatch.setattr(sys, "argv", ["__main__.py"])
+
+        parser = FabArgumentParser()
+
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["--version"])
+        assert exc.value.code == 0
+
+        captured = capsys.readouterr()
+
+        assert captured.out.startswith("fab ")

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -217,7 +217,7 @@ class TestParser:
             pytest.param([], "/tmp/fab", Path("/tmp/fab").resolve(), id="environment"),
             pytest.param(
                 ["--workspace", "/run/fab"],
-                "/tmp/fab",
+                Path("/tmp/fab"),
                 Path("/run/fab").resolve(),
                 id="argument",
             ),
@@ -231,7 +231,7 @@ class TestParser:
         if env is None and "FAB_WORKSPACE" in os.environ:
             monkeypatch.delenv("FAB_WORKSPACE")
         elif env is not None:
-            monkeypatch.setenv("FAB_WORKSPACE", str(Path(env).resolve()))
+            monkeypatch.setenv("FAB_WORKSPACE", str(env).resolve())
 
         args = parser.parse_args(argv)
 


### PR DESCRIPTION
Two-phase command line argument parser based on argparse.  The first phase locates the Fab target file and sets zero config mode if the file is not found.  This allows the target to set additional command line options.  The second phases parses the full set of arguments as normal.

The parser adds a number of default options if these have not been added by the caller.

~~**Note:** this contains some placeholder code, so it can go on independently of the other changes in #424~~

The type checking depends on #451.
