### PR TITLE
Add build target classes to Fab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ instance/
 .scrapy
 
 # PyBuilder
-target/
+# target/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/source/fab/target/base.py
+++ b/source/fab/target/base.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""
+Class which can be subclassed to create fab build targets.
+"""
+
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser, Namespace
+
+
+class FabTargetBase(ABC):
+    """Abstract base class for creating fab build targets."""
+
+    @property
+    @abstractmethod
+    def project_name(self):
+        """Require subclasses to set a project name.
+
+        Defining project_name as an abstract property requires every
+        subclass to set a valid name.
+        """
+
+    @staticmethod
+    def add_arguments(parser: ArgumentParser) -> None:
+        """Extend an existing argument parser.
+
+        Add arguments to an ArgumentParser instance provided by the
+        fab command.  This allows build target classes to make their
+        own options visible in the argument parser used by the
+        command.
+
+        :param ArgumentParser parser: an existing command line argument parser.
+        """
+
+    @staticmethod
+    def check_arguments(parser: ArgumentParser, args: Namespace) -> None:
+        """Validate the command line arguments.
+
+        Check the command line arguments for correctness, allowing the
+        ArgumentParser.error method to used to raise usage problems.
+
+        :param ArgumentParser parser: an existing command line argument parser.
+        :param Namespace args: parsed arguments
+
+        """
+
+    @abstractmethod
+    def run(self, args: Namespace) -> None:
+        """Run arbitrary build actions.
+
+        Entry point used by the fab command to run the actions
+        required to build a particular target.  This must be
+        implemented by the target subclass.
+
+        :param Namespace args: the parsed command line arguments.
+        """

--- a/source/fab/target/zero.py
+++ b/source/fab/target/zero.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""
+Class which implements a zero-configuration build target.
+"""
+
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+from .base import FabTargetBase
+from ..tools import Category, ToolBox, ToolRepository
+from ..build_config import BuildConfig
+from ..steps.grab.folder import grab_folder
+from ..steps.find_source_files import find_source_files
+from ..steps.preprocess import preprocess_fortran
+from ..steps.c_pragma_injector import c_pragma_injector
+from ..steps.analyse import analyse
+from ..steps.compile_fortran import compile_fortran
+from ..steps.compile_c import compile_c
+from ..steps.link import link_exe
+
+
+class FabZeroConfig(FabTargetBase):
+    """Implementation of a zero-configuration build target."""
+
+    project_name = "zero-config"
+
+    @staticmethod
+    def add_arguments(parser: ArgumentParser) -> None:
+        """Add zero-config mode command line options.
+
+        Zero configuration requires the name of the directory
+        containing the source code.
+
+        :param ArgumentParser parser: an existing command line argument parser.
+        """
+
+        parser.add_argument(
+            "source", type=Path, nargs="?", default=".", help="source directory"
+        )
+
+    @staticmethod
+    def check_arguments(parser: ArgumentParser, args: Namespace) -> None:
+        """Check the zero-config options for correctness."""
+
+        if not args.source.is_dir():
+            parser.error("source must be a valid directory")
+
+    def run(self, args: Namespace) -> None:
+        """Build an executable with no previous knowledge.
+
+        Run the zero configuration build target recipe.
+
+        :param Namespace args: instance containing parsed command line arguments.
+        """
+
+        project_label = (
+            args.project
+            if hasattr(args, "project") and args.project
+            else self.project_name
+        )
+
+        tr = ToolRepository()
+        fc = tr.get_default(Category.FORTRAN_COMPILER, mpi=False, openmp=False)
+        linker = tr.get_tool(Category.LINKER, f"linker-{fc.name}")
+
+        tool_box = ToolBox()
+        tool_box.add_tool(fc)
+        tool_box.add_tool(linker)
+
+        with BuildConfig(
+            project_label=project_label,
+            mpi=False,
+            openmp=False,
+            tool_box=tool_box,
+            fab_workspace=Path(args.workspace),
+        ) as config:
+            grab_folder(config, args.source)
+            find_source_files(config)
+
+            preprocess_fortran(config)
+            c_pragma_injector(config)
+            analyse(config, find_programs=True)
+
+            compile_fortran(config)
+            compile_c(config)
+            link_exe(config, flags=[])

--- a/tests/unit_tests/test_target.py
+++ b/tests/unit_tests/test_target.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""
+Unit tests for fab recipe classes.
+"""
+
+import argparse
+import pytest
+
+from fab.target.base import FabTargetBase
+from fab.target.zero import FabZeroConfig
+
+
+def test_valid_subclass():
+    """Create a valid subclass from FabTargetBase."""
+
+    class FabTarget(FabTargetBase):
+        """Trivial test class."""
+
+        project_name = "test-class"
+
+        def run(self, _):
+            """Dummy run method."""
+
+    assert issubclass(FabTarget, FabTargetBase)
+
+    target = FabTarget()
+    assert isinstance(target, FabTargetBase)
+
+
+def test_invalid_subclasses():
+    """Create invalid subclasses from FabTargetBase."""
+
+    class FabInvalidMethod(FabTargetBase):
+        """Missing abstract methods."""
+
+        project_name = "test-class"
+
+    with pytest.raises(TypeError) as exc:
+        _ = FabInvalidMethod()
+    assert "Can't instantiate abstract class" in str(exc)
+
+    class FabInvalidProject(FabTargetBase):
+        """Missing project_name property."""
+
+        def run(self, _):
+            """Dummy run method."""
+
+    with pytest.raises(TypeError) as exc:
+        _ = FabInvalidMethod()
+    assert "Can't instantiate abstract class" in str(exc)
+
+
+def test_add_arguments():
+    """Test add_arguments static method."""
+
+    class FabTargetArgs(FabTargetBase):
+        """Test class with add_arguments."""
+
+        @staticmethod
+        def add_arguments(p):
+            """Add a positional argument."""
+            p.add_argument("test", type=str)
+
+    parser = argparse.ArgumentParser()
+    FabTargetArgs.add_arguments(parser)
+    args = parser.parse_args(["abc"])
+
+    assert isinstance(args, argparse.Namespace)
+    assert args.test == "abc"
+
+
+def test_zero_config(tmp_path):
+    """Test the zero config target class."""
+
+    # Create a trivial bit of fortran
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    work = tmp_path / "fab-workspace"
+    work.mkdir()
+
+    with open(src_dir / "test.f90", "w", encoding="utf-8") as fd:
+        print("program test\nwrite(*,*) 'testcase'\nend program test", file=fd)
+
+    zero = FabZeroConfig()
+    assert isinstance(zero, FabTargetBase)
+
+    zero.run(
+        argparse.Namespace(
+            source=src_dir,
+            workspace=work,
+        )
+    )
+
+    # Check the project directory to ensure that the zero config
+    # class has run correctly
+    project = work / "zero-config"
+
+    assert project.is_dir()
+    assert (project / "source").is_dir()
+    assert (project / "source" / "test.f90").is_file()
+    assert (project / "test").is_file()


### PR DESCRIPTION
This adds a module directory containing build target classes.  The base module contains an abstract build implementation which is intended to be subclassed by the application to create a set of rules which can be used to compile an application.

It also creates a zero-config class derived from the base class which is intended to show how the rules should be implemented.

**Note:** This is independent of the other changes in #424
