### PR TITLE
Working directory should default to current directory

### DIFF
--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -253,14 +253,13 @@ def by_type(iterable, cls):
 def get_fab_workspace() -> Path:
     """
     Read the Fab workspace from the `FAB_WORKSPACE` environment variable,
-    defaulting to *~/fab-workspace*.
+    defaulting to ./fab-workspace*.
 
     """
     if os.getenv("FAB_WORKSPACE"):
         fab_workspace = Path(os.getenv("FAB_WORKSPACE"))  # type: ignore
     else:
-        fab_workspace = Path(os.path.expanduser("~/fab-workspace"))
-        logger.info(f"FAB_WORKSPACE not set, defaulting to {fab_workspace}")
+        fab_workspace = Path(os.path.expanduser("./fab-workspace"))
     return fab_workspace
 
 


### PR DESCRIPTION
At the moment the fab workspace is created in the root of the users home directory. A more suitable place for the fab workspace to default to would be the current working directory. This pull request aims to implement a fix to this as outlined by https://github.com/MetOffice/fab/issues/338.

This PR is the replacement PR for #453 in the hope that commit histories will be slightly tidier in the future. Once merged this pull request closes #338 .