### PR TITLE
#463 Fixes #463.

### DIFF
--- a/source/fab/parse/fortran_common.py
+++ b/source/fab/parse/fortran_common.py
@@ -113,7 +113,7 @@ class FortranAnalyserBase(ABC):
         if isinstance(node_tree, Exception):
             return (Exception(f"error parsing file '{fpath}':\n{node_tree}"),
                     None)
-        if node_tree.content[0] is None:
+        if not node_tree.content or node_tree.content[0] is None:
             logger.debug(f"  empty tree found when parsing {fpath}")
             # todo: If we don't save the empty result we'll keep analysing
             # it every time!


### PR DESCRIPTION
Small bug fix (avoids a crash due to a recent, though not yet released fparser update).

Fparser now returns an empty list if the input file is empty (previously it would return a single element list with empty content).