### PR TITLE
465 absolute path

### DIFF
--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -107,6 +107,11 @@ class BuildConfig():
         # workspace folder
         if not fab_workspace:
             fab_workspace = get_fab_workspace()
+
+        # Make sure fab_workspace is an absolute path, some tools
+        # (esp. compiler) change working directory and so need
+        # absolute paths.
+        fab_workspace = fab_workspace.resolve()
         logger.info(f"fab workspace is {fab_workspace}")
 
         self._project_workspace: Path = fab_workspace / self.project_label

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -110,8 +110,9 @@ class BuildConfig():
 
         # Make sure fab_workspace is an absolute path, some tools
         # (esp. compiler) change working directory and so need
-        # absolute paths.
-        fab_workspace = fab_workspace.resolve()
+        # absolute paths. Also support '~', in case that a user
+        # uses this when setting the fab workspace.
+        fab_workspace = fab_workspace.expanduser().resolve()
         logger.info(f"fab workspace is {fab_workspace}")
 
         self._project_workspace: Path = fab_workspace / self.project_label

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -253,14 +253,14 @@ def by_type(iterable, cls):
 def get_fab_workspace() -> Path:
     """
     Read the Fab workspace from the `FAB_WORKSPACE` environment variable,
-    defaulting to ./fab-workspace*.
+    defaulting to ./fab-workspace.
 
     """
-    if os.getenv("FAB_WORKSPACE"):
-        fab_workspace = Path(os.getenv("FAB_WORKSPACE"))  # type: ignore
-    else:
-        fab_workspace = Path("./fab-workspace")
-    return fab_workspace
+    workspace = os.getenv("FAB_WORKSPACE")
+    if not workspace:
+        workspace = "./fab-workspace"
+
+    return Path(workspace)
 
 
 def get_prebuild_file_groups(prebuild_files: Iterable[Path]) -> Dict[str, Set]:

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -259,7 +259,7 @@ def get_fab_workspace() -> Path:
     if os.getenv("FAB_WORKSPACE"):
         fab_workspace = Path(os.getenv("FAB_WORKSPACE"))  # type: ignore
     else:
-        fab_workspace = Path(os.path.expanduser("./fab-workspace"))
+        fab_workspace = Path("./fab-workspace")
     return fab_workspace
 
 

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -4,6 +4,14 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 
+'''
+This module tests the BuildConfig class.
+'''
+
+import os
+from pathlib import Path
+from unittest import mock
+
 from fab.build_config import BuildConfig
 from fab.steps import step
 from fab.steps.cleanup_prebuilds import CLEANUP_COUNT
@@ -11,22 +19,66 @@ from fab.tools import ToolBox
 
 
 class TestBuildConfig:
+    '''
+    This class tests the BuildConfig class.
+    '''
 
-    def test_error_newlines(self, tmp_path):
-        # Check cli tool errors have newlines displayed correctly.
-        # v0.9.0a1 displayed then as `\\n` (see #164).
+    def test_error_newlines(self):
+        '''
+        Check cli tool errors have newlines displayed correctly.
+        v0.9.0a1 displayed then as `\\n` (see #164).
+        '''
         @step
         def simple_step(config):
             raise RuntimeError("foo error\n1\n2\n3")
 
         try:
             simple_step(None)
-        except Exception as err:
+        except RuntimeError as err:
             assert '1\n2\n3' in str(err)
 
     def test_add_cleanup(self):
-        # ensure the cleanup step is added
+        '''
+        Ensure the cleanup step is added.
+        '''
         with BuildConfig('proj', ToolBox()) as config:
             assert CLEANUP_COUNT not in config.artefact_store
 
         assert CLEANUP_COUNT in config.artefact_store
+
+    @mock.patch.dict('os.environ')
+    def test_fab_workspace_no_env(self, tmpdir):
+        '''
+        Test that the Fab workspace is set as expected when the
+        environment variable FAB_WORKSPACE is not used
+        '''
+
+        this_dir = Path.cwd()
+        config = BuildConfig('proj', ToolBox())
+        assert config.project_workspace == this_dir / "fab-workspace" / "proj"
+
+        some_dir = Path("/some_dir")
+        config = BuildConfig('proj', ToolBox(), fab_workspace=some_dir)
+        assert config.project_workspace == some_dir / "proj"
+
+        # Test again the expected behaviour from a different directory,
+        # to ensure that Fab correctly querier cwd
+        os.chdir(tmpdir)
+        config = BuildConfig('proj', ToolBox())
+        assert config.project_workspace == tmpdir / "fab-workspace" / "proj"
+
+    @mock.patch.dict('os.environ', {'FAB_WORKSPACE': '/FAB'})
+    def test_fab_workspace_with_env(self):
+        '''
+        Test that the Fab workspace is set as expected when the environment
+        variable FAB_WORKSPACE is defined.
+        '''
+
+        fab_dir = Path("/FAB")
+        config = BuildConfig('proj', ToolBox())
+        assert config.project_workspace == fab_dir / "proj"
+
+        # An explicit option should overwrite FAB_WORKSPACE
+        some_dir = Path("/some_dir")
+        config = BuildConfig('proj', ToolBox(), fab_workspace=some_dir)
+        assert config.project_workspace == some_dir / "proj"

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -55,17 +55,17 @@ class TestBuildConfig:
 
         this_dir = Path.cwd()
         config = BuildConfig('proj', ToolBox())
-        assert config.project_workspace == this_dir / "fab-workspace" / "proj"
+        assert config.project_workspace == this_dir / 'fab-workspace' / 'proj'
 
-        some_dir = Path("/some_dir")
+        some_dir = Path('/some_dir')
         config = BuildConfig('proj', ToolBox(), fab_workspace=some_dir)
-        assert config.project_workspace == some_dir / "proj"
+        assert config.project_workspace == some_dir / 'proj'
 
         # Test again the expected behaviour from a different directory,
-        # to ensure that Fab correctly querier cwd
+        # to ensure that Fab correctly queries cwd
         os.chdir(tmpdir)
         config = BuildConfig('proj', ToolBox())
-        assert config.project_workspace == tmpdir / "fab-workspace" / "proj"
+        assert config.project_workspace == tmpdir / 'fab-workspace' / 'proj'
 
     @mock.patch.dict('os.environ', {'FAB_WORKSPACE': '/FAB'})
     def test_fab_workspace_with_env(self):
@@ -74,11 +74,10 @@ class TestBuildConfig:
         variable FAB_WORKSPACE is defined.
         '''
 
-        fab_dir = Path("/FAB")
         config = BuildConfig('proj', ToolBox())
-        assert config.project_workspace == fab_dir / "proj"
+        assert config.project_workspace == Path('/FAB') / 'proj'
 
         # An explicit option should overwrite FAB_WORKSPACE
-        some_dir = Path("/some_dir")
+        some_dir = Path('/some_dir')
         config = BuildConfig('proj', ToolBox(), fab_workspace=some_dir)
-        assert config.project_workspace == some_dir / "proj"
+        assert config.project_workspace == some_dir / 'proj'


### PR DESCRIPTION
As far as I can tell, compilation is broken atm (looks like the testing could do with some improvements :) ). This should fix it by ensuring that the project directory is always an absolute path (see #465 for details).