### PR TITLE
Update documentation links and fix minor typos across multiple files

### DIFF
--- a/Documentation/Design/GraphObject.puml
+++ b/Documentation/Design/GraphObject.puml
@@ -137,4 +137,4 @@ object fileSink02 {
 }
 link02 -> fileSink02
 
-@end uml
+@enduml

--- a/Documentation/source/advanced_config.rst
+++ b/Documentation/source/advanced_config.rst
@@ -23,14 +23,14 @@ could be helpful to factor out the commonality into a shared module. Remember,
 your build configuration is just a Python script at the end of the day.
 
 In Fab's
-`example configurations <https://github.com/metomi/fab/tree/master/run_configs>`_,
+`example configurations <https://github.com/MetOffice/fab/tree/main/run_configs>`_,
 we have two build scripts to compile GCOM. Much of the configuration for these
 two scripts is identical. We extracted the common steps into
-`gcom_build_steps.py <https://github.com/metomi/fab/blob/master/run_configs/gcom/gcom_build_steps.py>`_
+`gcom_build_steps.py <https://github.com/MetOffice/fab/blob/main/run_configs/gcom/gcom_build_steps.py>`_
 and used them in
-`build_gcom_ar.py <https://github.com/metomi/fab/blob/master/run_configs/gcom/build_gcom_ar.py>`_
+`build_gcom_ar.py <https://github.com/MetOffice/fab/blob/main/run_configs/gcom/build_gcom_ar.py>`_
 and
-`build_gcom_so.py <https://github.com/metomi/fab/blob/master/run_configs/gcom/build_gcom_so.py>`_.
+`build_gcom_so.py <https://github.com/MetOffice/fab/blob/main/run_configs/gcom/build_gcom_so.py>`_.
 
 
 Separate grab and build scripts
@@ -289,7 +289,7 @@ will be affected consistently.
 
 
 Tool arguments
-============== 
+==============
 
 Sometimes it is necessary to pass additional arguments when we call a software
 tool.
@@ -398,13 +398,13 @@ We can currently only *add* flags for a path.
     This can require some understanding of where and when files are placed in
     the *build_output* folder: It will generally match the structure you've
     created in ``*<project workspace>/source*``, with your grab steps.
-    
+
     Early steps like preprocessors generally read files from ``*source*`` and
     write to ``*build_output*``.
-    
+
     Later steps like compilers generally read files which are already in
     ``*build_output*``.
-    
+
     For more information on where files end up see :ref:`Directory Structure`.
 
 
@@ -608,7 +608,7 @@ Custom Step
 An alternative approach for some problems is to write a custom step to modify
 the source so that the language parser can process it. Here's a simple example,
 based on a
-`real workaround <https://github.com/metomi/fab/blob/216e00253ede22bfbcc2ee9b2e490d8c40421e5d/run_configs/um/build_um.py#L42-L65>`_
+`real workaround <https://github.com/MetOffice/fab/blob/216e00253ede22bfbcc2ee9b2e490d8c40421e5d/run_configs/um/build_um.py#L42-L65>`_
 where the parser gets confused by a variable called `NameListFile`.
 
 .. code-block::

--- a/Documentation/source/conf.py
+++ b/Documentation/source/conf.py
@@ -12,7 +12,9 @@
 #
 import os
 import sys
+
 from fab import __version__ as fab_version
+
 sys.path.insert(0, os.path.abspath('../../source'))
 
 
@@ -73,7 +75,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/metomi/fab",
+            "url": "https://github.com/MetOffice/fab",
             "icon": "fa-brands fa-github"
         }
     ],

--- a/Documentation/source/development.rst
+++ b/Documentation/source/development.rst
@@ -19,7 +19,7 @@ This lets you edit the code without needing to reinstall fab after every change.
 
 .. code-block:: console
 
-    $ git clone https://github.com/metomi/fab.git <fab-folder>
+    $ git clone https://github.com/MetOffice/fab.git <fab-folder>
     $ pip install -e <fab-folder>
 
 
@@ -138,7 +138,7 @@ Build these docs
 
 The github action to build the docs is defined in
 ``.github/workflows/build_docs.yml``. It is manually triggered and can be run
-from any branch in the metomi repo.
+from any branch in the MetOffice repo.
 
 You can also run it on your fork to produce a separate build, for viewing work
 in progress.

--- a/Documentation/source/environment.rst
+++ b/Documentation/source/environment.rst
@@ -41,7 +41,7 @@ preferable to use one of the managed packages.
 Packages are made available through `PyPI`_ and `Conda forge`_ and are installed
 in the usual way for these services. Some examples follow.
 
-.. _source: https://github.com/metomi/fab
+.. _source: https://github.com/MetOffice/fab
 .. _PyPI: https://pypi.org/project/sci-fab/
 .. _Conda forge: https://anaconda.org/conda-forge/sci-fab
 
@@ -74,8 +74,8 @@ If you want to compile C you will need to add the prerequisites for that:
 
     $ pip install python-clang
 
-Note that this requires a suitible `libclang` to be installed on your system
-which may require system administrator internvention.
+Note that this requires a suitable `libclang` to be installed on your system
+which may require system administrator intervention.
 
 Finally, to get plots from the metrics you will need:
 
@@ -90,7 +90,7 @@ Using Anaconda
 --------------
 
 Anaconda can be used in a similar way to the built in Python virtual
-environemnt but can also handle your C needs:
+environment but can also handle your C needs:
 
 .. code-block:: console
 
@@ -118,7 +118,7 @@ And again, if you want to plot the build metrics:
 Using Containers
 ----------------
 
-The dockerfile in `envs/docker`_ can be used to create a suitible container for
+The dockerfile in `envs/docker`_ can be used to create a suitable container for
 running Fab:
 
 .. code-block:: console
@@ -129,4 +129,4 @@ running Fab:
 This was tested on Windows, running Ubuntu in WSL but is not regularly tested
 so can not be guaranteed.
 
-.. _envs/docker: https://github.com/metomi/fab/tree/master/envs/docker
+.. _envs/docker: https://github.com/MetOffice/fab/tree/main/envs/docker

--- a/Documentation/source/features.rst
+++ b/Documentation/source/features.rst
@@ -82,7 +82,7 @@ Limitations
 ===========
 
 Known problems at the time of writing. For further issues see the
-`issue tracker <https://github.com/metomi/fab/issues>`_.
+`issue tracker <https://github.com/MetOffice/fab/issues>`_.
 
 Fortran single-line IF calls
 ----------------------------
@@ -98,7 +98,7 @@ Name Clash
 
 Fab currently assumes there are no name clashes in your project by the time we reach certain build steps:
 
-- C and Fortran symbols go into one symbol table so there can be no duplicate 
+- C and Fortran symbols go into one symbol table so there can be no duplicate
   symbol names by the time we reach the analysis stage.
 - Fortran mod files are created in a flat folder, so Fortran module names must
   be unique by the time we reach the compile stage.
@@ -122,4 +122,4 @@ override). It will *not* notice if a Fortran `*.mod` changes in an include
 folder elsewhere.
 
 An example is the UM build which uses GCom's mpl.mod. This issue is raised in
-`#192 <https://github.com/metomi/fab/issues/192>`_.
+`#192 <https://github.com/MetOffice/fab/issues/192>`_.

--- a/Documentation/source/index.rst
+++ b/Documentation/source/index.rst
@@ -61,9 +61,9 @@ Config files
 
 See also
 ========
-* `Project wiki <https://github.com/metomi/fab/wiki>`_
+* `Project wiki <https://github.com/MetOffice/fab/wiki>`_
 * `Fab on PyPI <https://pypi.org/project/sci-fab/>`_
-* `Fab on Github <https://github.com/metomi/fab>`_
+* `Fab on Github <https://github.com/MetOffice/fab>`_
 * :ref:`Developers guide<Development>`
 
 

--- a/Documentation/source/metoffice.rst
+++ b/Documentation/source/metoffice.rst
@@ -47,7 +47,7 @@ Singularity Container
 
 You can run Fab in a singularity container as follows::
 
-    singularity run oras://$URL/metomi/fab/MyImage:latest
+    singularity run oras://$URL/MetOffice/fab/MyImage:latest
 
 The necessary URL is that normally used with singularity. Ask Science I.T. for
 details.
@@ -115,12 +115,12 @@ so that changes you make are immediately available through the environment.
     $ pip install --editable $FAB_WORKING_COPY
 
 
-Mixing Conda and Environemnt Modules
+Mixing Conda and Environment Modules
 ------------------------------------
 
 In order to have both an environment capable of building C files and modern
 Fortran compilers and the LFRic library stack you will need an awkward
-amalgemation of conda environment and environment modules.
+amalgamation of conda environment and environment modules.
 
 The conda environment is created as follows:
 
@@ -165,7 +165,7 @@ to be that in the conda environment.
 Rose
 ----
 Various configs for building projects using Rose on SPICE can be found in
-`run_configs <https://github.com/metomi/fab/tree/master/run_configs>`_.
+`run_configs <https://github.com/MetOffice/fab/tree/main/run_configs>`_.
 
 
 .. _MetOfficeDevelopment:
@@ -192,12 +192,12 @@ The config file in envs/picasso defines the contents of a Singularity image
 which is built by the experimental Picasso app. We can build this image using a
 GitHub action, defined in ``.github/workflows/picasso_build.yml``.
 
-This action is manually triggered. You have to push a branch to the metomi repo,
+This action is manually triggered. You have to push a branch to the MetOffice repo,
 not a fork, then you can trigger the action from your branch. Please remember
 to clean up the branch when you're finished.
 
 You can see the image in artefactory
-`here <https://metoffice.jfrog.io/ui/repos/tree/General/docker-local/picasso/metomi/fab/MyImage>`_.
+`here <https://metoffice.jfrog.io/ui/repos/tree/General/docker-local/picasso/MetOffice/fab/MyImage>`_.
 
 
 See also

--- a/Documentation/source/site-specific-config.rst
+++ b/Documentation/source/site-specific-config.rst
@@ -37,7 +37,7 @@ the user explicitly puts a tool into the ToolBox).
           compile, or a hard-coded set of criteria) which compiler to use.
 
 Category
-==========
+========
 All possible categories are defined in
 :class:`~fab.tool.category.Category`. If additional categories
 should be required, they can be added.

--- a/Documentation/source/writing_config.rst
+++ b/Documentation/source/writing_config.rst
@@ -141,11 +141,11 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
 * For :func:`~fab.steps.psyclone.psyclone`:
             You can pass in:
 
-            * kernel file roots to `kernel_roots`, 
-            * a function to get transformation script to `transformation_script` 
+            * kernel file roots to `kernel_roots`,
+            * a function to get transformation script to `transformation_script`
               (see examples in ``~fab.run_configs.lfric.gungho.py`` and ``~fab.run_configs.lfric.atm.py``),
             * command-line arguments to `cli_args`,
-            * override for input files to `source_getter`, 
+            * override for input files to `source_getter`,
             * folders containing override files to `overrides_folder`.
 
 
@@ -271,7 +271,7 @@ ArtefactStore
 =============
 Each build configuration contains an artefact store, containing various
 sets of artefacts. The artefact sets used by Fab are defined in the
-enum :class:`~fab.artefacts.ArtefactSet`. The most important sets are ``FORTRAN_BUILD_FILES``, 
+enum :class:`~fab.artefacts.ArtefactSet`. The most important sets are ``FORTRAN_BUILD_FILES``,
 ``C_BUILD_FILES``, which will always contain all known source files that
 will need to be analysed for dependencies, compiled, and linked. All existing
 steps in Fab will make sure to maintain these artefact sets consistently,
@@ -333,4 +333,4 @@ More advanced configuration topics are discussed in
 :ref:`Advanced Config`.
 
 You can see more complicated configurations in the
-`developer testing directory <https://github.com/metomi/fab/tree/master/run_configs>`_.
+`developer testing directory <https://github.com/MetOffice/fab/tree/main/run_configs>`_.

--- a/Experimental/conda/readme.md
+++ b/Experimental/conda/readme.md
@@ -1,36 +1,39 @@
-Create a conda environment for running fab
-```
+# Create a conda environment for running fab
+
+```sh
 conda env create -f environment.yml
 ```
 
-
 Activate the new environment
 
-```
+```sh
 conda activate fab
 ```
 
 Install fab (from the fab folder)
-```
+
+```sh
 python setup.py install
-or
+# or
 pip install .
 ```
 
 [Editable install](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs) for developers
-```
+
+
+```sh
 python setup.py develop
-or
+# or
 pip install -e .
 ```
 
 Uninstall fab
-```
+
+```sh
 python setup.py uninstall
-or
+# or
 pip uninstall sci_fab
 ```
-
 
 Please be aware of some considerations when
 [using pip and conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Fab - A Build System for Tomorrow!
+# Fab - A Build System for Tomorrow
 
-![](https://github.com/Metomi/fab/workflows/Build/badge.svg)
+[![Build](https://github.com/MetOffice/fab/actions/workflows/build.yml/badge.svg)](https://github.com/MetOffice/fab/actions/workflows/build.yml)
 
 The "Fab" project aims to provide the means to quickly and easily compile
 software in a way tailored for scientific software development. It aims to be

--- a/envs/picasso/readme
+++ b/envs/picasso/readme
@@ -1,13 +1,16 @@
+# Note
+
 This image is currently built with a manual trigger from the github actions page.
 We should consider adding more images, with combinations of versions of Python and other software, for testing.
 
-See the image in artefactory
-https://metoffice.jfrog.io/ui/repos/tree/General/docker-local/picasso/metomi/fab/MyImage
+See the [image in artifactory](https://metoffice.jfrog.io/ui/repos/tree/General/docker-local/picasso/MetOffice/fab/MyImage)
 
 Run the image
-singularity run oras://metoffice-docker-local.jfrog.io/picasso/metomi/fab/MyImage:latest
 
-# with the mo proxy certificate bound for git
-export SINGULARITY_BIND="/etc/pki/ca-trust/extracted/pem:/pem"
-export SINGULARITYENV_GIT_SSL_CAPATH="/pem"
-singularity shell oras://metoffice-docker-local.jfrog.io/picasso/metomi/fab/MyImage:latest
+    singularity run oras://metoffice-docker-local.jfrog.io/picasso/MetOffice/fab/MyImage:latest
+
+with the mo proxy certificate bound for git
+
+    export SINGULARITY_BIND="/etc/pki/ca-trust/extracted/pem:/pem"
+    export SINGULARITYENV_GIT_SSL_CAPATH="/pem"
+    singularity shell oras://metoffice-docker-local.jfrog.io/picasso/MetOffice/fab/MyImage:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ dev = [
 fab = 'fab.cli:cli_fab'
 
 [project.urls]
-homepage = 'https://github.com/Metomi/fab'
-documentation = 'https://metomi.github.io/fab/'
-repository = 'https://github.com/metomi/fab'
-'Bug Reports' = 'https://github.com/metomi/fab/issues'
+homepage = 'https://github.com/MetOffice/fab'
+documentation = 'https://MetOffice.github.io/fab'
+repository = 'https://github.com/MetOffice/fab'
+'Bug Reports' = 'https://github.com/MetOffice/fab/issues'
 
 [tool.setuptools.packages.find]
 where = ['source']

--- a/run_configs/_cron/cron_system_tests.sh
+++ b/run_configs/_cron/cron_system_tests.sh
@@ -1,6 +1,6 @@
-#
+#!/usr/bin/env bash
 # Build and rebuild all our Met Office example build projects, for both compilers.
-# Use a fresh clone of Fab's master branch.
+# Use a fresh clone of Fab's main branch.
 #
 # Cron this to run every weekday midnight with
 # 0 0 * * 1-5 bash -l -c "~/git/fab/run_configs/_cron/cron_system_tests.sh 2>&1 >/dev/null"
@@ -14,7 +14,7 @@ mkdir /tmp/persistent/cron_system_tests
 cd /tmp/persistent/cron_system_tests
 
 # clone fab
-git clone --branch master --depth 1 https://github.com/metomi/fab.git 2>&1 >/dev/null
+git clone --branch main --depth 1 https://github.com/MetOffice/fab.git 2>&1 >/dev/null
 # ...or if you're working on the system tests cron you can clone from your local repo like this
 #git clone --branch 195_grab_git --depth 1 file:///home/h02/bblay/git/fab/ 2>&1 >/dev/null
 

--- a/source/fab/parse/__init__.py
+++ b/source/fab/parse/__init__.py
@@ -7,10 +7,9 @@ import json
 import logging
 from abc import ABC
 from pathlib import Path
-from typing import Union, Optional, Dict, Any, Set
+from typing import Any, Dict, Optional, Set, Union
 
 from fab.util import file_checksum
-
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +110,7 @@ class AnalysedFile(ABC):
         # We use self.field_names() rather than vars(self) because we want to evaluate any lazy attributes.
         # We turn dicts and sets into sorted tuples for hashing.
         # todo: There's a good reason dicts and sets aren't supposed to be hashable.
-        #       Please see https://github.com/metomi/fab/issues/229
+        #       Please see https://github.com/MetOffice/fab/issues/229
         things = set()
         for field_name in self.field_names():
             thing = getattr(self, field_name)

--- a/tests/system_tests/git/create_repo.sh
+++ b/tests/system_tests/git/create_repo.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Create a repo with two conflicting branches.
 
 set -e
@@ -6,26 +7,27 @@ mkdir repo
 cd repo
 git init .
 
-echo "This is sentence one in file one." >> file1.txt
-echo "" >> file1.txt
-echo "This is sentence two in file one." >> file1.txt
-echo "" >> file1.txt
+echo "This is sentence one in file one.
+
+This is sentence two in file one.
+
+" >> file1.txt
 
 git add file1.txt
-git commit -m "intial commit"
+git commit -m "initial commit"
 
 
 # Create a branch which changes file 1.
-git checkout -b experiment_a master
+git checkout -b experiment_a main
 sed -i 's/This is sentence one in file one./This is sentence one, with Experiment A modification./' file1.txt
 git commit -am "experiment a modifications"
 
 # Create another branch which changes file 1, conflicting with the first branch.
-git checkout -b experiment_b master
+git checkout -b experiment_b main
 sed -i 's/This is sentence one in file one./This is sentence one, with Experiment B modification./' file1.txt
 git commit -am "experiment a modifications"
 
-git checkout master
+git checkout main
 
 # zip it up
 cd ..

--- a/tests/system_tests/git/test_git.py
+++ b/tests/system_tests/git/test_git.py
@@ -21,7 +21,6 @@ import shutil
 from pathlib import Path
 
 import pytest
-
 from fab.build_config import BuildConfig
 from fab.steps.grab.git import git_checkout, git_merge
 from fab.tools import Git, ToolBox
@@ -80,9 +79,9 @@ class TestGitMerge:
                                 "Use the filter argument to control this behavior.")
     def test_vanilla(self, repo_url, config):
 
-        # checkout master
+        # checkout main
         with pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-            git_checkout(config, src=repo_url, dst_label='tiny_fortran', revision='master')
+            git_checkout(config, src=repo_url, dst_label='tiny_fortran', revision='main')
             check_file = config.source_root / 'tiny_fortran/file1.txt'
             assert 'This is sentence one in file one.' in open(check_file).read()
 
@@ -93,6 +92,6 @@ class TestGitMerge:
         with pytest.raises(RuntimeError):
             git_merge(config, src=repo_url, dst_label='tiny_fortran', revision='experiment_b')
 
-        # The conflicted merge must have been aborted, check that we can do another checkout of master
+        # The conflicted merge must have been aborted, check that we can do another checkout of main
         with pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-            git_checkout(config, src=repo_url, dst_label='tiny_fortran', revision='master')
+            git_checkout(config, src=repo_url, dst_label='tiny_fortran', revision='main')

--- a/tests/system_tests/svn_fcm/create_repo.sh
+++ b/tests/system_tests/svn_fcm/create_repo.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # I had to do this a few times to get it right. It was a bit time consuming,
 # and I realised it might be useful to put it in a script so we can
 # reproduce it quickly and easily, and so others can see what's in the repo
@@ -6,18 +7,20 @@ set -e
 
 svnadmin create repo
 
-# Create the inital files in trunk.
+# Create the initial files in trunk.
 mkdir import
 
-echo "This is sentence one in file one." >> import/file1.txt
-echo "" >> import/file1.txt
-echo "This is sentence two in file one." >> import/file1.txt
-echo "" >> import/file1.txt
+echo "This is sentence one in file one.
 
-echo "This is sentence one in file two." >> import/file2.txt
-echo "" >> import/file2.txt
-echo "This is sentence two in file two." >> import/file2.txt
-echo "" >> import/file2.txt
+This is sentence two in file one.
+
+" >> import/file1.txt
+
+echo "This is sentence one in file two.
+
+This is sentence two in file two.
+
+" >> import/file2.txt
 
 svn import import/ file://$PWD/repo/proj/main/trunk -m "initial commit"
 rm -rf import

--- a/tests/system_tests/svn_fcm/see_all.sh
+++ b/tests/system_tests/svn_fcm/see_all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # use this to see all the branches we expect to be created by create_repo.sh
 set -e
 

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -9,19 +9,18 @@ Tests tooling base classes.
 import logging
 from pathlib import Path
 
+from fab.tools.category import Category
+from fab.tools.flags import ProfileFlags
+from fab.tools.tool import CompilerSuiteTool, Tool
 from pytest import raises
 from pytest_subprocess.fake_process import FakeProcess
 
 from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
-from fab.tools.category import Category
-from fab.tools.flags import ProfileFlags
-from fab.tools.tool import CompilerSuiteTool, Tool
-
 
 def test_constructor() -> None:
     """
-    Tests comstruction from argument list.
+    Tests construction from argument list.
     """
     tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
     assert str(tool) == "Tool - gnu: gfortran"


### PR DESCRIPTION
Correct various documentation links to reflect the proper repository name and fix minor typographical errors throughout the codebase.