### PR TITLE
479 added check of ignore_mod_deps for "DEPENDS ON:" comment analysis

### DIFF
--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -195,7 +195,9 @@ class FortranAnalyser(FortranAnalyserBase):
         :param std:
             The Fortran standard.
         :param ignore_mod_deps:
-            Module names to ignore in use statements.
+            Module names to ignore in use statements or
+            'DEPENDS ON' files to ignore or 'DEPENDS ON'
+            modules to ignore.
 
         """
         super().__init__(config=config,
@@ -372,8 +374,10 @@ class FortranAnalyser(FortranAnalyserBase):
         if depends_str in comment:
             self.depends_on_comment_found = True
             dep = comment.split(depends_str)[-1].strip()
+            if dep in self.ignore_mod_deps:
+                logger.debug(f"ignoring use of {dep}")
             # with .o means a c file
-            if dep.endswith(".o"):
+            elif dep.endswith(".o"):
                 analysed_file.mo_commented_file_deps.add(
                     dep.replace(".o", ".c"))
             # without .o means a fortran symbol

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -110,7 +110,7 @@ def analyse(
         Assuming the files containing these symbols are present and analysed,
         those files and all their dependencies will be added to the build tree(s).
     :param ignore_mod_deps:
-        Third party Fortran module names to be ignored.
+        Third party Fortran module names in USE statements, 'DEPENDS ON' files and modules to be ignored.
     :param name:
         Human friendly name for logger output, with sensible default.
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -92,6 +92,29 @@ class TestAnalyser:
         assert artefact == (fortran_analyser._config.prebuild_folder /
                             f'test_fortran_analyser.{analysis.file_hash}.an')
 
+    def test_module_file_ignore_mod_deps(self, fortran_analyser, module_fpath,
+                                         module_expected):
+        '''Test ignore_mod_deps parameter for fortran_analyser, meaning the
+        dependency on some_file.o ('DEPENDS ON' c file), monty_func ('DEPENDS
+        ON' fortran module) and compute_chunk_size_mod (Use fortran module)
+        should not be detected
+        '''
+        fortran_analyser.ignore_mod_deps = ['some_file.o', 'monty_func',
+                                            'compute_chunk_size_mod']
+        with mock.patch('fab.parse.AnalysedFile.save'):
+            analysis, artefact = fortran_analyser.run(fpath=module_fpath)
+
+        # With ignore_mod_deps, some_file.o, monty_func symbol and
+        # compute_chunk_size_mod symbol must not be added:
+        module_expected.mo_commented_file_deps = set()
+        module_expected.symbol_deps.remove('monty_func')
+        module_expected.module_deps.remove('compute_chunk_size_mod')
+        module_expected.symbol_deps.remove('compute_chunk_size_mod')
+
+        assert analysis == module_expected
+        assert artefact == (fortran_analyser._config.prebuild_folder /
+                            f'test_fortran_analyser.{analysis.file_hash}.an')
+
     def test_program_file(self, fortran_analyser, module_fpath,
                           module_expected):
         # same as test_module_file() but replacing MODULE with PROGRAM


### PR DESCRIPTION
This PR is for the issue #479.

This PR has added the check of ignore_mod_deps for "DEPENDS ON:" comment analysis. It has also added a test for the ignore_mod_deps parameter of Fortran Analyser, which confirms that fortran modules in USE statements and "DEPENDS ON:"  and c file in "DEPENDS ON:"  can be ignored.