### PR TITLE
Detect and error on duplicate module definitions

### DIFF
--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -66,18 +66,24 @@ class ArtefactStore(dict):
                 self[artefact] = set()
 
     def add(self, collection: Union[str, ArtefactSet],
-            files: Iterable[Path]):
+            files: Union[Path, Iterable[Path]]):
         '''Adds the specified artefacts to a collection. The artefact
-        can be specified as a simple string, a list of string or a set, in
-        which case all individual entries of the list/set will be added.
+        can be specified as a single Path or an iterable of Paths.
         :param collection: the name of the collection to add this to.
         :param files: the artefacts to add.
         '''
-        files = {files}
+
+        if isinstance(files, Path):
+            files = {files}
+        elif isinstance(files, list):
+            files = set(files)
+        elif not isinstance(files, Iterable):
+            files = {Path(files)}
+
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    values: Path,
+                    values: Union[Path, Iterable[Path]],
                     key: Optional[str] = None):
         """
         Modifies data associated with artefact set.

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -66,7 +66,7 @@ class ArtefactStore(dict):
                 self[artefact] = set()
 
     def add(self, collection: Union[str, ArtefactSet],
-            files: Union[Path, Iterable[Path]]):
+            files: Path):
         '''Adds the specified artefacts to a collection. The artefact
         can be specified as a simple string, a list of string or a set, in
         which case all individual entries of the list/set will be added.
@@ -77,7 +77,7 @@ class ArtefactStore(dict):
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    values: Union[Path, Iterable[Path]],
+                    values: Path,
                     key: Optional[str] = None):
         """
         Modifies data associated with artefact set.

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -66,7 +66,7 @@ class ArtefactStore(dict):
                 self[artefact] = set()
 
     def add(self, collection: Union[str, ArtefactSet],
-            files: Union[Path, str, Iterable[Path], Iterable[str]]):
+            files: Union[Path, Iterable[Path]]):
         '''Adds the specified artefacts to a collection. The artefact
         can be specified as a simple string, a list of string or a set, in
         which case all individual entries of the list/set will be added.
@@ -77,12 +77,12 @@ class ArtefactStore(dict):
             files = set(files)
         elif not isinstance(files, Iterable):
             # We need to use a list, otherwise each character is added
-            files = set([files])
+            files = set(Path(files))
 
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    values: Union[str, Iterable],
+                    values: Union[Path, Iterable[Path]],
                     key: Optional[str] = None):
         """
         Modifies data associated with artefact set.
@@ -92,7 +92,7 @@ class ArtefactStore(dict):
         :param key: Executable name associated with data. Do not specify for
                     libraries.
         """
-        self[collection][key].update([values] if isinstance(values, str)
+        self[collection][key].update([values] if isinstance(values, Path)
                                      else values)
 
     def copy_artefacts(self, source: Union[str, ArtefactSet],

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -66,7 +66,7 @@ class ArtefactStore(dict):
                 self[artefact] = set()
 
     def add(self, collection: Union[str, ArtefactSet],
-            files: Path):
+            files: Iterable[Path]):
         '''Adds the specified artefacts to a collection. The artefact
         can be specified as a simple string, a list of string or a set, in
         which case all individual entries of the list/set will be added.

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -68,15 +68,15 @@ class ArtefactStore(dict):
     def add(self, collection: Union[str, ArtefactSet],
             files: Union[Path, Iterable[Path]]):
         '''Adds the specified artefacts to a collection. The artefact
-        can be specified as a single Path or an iterable of Paths.
+        can be specified as a simple string, a list of string or a set, in
+        which case all individual entries of the list/set will be added.
         :param collection: the name of the collection to add this to.
         :param files: the artefacts to add.
         '''
-
-        if isinstance(files, Path):
-            files = {files}
-        elif isinstance(files, list):
+        if isinstance(files, list):
             files = set(files)
+        elif isinstance(files, Path):
+            files = {files}
         elif not isinstance(files, Iterable):
             files = {Path(files)}
 

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -73,12 +73,7 @@ class ArtefactStore(dict):
         :param collection: the name of the collection to add this to.
         :param files: the artefacts to add.
         '''
-        if isinstance(files, list):
-            files = set(files)
-        elif not isinstance(files, Iterable):
-            # We need to use a list, otherwise each character is added
-            files = set(Path(files))
-
+        files = {files}
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -34,7 +34,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 
 @step
 def archive_objects(config: BuildConfig,
-                    source: Optional[ArtefactsGetter]=None,
+                    source: Optional[ArtefactsGetter] = None,
                     output_fpath=None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -108,7 +108,6 @@ def archive_objects(config: BuildConfig,
     if not isinstance(ar, Ar):
         raise RuntimeError(f"Unexpected tool '{ar.name}' of type "
                            f"'{type(ar)}' instead of Ar")
-    output_fpath = str(output_fpath) if output_fpath else None
 
     target_objects = source_getter(config.artefact_store)
     assert target_objects.keys()

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -34,7 +34,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 @step
 def archive_objects(config: BuildConfig,
                     source: Optional[ArtefactsGetter] = None,
-                    output_fpath=None,
+                    output_fpath: Optional[str]=None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -10,8 +10,8 @@ Object archive creation from a list of object files for use in static linking.
 
 import logging
 from string import Template
-from typing import Optional,Union
-from pathlib import Path 
+from typing import Optional, Union
+from pathlib import Path
 
 
 from fab.artefacts import ArtefactSet

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -10,7 +10,7 @@ Object archive creation from a list of object files for use in static linking.
 
 import logging
 from string import Template
-from typing import Optional, Union
+from typing import Optional
 from pathlib import Path
 
 from fab.artefacts import ArtefactSet

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -13,7 +13,6 @@ from string import Template
 from typing import Optional, Union
 from pathlib import Path
 
-
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps import step

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -10,9 +10,9 @@ Object archive creation from a list of object files for use in static linking.
 
 import logging
 from string import Template
-from typing import Optional, Union
+from typing import Optional
 
-from pathlib import Path 
+
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps import step
@@ -34,8 +34,8 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 
 @step
 def archive_objects(config: BuildConfig,
-                    source: Optional[ArtefactsGetter] = None,
-                    output_fpath = None,
+                    source: Optional[ArtefactsGetter]=None,
+                    output_fpath=None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -35,7 +35,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 @step
 def archive_objects(config: BuildConfig,
                     source: Optional[ArtefactsGetter] = None,
-                    output_fpath: Optional[Union[str,Path]] = None,
+                    output_fpath = None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -10,7 +10,8 @@ Object archive creation from a list of object files for use in static linking.
 
 import logging
 from string import Template
-from typing import Optional
+from typing import Optional,Union
+from pathlib import Path 
 
 
 from fab.artefacts import ArtefactSet
@@ -35,7 +36,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 @step
 def archive_objects(config: BuildConfig,
                     source: Optional[ArtefactsGetter] = None,
-                    output_fpath=None,
+                    output_fpath: Optional[Union[str, Path]] = None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -121,12 +121,12 @@ def archive_objects(config: BuildConfig,
 
         if root:
             # we're building an object archive for an executable
-            output_fpath = str(config.build_output / f'{root}.a')
+            output_fpath = Path(str(config.build_output / f'{root}.a'))
         else:
             # we're building a single object archive with a given filename
             assert len(target_objects) == 1, "unexpected root of None with multiple build targets"
-            output_fpath = Template(str(output_fpath)).substitute(
-                output=config.build_output)
+            output_fpath = Path(Template(str(output_fpath)).substitute(
+                output=config.build_output))
 
         log_or_dot(logger, f"CreateObjectArchive running archiver for "
                            f"'{output_fpath}'.")

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -35,7 +35,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 @step
 def archive_objects(config: BuildConfig,
                     source: Optional[ArtefactsGetter] = None,
-                    output_fpath: Optional[Union[str, Path]] = None,
+                    output_fpath: Optional[Path] = None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -10,8 +10,9 @@ Object archive creation from a list of object files for use in static linking.
 
 import logging
 from string import Template
-from typing import Optional
+from typing import Optional, Union
 
+from pathlib import Path 
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
 from fab.steps import step
@@ -34,7 +35,7 @@ DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
 @step
 def archive_objects(config: BuildConfig,
                     source: Optional[ArtefactsGetter] = None,
-                    output_fpath: Optional[str]=None,
+                    output_fpath: Optional[Union[str,Path]] = None,
                     output_collection=ArtefactSet.OBJECT_ARCHIVES):
     """
     Create an object archive for every build target, from their object files.

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -21,7 +21,7 @@ class Ar(Tool):
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 
-    def create(self, output_fpath,
+    def create(self, output_fpath: Union[str, Path],
                members: List[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -21,7 +21,7 @@ class Ar(Tool):
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 
-    def create(self, output_fpath: Path,
+    def create(self, output_fpath,
                members: List[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -8,7 +8,7 @@
 """
 
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Optional
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -21,7 +21,7 @@ class Ar(Tool):
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 
-    def create(self, output_fpath: Path,
+    def create(self, output_fpath: Optional[Path],
                members: List[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -8,7 +8,7 @@
 """
 
 from pathlib import Path
-from typing import List, Union, Optional
+from typing import List, Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -31,7 +31,7 @@ class Ar(Tool):
         '''
         # Explicit type is required to avoid mypy errors :(
         if isinstance(output_fpath, str):
-            output_fpath = Path(output_fpath)    
+            output_fpath = Path(output_fpath)  
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -31,7 +31,7 @@ class Ar(Tool):
         '''
         # Explicit type is required to avoid mypy errors :(
         if isinstance(output_fpath, str):
-            output_fpath = Path(output_fpath)  
+            output_fpath = Path(output_fpath)
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -30,7 +30,8 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        output_fpath = Path(output_fpath)
+        if isinstance(output_fpath, str):
+            output_fpath = Path(output_fpath)    
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -21,7 +21,7 @@ class Ar(Tool):
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 
-    def create(self, output_fpath: Union[str, Path],
+    def create(self, output_fpath: Path,
                members: List[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.
@@ -30,8 +30,6 @@ class Ar(Tool):
         :param members: the list of objects to be added to the archive.
         '''
         # Explicit type is required to avoid mypy errors :(
-        if isinstance(output_fpath, str):
-            output_fpath = Path(output_fpath)
         output_fpath.unlink(missing_ok=True)
         parameters: List[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -21,7 +21,7 @@ class Ar(Tool):
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 
-    def create(self, output_fpath: Optional[Path],
+    def create(self, output_fpath: Path,
                members: List[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -81,7 +81,7 @@ class TestArchiveObjects:
         with warns(UserWarning,
                    match="_metric_send_conn not set, cannot send metrics"):
             archive_objects(config=config,
-                            output_fpath=config.build_output / 'mylib.a')
+                            output_fpath=Path(config.build_output / 'mylib.a'))
         assert call_list(fake_process) == [ar_command]
 
         # ensure the correct artefacts were created
@@ -101,7 +101,7 @@ class TestArchiveObjects:
 
         with raises(RuntimeError) as err:
             archive_objects(config=config,
-                            output_fpath=config.build_output / 'mylib.a')
+                            output_fpath=Path(config.build_output / 'mylib.a'))
         assert str(err.value) == ("Unexpected tool 'some C compiler' of type "
                                   "'<class 'fab.tools.compiler.CCompiler'>' "
                                   "instead of Ar")

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -56,7 +56,7 @@ class TestArchiveObjects:
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            target: {str(config.build_output / f'{target}.a')}
+            target: {Path(str(config.build_output / f'{target}.a'))}
             for target in targets}
 
     def test_for_library(self, stub_tool_box,
@@ -86,7 +86,7 @@ class TestArchiveObjects:
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            None: {str(config.build_output / 'mylib.a')}}
+            None: {Path(str(config.build_output / 'mylib.a'))}}
 
     def test_incorrect_tool(self, stub_tool_box):
         """

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -45,7 +45,7 @@ class TestArchiveObjects:
         for target in targets:
             config.artefact_store.update_dict(
                 ArtefactSet.OBJECT_FILES,
-                {f'{target}.o', 'util.o'},
+                {Path(f'{target}.o'), Path('util.o')},
                 target
             )
 
@@ -75,7 +75,7 @@ class TestArchiveObjects:
         config = BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab'),
                              multiprocessing=False)
         config.artefact_store.update_dict(
-            ArtefactSet.OBJECT_FILES, {'util1.o', 'util2.o'}, None
+            ArtefactSet.OBJECT_FILES, {Path('util1.o'), Path('util2.o')}, None
         )
 
         with warns(UserWarning,

--- a/tests/unit_tests/test_artefacts.py
+++ b/tests/unit_tests/test_artefacts.py
@@ -179,7 +179,7 @@ class TestFilterBuildTrees():
 def test_collection_getter() -> None:
     '''Test CollectionGetter.'''
     artefact_store = ArtefactStore()
-    artefact_store.add(ArtefactSet.INITIAL_SOURCE, ["a", "b", "c"])
+    artefact_store.add(ArtefactSet.INITIAL_SOURCE, [Path("a"), Path("b"), Path("c")])
     cg = CollectionGetter(ArtefactSet.INITIAL_SOURCE)
     assert artefact_store[ArtefactSet.INITIAL_SOURCE] == cg(artefact_store)
 


### PR DESCRIPTION
Instead of warnings being used when duplicate modules are detected, ideally the analysis code in `analyse.py` would give an error forcing the build to be aborted (as module names must be unique in order for dependency analysis to work).

This PR aims to fix this issue and once merged will close #406.