### PR TITLE
Replace RuntimeErrors with custom exceptions

### DIFF
--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -129,8 +129,7 @@ class ArtefactStore(dict):
 
         art_set = self[artefact]
         if not isinstance(art_set, set):
-            raise RuntimeError(f"Replacing artefacts in dictionary "
-                               f"'{artefact}' is not supported.")
+            raise ValueError(f"{artefact.name} is not mutable")
         art_set.difference_update(set(remove_files))
         art_set.update(add_files)
 

--- a/source/fab/errors.py
+++ b/source/fab/errors.py
@@ -1,0 +1,312 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Custom exception classes designed to replace generic RuntimeError
+exceptions originally used in fab.
+"""
+
+from typing import Optional, Union
+
+
+class FabError(RuntimeError):
+    """Base class for all fab specific exceptions.
+
+    :param message: reason for the exception
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class FabToolError(FabError):
+    """Base class for fab tool and toolbox exceptions.
+
+    :param tool: name of the current tool or category
+    :param message: reason for the exception
+    """
+
+    def __init__(self, tool: str, message: str) -> None:
+        self.tool = tool
+        super().__init__(f"[{tool}] {message}")
+
+
+class FabToolMismatch(FabToolError):
+    """Tool and category mismatch.
+
+    Error when a tool category does not match the expected setting.
+
+    :param tool: name of the current tool
+    :param category: name of the current category
+    :param expectedd: name of the correct category
+    """
+
+    def __init__(self, tool: str, category: str, expected: str) -> None:
+        self.category = category
+        self.expected = expected
+
+        super().__init__(tool, f"got type {category} instead of {expected}")
+
+
+class FabToolInvalidVersion(FabToolError):
+    """Version format problem.
+
+    Error when version information cannot be extracted from a specific
+    tool.  Where a version pattern is available, report this as part
+    of the error.
+
+    :param tool: name of the current tool
+    :param value: output from the query command
+    :param expected: optional format of version string
+    """
+
+    def __init__(self, tool: str, value: str, expected: Optional[str] = None) -> None:
+        self.value = value
+        self.expected = expected
+
+        message = f"invalid version {repr(self.value)}"
+        if expected is not None:
+            message += f" should be {repr(expected)}"
+
+        super().__init__(tool, message)
+
+
+class FabToolPsycloneAPI(FabToolError):
+    """PSyclone API and target problem.
+
+    Error when the specified PSyclone API, which can be empty to
+    indicate DSL mode, and the associated target do not match.
+
+    :param api: the current API or empty for DSL mode
+    :param target: the name of the target
+    :param present: optionally whether the target is present or
+        absent.  Used to format the error message.  Defaults to False.
+    """
+
+    def __init__(
+        self, api: Union[str, None], target: str, present: Optional[bool] = False
+    ) -> None:
+        self.target = target
+        self.present = present
+        self.api = api
+
+        message = "called "
+        if api:
+            message += f"with {api} API "
+        else:
+            message += "without API "
+        if present:
+            message += "and with "
+        else:
+            message += "but not with "
+        message += f"{target}"
+
+        super().__init__("psyclone", message)
+
+
+class FabToolNotAvailable(FabToolError):
+    """An unavailable tool has been requested.
+
+    Error where a tool which is not available in a particular suite of
+    tools has been requested.
+
+    :param tool: name of the current tool
+    :param suite: optional name of the current tool suite
+    """
+
+    def __init__(self, tool: str, suite: Optional[str] = None) -> None:
+        message = "not available"
+        if suite:
+            message += f" in suite {suite}"
+        super().__init__(tool, message)
+
+
+class FabToolInvalidSetting(FabToolError):
+    """An invalid tool setting has been requested.
+
+    Error where an invalid setting, e.g. MPI, has been requested for a
+    particular tool.
+
+    :param setting_type: name of the invalid setting
+    :param tool: the tool to which setting applies
+    :param additional: optional additional information
+    """
+
+    # FIXME: improve these here and in tool_repository
+
+    def __init__(
+        self, setting_type: str, tool: str, additional: Optional[str] = None
+    ) -> None:
+        self.setting_type = setting_type
+
+        message = f"invalid {setting_type}"
+        if additional:
+            message += f" {additional}"
+
+        super().__init__(tool, message)
+
+
+class FabUnknownLibraryError(FabError):
+    """An unknown library has been requested.
+
+    Error where an library which is not known to the current Linker
+    instance is requested.
+
+    :param library: the name of the unknown library
+    """
+
+    def __init__(self, library: str) -> None:
+        self.library = library
+        super().__init__(f"unknown library {library}")
+
+
+class FabCommandError(FabError):
+    """An error was encountered running a subcommand.
+
+    Error where a subcommand run by the fab framework returned with a
+    non-zero exit code.  The exit code plus any data from the stdout
+    and stderr streams are retained to allow them to be passed back up
+    the calling stack.
+
+    :param command: the command being run
+    :param code: the command return code from the OS
+    :param output: output stream from the command
+    :param error: error stream from the command
+    """
+
+    def __init__(
+        self,
+        command: str,
+        code: int,
+        output: Union[str, bytes, None],
+        error: Union[str, bytes, None],
+        cwd: Optional[str] = None,
+    ) -> None:
+        if isinstance(command, list):
+            self.command: str = " ".join(command)
+        else:
+            self.command = str(command)
+        self.code = int(code)
+        self.output = self._decode(output)
+        self.error = self._decode(error)
+        self.cwd = cwd
+        super().__init__(f"command {repr(self.command)} returned {code}")
+
+    def _decode(self, value: Union[str, bytes, None]) -> str:
+        """Convert from bytes to a string as necessary."""
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode()
+        return value
+
+
+class FabCommandNotFound(FabError):
+    """Target command could not be found by subprocess.
+
+    Error where the target command passed to a subprocess call could
+    not be found.
+
+    :param command: the target command.  For clarity, only the first
+        item is used in the error message but the entire command is
+        preserved for inspection by the caller.
+    """
+
+    def __init__(self, command: str) -> None:
+        self.command = command
+        if isinstance(command, list):
+            self.target: str = command[0]
+        elif isinstance(command, str):
+            self.target = command.split()[0]
+        else:
+            raise ValueError(f"invalid command: {command}")
+
+        super().__init__(f"unable to execute {self.target}")
+
+
+class FabMultiCommandError(FabError):
+    """Unpack multiple exceptions into a single one.
+
+    Error which combines all potential exceptions raised by a
+    multiprocessing section into a single exception class for
+    subsequent inspection.
+
+    This feature is is required because versions of python prior to
+    3.11 do not support ExceptionGroups.
+
+    :param errors: a list ot exceptions
+    :param label: an identifier for the multiprocessing section
+    """
+
+    def __init__(self, errors: str, label: Optional[str] = None) -> None:
+        self.errors = errors
+        self.label = label or "during multiprocessing"
+
+        message = f"{len(errors)} exception"
+        message += " " if len(errors) == 1 else "s "
+        message += f"{self.label}"
+
+        super().__init__(message)
+
+
+class FabSourceError(FabError):
+    """Base class for source code management exceptions."""
+
+
+class FabSourceNoFilesError(FabSourceError):
+    """No source files were found.
+
+    Error where no source files have been once any filtering rules
+    have been applied.
+
+    """
+
+    def __init__(self) -> None:
+        super().__init__("no source files found after filtering")
+
+
+class FabSourceMergeError(FabSourceError):
+    """Version control merge has failed.
+
+    Error where the underlying version control system has failed to
+    automatically merge source code changes, e.g. because of a source
+    conflict that requires manual resolution.
+
+    :param tool: name of the version control system
+    :param reason: reason/error output from the version control system
+        indicating why the merge failed
+    :param revision: optional name of the specific revision being
+        targeted
+    """
+
+    def __init__(self, tool: str, reason: str, revision: Optional[str] = None) -> None:
+        self.tool = tool
+        self.reason = reason
+
+        message = f"[{tool}] merge "
+        if revision:
+            message += f"of {revision} "
+        message += f"failed: {reason}"
+
+        super().__init__(message)
+
+
+class FabSourceFetchError(FabSourceError):
+    """An attempt to fetch source files has failed.
+
+    Error where a specific set of files could not be fetched,
+    e.g. from a location containing prebuild files.
+
+    :params source: location of the source files
+    :param reason: reason for the failure
+    """
+
+    def __init__(self, source: str, reason: str) -> None:
+        self.source = source
+        self.reason = reason
+        super().__init__(f"could not fetch {source}: {reason}")

--- a/source/fab/steps/__init__.py
+++ b/source/fab/steps/__init__.py
@@ -11,6 +11,8 @@ from typing import Iterable, Optional, Union
 
 from fab.metrics import send_metric
 from fab.util import by_type, TimerLogger
+from fab.errors import FabMultiCommandError
+
 from functools import wraps
 
 
@@ -96,7 +98,4 @@ def check_for_errors(results: Iterable[Union[str, Exception]],
 
     exceptions = list(by_type(results, Exception))
     if exceptions:
-        formatted_errors = "\n\n".join(map(str, exceptions))
-        raise RuntimeError(
-            f"{formatted_errors}\n\n{len(exceptions)} error(s) found {caller_label}"
-        )
+        raise FabMultiCommandError(exceptions, caller_label)

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -19,6 +19,8 @@ from fab.util import log_or_dot
 from fab.tools import Ar, Category
 from fab.artefacts import ArtefactsGetter, CollectionGetter
 
+from fab.errors import FabToolMismatch, FabCommandError
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SOURCE_GETTER = CollectionGetter(ArtefactSet.OBJECT_FILES)
@@ -105,8 +107,7 @@ def archive_objects(config: BuildConfig,
     source_getter = source or DEFAULT_SOURCE_GETTER
     ar = config.tool_box[Category.AR]
     if not isinstance(ar, Ar):
-        raise RuntimeError(f"Unexpected tool '{ar.name}' of type "
-                           f"'{type(ar)}' instead of Ar")
+        raise FabToolMismatch(ar.name, type(ar), "Ar")
     output_fpath = str(output_fpath) if output_fpath else None
 
     target_objects = source_getter(config.artefact_store)
@@ -133,6 +134,6 @@ def archive_objects(config: BuildConfig,
         try:
             ar.create(output_fpath, sorted(objects))
         except RuntimeError as err:
-            raise RuntimeError(f"error creating object archive:\n{err}") from err
+            raise FabCommandError(f"error creating object archive:\n{err}") from err
 
         config.artefact_store.update_dict(output_collection, output_fpath, root)

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -21,6 +21,8 @@ from fab.steps import check_for_errors, run_mp, step
 from fab.tools import Category, Compiler, Flags
 from fab.util import CompiledFile, log_or_dot, Timer, by_type
 
+from fab.errors import FabToolMismatch
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SOURCE_GETTER = FilterBuildTrees(suffix='.c')
@@ -123,8 +125,7 @@ def _compile_file(arg: Tuple[AnalysedC, MpCommonArgs]):
     config = mp_payload.config
     compiler = config.tool_box[Category.C_COMPILER]
     if compiler.category != Category.C_COMPILER:
-        raise RuntimeError(f"Unexpected tool '{compiler.name}' of category "
-                           f"'{compiler.category}' instead of CCompiler")
+        raise FabToolMismatch(compiler.name, compiler.category, "CCompiler")
     # Tool box returns a Tool, in order to make mypy happy, we need
     # to cast it to be a Compiler.
     compiler = cast(Compiler, compiler)

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -25,6 +25,8 @@ from fab.tools import Category, Compiler, Flags
 from fab.util import (CompiledFile, log_or_dot_finish, log_or_dot, Timer,
                       by_type, file_checksum)
 
+from fab.errors import FabToolMismatch
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SOURCE_GETTER = FilterBuildTrees(suffix=['.f', '.f90'])
@@ -133,8 +135,7 @@ def handle_compiler_args(config: BuildConfig, common_flags=None,
     # Command line tools are sometimes specified with flags attached.
     compiler = config.tool_box[Category.FORTRAN_COMPILER]
     if compiler.category != Category.FORTRAN_COMPILER:
-        raise RuntimeError(f"Unexpected tool '{compiler.name}' of category "
-                           f"'{compiler.category}' instead of FortranCompiler")
+        raise FabToolMismatch(compiler.name, compiler.category, "FortranCompiler")
     # The ToolBox returns a Tool. In order to make mypy happy, we need to
     # cast this to become a Compiler.
     compiler = cast(Compiler, compiler)
@@ -264,9 +265,7 @@ def process_file(arg: Tuple[AnalysedFortran, MpCommonArgs]) \
         compiler = config.tool_box.get_tool(Category.FORTRAN_COMPILER,
                                             config.mpi)
         if compiler.category != Category.FORTRAN_COMPILER:
-            raise RuntimeError(f"Unexpected tool '{compiler.name}' of "
-                               f"category '{compiler.category}' instead of "
-                               f"FortranCompiler")
+            raise FabToolMismatch(compiler.name, compiler.category, "FortranCompiler")
         # The ToolBox returns a Tool, but we need to tell mypy that
         # this is a Compiler
         compiler = cast(Compiler, compiler)

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -13,6 +13,7 @@ from typing import Optional, Iterable
 from fab.artefacts import ArtefactSet
 from fab.steps import step
 from fab.util import file_walk
+from fab.errors import FabSourceNoFilesError
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ def find_source_files(config, source_root=None,
             logger.debug(f"excluding {fpath}")
 
     if not filtered_fpaths:
-        raise RuntimeError("no source files found after filtering")
+        raise FabSourceNoFilesError()
 
     config.artefact_store.add(output_collection, filtered_fpaths)
 

--- a/source/fab/steps/grab/prebuild.py
+++ b/source/fab/steps/grab/prebuild.py
@@ -6,6 +6,7 @@
 from fab.steps import step
 from fab.steps.grab import logger
 from fab.tools import Category
+from fab.errors import FabSourceFetchError
 
 
 @step
@@ -28,4 +29,4 @@ def grab_pre_build(config, path, allow_fail=False):
         msg = f"could not grab pre-build '{path}':\n{err}"
         logger.warning(msg)
         if not allow_fail:
-            raise RuntimeError(msg) from err
+            raise FabSourceFetchError(path, err) from err

--- a/source/fab/steps/grab/svn.py
+++ b/source/fab/steps/grab/svn.py
@@ -15,6 +15,7 @@ import xml.etree.ElementTree as ET
 
 from fab.steps import step
 from fab.tools import Category, Versioning
+from fab.errors import FabSourceMergeError
 
 
 def _get_revision(src, revision=None) -> Tuple[str, Union[str, None]]:
@@ -124,6 +125,6 @@ def check_conflict(tool: Versioning, dst: Union[str, Path]):
             for element in entry:
                 if (element.tag == 'wc-status' and
                         element.attrib['item'] == 'conflicted'):
-                    raise RuntimeError(f'{tool} merge encountered a '
-                                       f'conflict:\n{xml_str}')
+                    raise FabSourceMergeError("svn", xml_str)
+
     return False

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -22,6 +22,8 @@ from fab.tools import Category, Cpp, CppFortran, Preprocessor
 from fab.util import (log_or_dot_finish, input_to_output_fpath, log_or_dot,
                       suffix_filter, Timer, by_type)
 
+from fab.errors import FabToolMismatch
+
 logger = logging.getLogger(__name__)
 
 
@@ -150,8 +152,7 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
 
     fpp = config.tool_box[Category.FORTRAN_PREPROCESSOR]
     if not isinstance(fpp, CppFortran):
-        raise RuntimeError(f"Unexpected tool '{fpp.name}' of type "
-                           f"'{type(fpp)}' instead of CppFortran")
+        raise FabToolMismatch(fpp.name, type(fpp), "CppFortran")
 
     try:
         common_flags = kwargs.pop('common_flags')
@@ -223,8 +224,7 @@ def preprocess_c(config: BuildConfig,
     source_files = source_getter(config.artefact_store)
     cpp = config.tool_box[Category.C_PREPROCESSOR]
     if not isinstance(cpp, Cpp):
-        raise RuntimeError(f"Unexpected tool '{cpp.name}' of type "
-                           f"'{type(cpp)}' instead of Cpp")
+        raise FabToolMismatch(cpp.name, type(cpp), "Cpp")
 
     pre_processor(
         config,

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -29,6 +29,8 @@ from fab.util import (log_or_dot, input_to_output_fpath, file_checksum,
                       file_walk, TimerLogger, string_checksum, suffix_filter,
                       by_type, log_or_dot_finish)
 
+from fab.errors import FabToolMismatch
+
 logger = logging.getLogger(__name__)
 
 
@@ -303,8 +305,8 @@ def do_one_file(arg: Tuple[Path, MpCommonArgs]):
         config = mp_payload.config
         psyclone = config.tool_box[Category.PSYCLONE]
         if not isinstance(psyclone, Psyclone):
-            raise RuntimeError(f"Unexpected tool '{psyclone.name}' of type "
-                               f"'{type(psyclone)}' instead of Psyclone")
+            raise FabToolMismatch(psyclone.name, type(psyclone), "Psyclone")
+
         try:
             transformation_script = mp_payload.transformation_script
             logger.info(f"running psyclone on '{x90_file}'.")

--- a/source/fab/tools/compiler_wrapper.py
+++ b/source/fab/tools/compiler_wrapper.py
@@ -14,6 +14,8 @@ from typing import cast, List, Optional, TYPE_CHECKING, Union
 from fab.tools.category import Category
 from fab.tools.compiler import Compiler, FortranCompiler
 from fab.tools.flags import Flags
+from fab.errors import FabToolError
+
 if TYPE_CHECKING:
     from fab.build_config import BuildConfig
 
@@ -68,8 +70,7 @@ class CompilerWrapper(Compiler):
         if self._compiler.category == Category.FORTRAN_COMPILER:
             return cast(FortranCompiler, self._compiler).has_syntax_only
 
-        raise RuntimeError(f"Compiler '{self._compiler.name}' has "
-                           f"no has_syntax_only.")
+        raise FabToolError(self._compiler.name, "no syntax-only feature")
 
     def get_flags(self, profile: Optional[str] = None) -> List[str]:
         ''':returns: the ProfileFlags for the given profile, combined
@@ -90,8 +91,7 @@ class CompilerWrapper(Compiler):
         '''
 
         if self._compiler.category != Category.FORTRAN_COMPILER:
-            raise RuntimeError(f"Compiler '{self._compiler.name}' has no "
-                               f"'set_module_output_path' function.")
+            raise FabToolError(self._compiler.name, "no module output path feature")
         cast(FortranCompiler, self._compiler).set_module_output_path(path)
 
     def get_all_commandline_options(
@@ -141,8 +141,7 @@ class CompilerWrapper(Compiler):
         else:
             # It's not valid to specify syntax_only for a non-Fortran compiler
             if syntax_only is not None:
-                raise RuntimeError(f"Syntax-only cannot be used with compiler "
-                                   f"'{self.name}'.")
+                raise FabToolError(self._compiler.name, "syntax-only is Fortran-specific")
             flags = self._compiler.get_all_commandline_options(
                     config, input_file, output_file, add_flags=add_flags)
 

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -17,6 +17,7 @@ from fab.tools.category import Category
 from fab.tools.compiler import Compiler
 from fab.tools.flags import ProfileFlags
 from fab.tools.tool import CompilerSuiteTool
+from fab.errors import FabUnknownLibraryError
 if TYPE_CHECKING:
     from fab.build_config import BuildConfig
 
@@ -138,7 +139,7 @@ class Linker(CompilerSuiteTool):
             # another linker, return the result from the wrapped linker
             if self._linker:
                 return self._linker.get_lib_flags(lib)
-            raise RuntimeError(f"Unknown library name: '{lib}'") from err
+            raise FabUnknownLibraryError(lib) from err
 
     def add_lib_flags(self, lib: str, flags: List[str],
                       silent_replace: bool = False):

--- a/source/fab/tools/psyclone.py
+++ b/source/fab/tools/psyclone.py
@@ -14,6 +14,7 @@ import warnings
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
+from fab.errors import FabToolPsycloneAPI, FabToolNotAvailable
 
 if TYPE_CHECKING:
     # TODO 314: see if this circular dependency can be broken
@@ -90,7 +91,7 @@ class Psyclone(Tool):
         '''
 
         if not self.is_available:
-            raise RuntimeError("PSyclone is not available.")
+            raise FabToolNotAvailable("psyclone")
 
         # Convert the old style API nemo to be empty
         if api and api.lower() == "nemo":
@@ -100,24 +101,23 @@ class Psyclone(Tool):
             # API specified, we need both psy- and alg-file, but not
             # transformed file.
             if not psy_file:
-                raise RuntimeError(f"PSyclone called with api '{api}', but "
-                                   f"no psy_file is specified.")
+                raise FabToolPsycloneAPI(api, "psy_file")
+
             if not alg_file:
-                raise RuntimeError(f"PSyclone called with api '{api}', but "
-                                   f"no alg_file is specified.")
+                raise FabToolPsycloneAPI(api, "alg_file")
+
             if transformed_file:
-                raise RuntimeError(f"PSyclone called with api '{api}' and "
-                                   f"transformed_file.")
+                raise FabToolPsycloneAPI(api, "transformed_file", True)
+
         else:
             if psy_file:
-                raise RuntimeError("PSyclone called without api, but "
-                                   "psy_file is specified.")
+                raise FabToolPsycloneAPI(api, "psy_file", True)
+
             if alg_file:
-                raise RuntimeError("PSyclone called without api, but "
-                                   "alg_file is specified.")
+                raise FabToolPsycloneAPI(api, "alg_file", True)
+
             if not transformed_file:
-                raise RuntimeError("PSyclone called without api, but "
-                                   "transformed_file is not specified.")
+                raise FabToolPsycloneAPI(api, "transformed_file")
 
         parameters: List[Union[str, Path]] = []
         # If an api is defined in this call (or in the constructor) add it

--- a/source/fab/tools/tool_box.py
+++ b/source/fab/tools/tool_box.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
+from fab.errors import FabToolNotAvailable
 
 
 class ToolBox:
@@ -37,7 +38,7 @@ class ToolBox:
         :raises RuntimeError: if the tool to be added is not available.
         '''
         if not tool.is_available:
-            raise RuntimeError(f"Tool '{tool}' is not available.")
+            raise FabToolNotAvailable(tool)
 
         if tool.category in self._all_tools and not silent_replace:
             warnings.warn(f"Replacing existing tool "

--- a/source/fab/tools/versioning.py
+++ b/source/fab/tools/versioning.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
+from fab.errors import FabSourceMergeError
 
 
 class Versioning(Tool, ABC):
@@ -108,8 +109,7 @@ class Git(Versioning):
             self.run(['merge', 'FETCH_HEAD'], cwd=dst, capture_output=False)
         except RuntimeError as err:
             self.run(['merge', '--abort'], cwd=dst, capture_output=False)
-            raise RuntimeError(f"Error merging {revision}. "
-                               f"Merge aborted.\n{err}") from err
+            raise FabSourceMergeError("git", err, revision) from err
 
 
 # =============================================================================

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -19,6 +19,8 @@ from fab.build_config import BuildConfig
 from fab.steps.archive_objects import archive_objects
 from fab.tools import Category, ToolRepository
 
+from fab.errors import FabToolMismatch
+
 
 class TestArchiveObjects:
     """
@@ -116,6 +118,6 @@ class TestArchiveObjects:
         with raises(RuntimeError) as err:
             archive_objects(config=config,
                             output_fpath=config.build_output / 'mylib.a')
-        assert str(err.value) == ("Unexpected tool 'some C compiler' of type "
-                                  "'<class 'fab.tools.compiler.CCompiler'>' "
-                                  "instead of Ar")
+        assert isinstance(err.value, FabToolMismatch)
+        assert str(err.value) == ("[some C compiler] got type "
+                                  "<class 'fab.tools.compiler.CCompiler'> instead of Ar")

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -20,6 +20,8 @@ from fab.tools.category import Category
 from fab.tools.flags import Flags
 from fab.tools.tool_box import ToolBox
 
+from fab.errors import FabToolMismatch
+
 
 @fixture(scope='function')
 def content(tmp_path: Path, stub_tool_box: ToolBox):
@@ -62,8 +64,9 @@ def test_compile_c_wrong_compiler(content, fake_process: FakeProcess) -> None:
     mp_common_args = Mock(config=config)
     with raises(RuntimeError) as err:
         _compile_file((Mock(), mp_common_args))
-    assert str(err.value) == ("Unexpected tool 'some C compiler' of category "
-                              "'FORTRAN_COMPILER' instead of CCompiler")
+    assert isinstance(err.value, FabToolMismatch)
+    assert str(err.value) == ("[some C compiler] got type "
+                              "FORTRAN_COMPILER instead of CCompiler")
 
 
 # This is more of an integration test than a unit test

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -18,6 +18,8 @@ from fab.tools.category import Category
 from fab.tools.tool_box import ToolBox
 from fab.util import CompiledFile
 
+from fab.errors import FabToolMismatch
+
 
 @fixture(scope='function')
 def analysed_files():
@@ -60,15 +62,17 @@ def test_compile_cc_wrong_compiler(stub_tool_box,
     mp_common_args = Mock(config=config)
     with raises(RuntimeError) as err:
         process_file((Mock(), mp_common_args))
+    assert isinstance(err.value, FabToolMismatch)
     assert str(err.value) \
-           == "Unexpected tool 'some Fortran compiler' of category " \
-              + "'C_COMPILER' instead of FortranCompiler"
+           == "[some Fortran compiler] got type " \
+              + "C_COMPILER instead of FortranCompiler"
 
     with raises(RuntimeError) as err:
         handle_compiler_args(config)
+    assert isinstance(err.value, FabToolMismatch)
     assert str(err.value) \
-        == "Unexpected tool 'some Fortran compiler' of category " \
-           + "'C_COMPILER' instead of FortranCompiler"
+        == "[some Fortran compiler] got type " \
+           + "C_COMPILER instead of FortranCompiler"
 
 
 class TestCompilePass:

--- a/tests/unit_tests/steps/test_preprocess.py
+++ b/tests/unit_tests/steps/test_preprocess.py
@@ -13,6 +13,8 @@ from fab.steps.preprocess import preprocess_fortran
 from fab.tools.category import Category
 from fab.tools.tool_box import ToolBox
 
+from fab.errors import FabToolMismatch
+
 
 class Test_preprocess_fortran:
 
@@ -68,5 +70,6 @@ class Test_preprocess_fortran:
         config = BuildConfig('proj', tool_box, fab_workspace=tmp_path)
         with raises(RuntimeError) as err:
             preprocess_fortran(config=config)
-        assert str(err.value) == "Unexpected tool 'cpp' of type '<class " \
-            "'fab.tools.preprocessor.Cpp'>' instead of CppFortran"
+        assert isinstance(err.value, FabToolMismatch)
+        assert str(err.value) == "[cpp] got type <class " \
+            "'fab.tools.preprocessor.Cpp'> instead of CppFortran"

--- a/tests/unit_tests/test_artefacts.py
+++ b/tests/unit_tests/test_artefacts.py
@@ -84,11 +84,10 @@ def test_artefact_store_replace() -> None:
                                                               Path("c")])
 
     # Test the behaviour for dictionaries
-    with pytest.raises(RuntimeError) as err:
+    with pytest.raises(ValueError) as err:
         artefact_store.replace(ArtefactSet.OBJECT_FILES,
                                remove_files=[Path("a")], add_files=["c"])
-    assert ("Replacing artefacts in dictionary 'ArtefactSet.OBJECT_FILES' "
-            "is not supported" in str(err.value))
+    assert str(err.value) == "OBJECT_FILES is not mutable"
 
 
 def test_artefacts_getter():

--- a/tests/unit_tests/test_cui_arguments.py
+++ b/tests/unit_tests/test_cui_arguments.py
@@ -101,7 +101,7 @@ class TestFabFile:
         assert exc.value.code == 2
 
         captured = capsys.readouterr()
-        assert "error: fab file does not exist" in captured.err
+        assert "fab file does not exist" in captured.err
 
     def test_user_file_missing_arg(self, capsys):
         """Check missing file name triggers an error."""

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1,0 +1,164 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Unit tests for custom fab exceptions.
+"""
+
+import pytest
+from fab.errors import (
+    FabError,
+    FabToolError,
+    FabToolMismatch,
+    FabToolInvalidVersion,
+    FabToolPsycloneAPI,
+    FabToolNotAvailable,
+    FabToolInvalidSetting,
+    FabCommandError,
+    FabCommandNotFound,
+    FabMultiCommandError,
+    FabSourceNoFilesError,
+    FabSourceMergeError,
+    FabSourceFetchError,
+    FabUnknownLibraryError,
+)
+
+
+class TestErrors:
+    """Basic tests for the FabError class hierarchy."""
+
+    def test_base(self):
+        """Test the base Fab error class."""
+
+        err = FabError("test message")
+        assert str(err) == "test message"
+
+    def test_unknown_library(self):
+        """Test unknown library errors."""
+
+        err = FabUnknownLibraryError("mylib")
+        assert str(err) == "unknown library mylib"
+
+
+class TestToolErrors:
+    """Test the FabToolError hierarchy."""
+
+    def test_tool_base(self):
+        """Test the base FabToolError class."""
+
+        err = FabToolError("cc", "compiler message")
+        assert str(err) == "[cc] compiler message"
+
+    def test_mismatch(self):
+        """Test tool type mismatch class."""
+
+        err = FabToolMismatch("cc", "CCompiler", "Ar")
+        assert str(err) == "[cc] got type CCompiler instead of Ar"
+
+    def test_invalid_version(self):
+        """Test invalid version class."""
+
+        err = FabToolInvalidVersion("cc", "abc")
+        assert str(err) == "[cc] invalid version 'abc'"
+
+        err = FabToolInvalidVersion("cc", "abc", "VV.NN")
+        assert str(err) == "[cc] invalid version 'abc' should be 'VV.NN'"
+
+    def test_psyclone_api(self):
+        """Test PSyclone API  class."""
+
+        err = FabToolPsycloneAPI(None, "alg_file")
+        assert str(err) == "[psyclone] called without API but not with alg_file"
+
+        err = FabToolPsycloneAPI("nemo", "alg_file")
+        assert str(err) == "[psyclone] called with nemo API but not with alg_file"
+
+        err = FabToolPsycloneAPI("nemo", "alg_file", present=True)
+        assert str(err) == "[psyclone] called with nemo API and with alg_file"
+
+    def test_not_available(self):
+        """Test tool not available class."""
+
+        err = FabToolNotAvailable("psyclone")
+        assert str(err) == "[psyclone] not available"
+
+        err = FabToolNotAvailable("gfortran", "GCC")
+        assert str(err) == "[gfortran] not available in suite GCC"
+
+    def test_invalid_setting(self):
+        """Test invalid setting class."""
+
+        err = FabToolInvalidSetting("category", "compiler")
+        assert str(err) == "[compiler] invalid category"
+
+        err = FabToolInvalidSetting("category", "compiler", "nosuch")
+        assert str(err) == "[compiler] invalid category nosuch"
+
+
+class TestCommandErrors:
+    """Test various command errors."""
+
+    def test_command(self):
+        """Test FabCommandError in various configurations."""
+
+        err = FabCommandError(["ls", "-l", "/nosuch"], 1, b"", b"ls: cannot", "/")
+        assert str(err) == "command 'ls -l /nosuch' returned 1"
+
+        err = FabCommandError("ls -l /nosuch", 1, None, "ls: cannot", "/")
+        assert str(err) == "command 'ls -l /nosuch' returned 1"
+
+    def test_not_found(self):
+        """Test command not found errors."""
+
+        err = FabCommandNotFound(["ls", "-l"])
+        assert str(err) == "unable to execute ls"
+
+        err = FabCommandNotFound("ls -l")
+        assert str(err) == "unable to execute ls"
+
+        with pytest.raises(ValueError) as exc:
+            FabCommandNotFound({"a": 1})
+        assert "invalid command" in str(exc.value)
+
+    def test_multi(self):
+        """Test multiprocessing command errors."""
+
+        err = FabMultiCommandError([ValueError("invalid value")])
+        assert str(err) == "1 exception during multiprocessing"
+
+        err = FabMultiCommandError(
+            [ValueError("invalid value"), TypeError("invalid type")]
+        )
+        assert str(err) == "2 exceptions during multiprocessing"
+
+        err = FabMultiCommandError(
+            [ValueError("invalid value"), TypeError("invalid type")], "during psyclone"
+        )
+        assert str(err) == "2 exceptions during psyclone"
+
+
+class TestSourceErrors:
+    """Test the source errors hierarchy."""
+
+    def test_no_files(self):
+        """Test lack of source files."""
+
+        err = FabSourceNoFilesError()
+        assert str(err) == "no source files found after filtering"
+
+    def test_merge(self):
+        """Test merge errors."""
+
+        err = FabSourceMergeError("git", "conflicting source files")
+        assert str(err) == "[git] merge failed: conflicting source files"
+
+        err = FabSourceMergeError("git", "conflicting source files", "vn1.1")
+        assert str(err) == "[git] merge of vn1.1 failed: conflicting source files"
+
+    def test_fetch(self):
+        """Test fetch errors."""
+
+        err = FabSourceFetchError("/my/dir1", "no such directory")
+        assert str(err) == "could not fetch /my/dir1: no such directory"

--- a/tests/unit_tests/tools/test_compiler_wrapper.py
+++ b/tests/unit_tests/tools/test_compiler_wrapper.py
@@ -19,6 +19,7 @@ from fab.tools.compiler import CCompiler, FortranCompiler
 from fab.tools.compiler_wrapper import (CompilerWrapper,
                                         CrayCcWrapper, CrayFtnWrapper,
                                         Mpicc, Mpif90)
+from fab.errors import FabToolError
 
 
 def test_compiler_getter(stub_c_compiler: CCompiler) -> None:
@@ -141,8 +142,8 @@ def test_syntax_only(stub_c_compiler: CCompiler) -> None:
     mpicc = Mpicc(stub_c_compiler)
     with raises(RuntimeError) as err:
         _ = mpicc.has_syntax_only
-    assert (str(err.value) == "Compiler 'some C compiler' has no "
-                              "has_syntax_only.")
+    assert isinstance(err.value, FabToolError)
+    assert str(err.value) == "[some C compiler] no syntax-only feature"
 
 
 def test_module_output(stub_fortran_compiler: FortranCompiler,
@@ -162,8 +163,8 @@ def test_module_output(stub_fortran_compiler: FortranCompiler,
     mpicc = Mpicc(stub_c_compiler)
     with raises(RuntimeError) as err:
         mpicc.set_module_output_path(Path("/tmp"))
-    assert str(err.value) == ("Compiler 'some C compiler' has "
-                              "no 'set_module_output_path' function.")
+    assert isinstance(err.value, FabToolError)
+    assert str(err.value) == "[some C compiler] no module output path feature"
 
 
 def test_fortran_with_add_args(stub_fortran_compiler: FortranCompiler,
@@ -233,8 +234,8 @@ def test_c_with_add_args(stub_c_compiler: CCompiler,
         mpicc.compile_file(Path("a.f90"), Path('a.o'),
                            add_flags=["-O3"], syntax_only=True,
                            config=stub_configuration)
-    assert (str(err.value) == "Syntax-only cannot be used with compiler "
-                              "'mpicc-some C compiler'.")
+    assert isinstance(err.value, FabToolError)
+    assert (str(err.value) == "[some C compiler] syntax-only is Fortran-specific")
 
     # Check that providing the openmp flag in add_flag raises a warning:
     with warns(UserWarning,

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -124,7 +124,7 @@ def test_get_lib_flags_unknown(stub_c_compiler: CCompiler) -> None:
     linker = Linker(compiler=stub_c_compiler)
     with raises(RuntimeError) as err:
         linker.get_lib_flags("unknown")
-    assert str(err.value) == "Unknown library name: 'unknown'"
+    assert str(err.value) == "unknown library unknown"
 
 
 def test_add_lib_flags(stub_c_compiler: CCompiler) -> None:
@@ -263,7 +263,7 @@ def test_c_with_unknown_library(stub_c_compiler: CCompiler,
         # Try to use "customlib" when we haven't added it to the linker
         linker.link([Path("a.o")], Path("a.out"),
                     libs=["customlib"], config=stub_configuration)
-    assert str(err.value) == "Unknown library name: 'customlib'"
+    assert str(err.value) == "unknown library customlib"
 
 
 def test_add_compiler_flag(stub_c_compiler: CCompiler,
@@ -363,7 +363,7 @@ def test_linker_inheriting() -> None:
 
     with raises(RuntimeError) as err:
         wrapper_linker.get_lib_flags("does_not_exist")
-    assert str(err.value) == "Unknown library name: 'does_not_exist'"
+    assert str(err.value) == "unknown library does_not_exist"
 
 
 def test_linker_profile_flags_inheriting(stub_c_compiler):

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -19,6 +19,8 @@ from fab.tools.category import Category
 import fab.tools.psyclone  # Needed for mockery
 from fab.tools.psyclone import Psyclone
 
+from fab.errors import FabToolPsycloneAPI, FabToolNotAvailable
+
 from tests.conftest import call_list, not_found_callback
 
 
@@ -108,7 +110,8 @@ def test_check_process_missing(fake_process: FakeProcess) -> None:
     with raises(RuntimeError) as err:
         psyclone.process(config,
                          Path("x90file"))
-    assert str(err.value).startswith("PSyclone is not available")
+    assert isinstance(err.value, FabToolNotAvailable)
+    assert str(err.value).startswith("[psyclone] not available")
 
 
 def test_processing_errors_without_api(fake_process: FakeProcess) -> None:
@@ -126,23 +129,23 @@ def test_processing_errors_without_api(fake_process: FakeProcess) -> None:
                          Path('x90file'),
                          api=None,
                          psy_file=Path('psy_file'))
-    assert (str(err.value) == "PSyclone called without api, but psy_file "
-                              "is specified.")
+    assert isinstance(err.value, FabToolPsycloneAPI)
+    assert (str(err.value) == "[psyclone] called without API and with psy_file")
 
     with raises(RuntimeError) as err:
         psyclone.process(config,
                          Path('x90file'),
                          api=None,
                          alg_file=Path('alg_file'))
-    assert (str(err.value) == "PSyclone called without api, but alg_file is "
-                              "specified.")
+    assert isinstance(err.value, FabToolPsycloneAPI)
+    assert (str(err.value) == "[psyclone] called without API and with alg_file")
 
     with raises(RuntimeError) as err:
         psyclone.process(config,
                          Path('x90file'),
                          api=None)
-    assert (str(err.value) == "PSyclone called without api, but "
-                              "transformed_file is not specified.")
+    assert isinstance(err.value, FabToolPsycloneAPI)
+    assert (str(err.value) == "[psyclone] called without API but not with transformed_file")
 
 
 @mark.parametrize("api", ["dynamo0.3", "lfric"])
@@ -162,16 +165,18 @@ def test_processing_errors_with_api(api: str,
                          Path("x90file"),
                          api=api,
                          psy_file=Path("psy_file"))
+    assert isinstance(err.value, FabToolPsycloneAPI)
     assert str(err.value).startswith(
-        f"PSyclone called with api '{api}', but no alg_file is specified"
+        f"[psyclone] called with {api} API but not with alg_file"
     )
     with raises(RuntimeError) as err:
         psyclone.process(config,
                          Path("x90file"),
                          api=api,
                          alg_file=Path("alg_file"))
+    assert isinstance(err.value, FabToolPsycloneAPI)
     assert str(err.value).startswith(
-        f"PSyclone called with api '{api}', but no psy_file is specified"
+        f"[psyclone] called with {api} API but not with psy_file"
     )
     with raises(RuntimeError) as err:
         psyclone.process(config,
@@ -180,8 +185,9 @@ def test_processing_errors_with_api(api: str,
                          psy_file=Path("psy_file"),
                          alg_file=Path("alg_file"),
                          transformed_file=Path("transformed_file"))
+    assert isinstance(err.value, FabToolPsycloneAPI)
     assert str(err.value).startswith(
-        f"PSyclone called with api '{api}' and transformed_file"
+        f"[psyclone] called with {api} API and with transformed_file"
     )
 
 

--- a/tests/unit_tests/tools/test_tool_box.py
+++ b/tests/unit_tests/tools/test_tool_box.py
@@ -17,6 +17,7 @@ from fab.tools.category import Category
 from fab.tools.compiler import CCompiler, Gfortran
 from fab.tools.tool_box import ToolBox
 from fab.tools.tool_repository import ToolRepository
+from fab.errors import FabToolNotAvailable
 
 
 def test_constructor() -> None:
@@ -88,4 +89,5 @@ def test_add_unavailable_tool(fake_process: FakeProcess) -> None:
     gfortran = Gfortran()
     with raises(RuntimeError) as err:
         tb.add_tool(gfortran)
-    assert str(err.value).startswith(f"Tool '{gfortran}' is not available")
+    assert isinstance(err.value, FabToolNotAvailable)
+    assert str(err.value).startswith(f"[{gfortran}] not available")

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -22,6 +22,8 @@ from tests.conftest import (ExtendedRecorder,
 from fab.tools.category import Category
 from fab.tools.versioning import Fcm, Git, Subversion
 
+from fab.errors import FabCommandError
+
 
 class TestGit:
     """
@@ -132,7 +134,8 @@ class TestGit:
         git = Git()
         with raises(RuntimeError) as err:
             git.fetch("/src", "/dst", revision="revision")
-        assert str(err.value).startswith("Command failed with return code 1:")
+        assert isinstance(err.value, FabCommandError)
+        assert str(err.value) == "command 'git fetch /src revision' returned 1"
         assert call_list(fake_process) == [
             ['git', 'fetch', "/src", "revision"]
         ]
@@ -164,7 +167,8 @@ class TestGit:
         git = Git()
         with raises(RuntimeError) as err:
             git.checkout("/src", "/dst", revision="revision")
-        assert str(err.value).startswith("Command failed with return code 1:")
+        assert isinstance(err.value, FabCommandError)
+        assert str(err.value) == "command 'git fetch /src revision' returned 1"
         assert call_list(fake_process) == [
             ['git', 'fetch', "/src", "revision"]
         ]
@@ -195,7 +199,7 @@ class TestGit:
         with raises(RuntimeError) as err:
             git.merge("/dst", revision="revision")
         assert str(err.value).startswith(
-            "Error merging revision. Merge aborted."
+            "[git] merge of revision failed:"
         )
         assert call_list(fake_process) == [
             ['git', 'merge', 'FETCH_HEAD'],
@@ -216,7 +220,7 @@ class TestGit:
         git = Git()
         with raises(RuntimeError) as err:
             git.merge("/dst", revision="revision")
-        assert str(err.value).startswith("Command failed with return code 1:")
+        assert str(err.value).startswith("command 'git merge")
         assert call_list(fake_process) == [
             ['git', 'merge', 'FETCH_HEAD'],
             ['git', 'merge', '--abort']


### PR DESCRIPTION
Swap all RuntimeError exceptions for custom fab exceptions using a class hierarchy derived from RuntimeError to minimise disruptive changes.

These changes fall into three broad areas:

* creation of a new set of error classes in `fab.errors` and an associated set of tests
* changes to the existing regression tests to:
  * check the new message formats
  * check the exceptions - which are still caught as `RuntimeError` to test the impact on calling functions - match the expected instance of the new error class
* replacement of `raise RuntimeError` across the code base with the new error classes

While the change is complete and the test suite runs successfully in my environment, I still have a couple of outstanding questions that need to be addressed in review:

* are the names of the new exceptions classes acceptable?  The top level class names end with `Error` but the derived classes do not.  Ending every class name with `Error` would make fab more consistent with python, at the cost of longer exception names
* are there any potential clashes or issues with the in-flight baf PR?

