### PR TITLE
Move to using `which` to determin tool presence

### DIFF
--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -3,9 +3,8 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-"""This file contains the base class for any compiler, and derived
-classes for gcc, gfortran, icc, ifort
+"""
+Compiler tool support.
 """
 
 import re
@@ -42,9 +41,6 @@ class Compiler(CompilerSuiteTool):
         of the output file
     :param openmp_flag: the flag to use to enable OpenMP. If no flag is
         specified, it is assumed that the compiler does not support OpenMP.
-    :param availability_option: a command line option for the tool to test
-        if the tool is available on the current system. Defaults to
-        `--version`.
     '''
 
     # pylint: disable=too-many-arguments
@@ -57,10 +53,8 @@ class Compiler(CompilerSuiteTool):
                  compile_flag: Optional[str] = None,
                  output_flag: Optional[str] = None,
                  openmp_flag: Optional[str] = None,
-                 version_argument: Optional[str] = None,
-                 availability_option: Optional[Union[str, List[str]]] = None):
-        super().__init__(name, exec_name, suite, category=category,
-                         availability_option=availability_option)
+                 version_argument: Optional[str] = None):
+        super().__init__(name, exec_name, suite, category=category)
         self._version: Union[Tuple[int, ...], None] = None
         self._mpi = mpi
         self._compile_flag = compile_flag if compile_flag else "-c"
@@ -216,13 +210,14 @@ class Compiler(CompilerSuiteTool):
         # The implementations depend on vendor
         output = self.run_version_command(self.__version_argument)
 
-        # Multiline is required in case that the version number is the end
+        # Multiline is required in case the version number is the end
         # of the string, otherwise the $ would not match the end of line
-        matches = re.search(self._version_regex, output, re.MULTILINE)
-        if not matches:
+        match = re.search(self._version_regex, output, re.MULTILINE)
+        if match:
+            version_string = match.groups()[0]
+        else:
             raise RuntimeError(f"Unexpected version output format for "
                                f"compiler '{self.name}': {output}")
-        version_string = matches.groups()[0]
         # Expect the version to be dot-separated integers.
         try:
             # Make mypy happy:
@@ -301,15 +296,13 @@ class CCompiler(Compiler):
                  compile_flag: Optional[str] = None,
                  output_flag: Optional[str] = None,
                  openmp_flag: Optional[str] = None,
-                 version_argument: Optional[str] = None,
-                 availability_option: Optional[str] = None):
+                 version_argument: Optional[str] = None):
         super().__init__(name, exec_name, suite,
                          category=Category.C_COMPILER, mpi=mpi,
                          compile_flag=compile_flag, output_flag=output_flag,
                          openmp_flag=openmp_flag,
                          version_argument=version_argument,
-                         version_regex=version_regex,
-                         availability_option=availability_option)
+                         version_regex=version_regex)
 
 
 # ============================================================================

--- a/source/fab/tools/compiler_wrapper.py
+++ b/source/fab/tools/compiler_wrapper.py
@@ -39,8 +39,12 @@ class CompilerWrapper(Compiler):
             category=self._compiler.category,
             suite=self._compiler.suite,
             version_regex=self._compiler._version_regex,
-            mpi=mpi,
-            availability_option=self._compiler.availability_option)
+            mpi=mpi)
+
+    @property
+    def is_available(self) -> bool:
+        this_availability = super().is_available
+        return this_availability and self._compiler.is_available
 
     @property
     def compiler(self) -> Compiler:

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -50,7 +50,7 @@ class Linker(CompilerSuiteTool):
 
         super().__init__(
             name=name,
-            exec_name=compiler.exec_path,
+            executable=compiler.executable,
             suite=self.suite,
             category=Category.LINKER)
 

--- a/source/fab/tools/preprocessor.py
+++ b/source/fab/tools/preprocessor.py
@@ -25,10 +25,8 @@ class Preprocessor(Tool):
     '''
 
     def __init__(self, name: str, exec_name: Union[str, Path],
-                 category: Category,
-                 availability_option: Optional[str] = None):
-        super().__init__(name, exec_name, category,
-                         availability_option=availability_option)
+                 category: Category):
+        super().__init__(name, exec_name, category)
         self._version = None
 
     def preprocess(self, input_file: Path, output_file: Path,
@@ -74,5 +72,4 @@ class Fpp(Preprocessor):
     def __init__(self):
         # fpp -V prints version information, but then hangs (i.e. reading
         # from stdin), so use -what to see if it is available
-        super().__init__("fpp", "fpp", Category.FORTRAN_PREPROCESSOR,
-                         availability_option="-what")
+        super().__init__("fpp", "fpp", Category.FORTRAN_PREPROCESSOR)

--- a/source/fab/tools/psyclone.py
+++ b/source/fab/tools/psyclone.py
@@ -3,17 +3,17 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-"""This file contains the tool class for PSyclone.
 """
-
+PSyclone tooling.
+"""
 from pathlib import Path
 import re
-from typing import Callable, List, Optional, TYPE_CHECKING, Union
-import warnings
+from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
+
+from source.fab import FabException
 
 if TYPE_CHECKING:
     # TODO 314: see if this circular dependency can be broken
@@ -23,40 +23,42 @@ if TYPE_CHECKING:
 
 
 class Psyclone(Tool):
-    '''This is the base class for `PSyclone`.
-    '''
-
+    """
+    Invokes the PSyclone tool.
+    """
     def __init__(self):
         super().__init__("psyclone", "psyclone", Category.PSYCLONE)
         self._version = None
 
-    def check_available(self) -> bool:
-        '''This function determines if PSyclone is available. Additionally,
-        it established the version, since command line option changes
-        significantly from python 2.5.0 to the next release.
-        '''
+    @property
+    def is_available(self) -> bool:
+        """
+        Determines PSyclone availability.
 
-        # First get the version (and confirm that PSyclone is installed):
-        try:
+        In addition, it also determines the version since a number of
+         behaviours are version dependent.
+        """
+        available = super().is_available
+
+        if available and self._version is None:
             version_output = self.run(["--version"], capture_output=True)
-        except RuntimeError:
-            # Something is wrong, report as not available
-            return False
+            pattern = r"PSyclone version: (\d[\d.]+\d)"
+            match = re.search(pattern, version_output)
+            if match:
+                self._version = tuple(int(x) for x in match.group(1).split('.'))
+            else:
+                raise FabException(
+                    f"Unexpected version information for PSyclone: "
+                    f"'{version_output}'."
+                )
 
-        # Search for the version info:
-        exp = r"PSyclone version: (\d[\d.]+\d)"
-        matches = re.search(exp, version_output)
-        if not matches:
-            warnings.warn(f"Unexpected version information for PSyclone: "
-                          f"'{version_output}'.")
-            # If we don't recognise the version number, something is wrong
-            return False
+        return available and (self._version is not None)
 
-        # Now convert the version info to integer. The regular expression
-        # match guarantees that we have integer numbers now:
-        self._version = tuple(int(x) for x in matches.groups()[0].split('.'))
-
-        return True
+    @property
+    def version(self) -> Tuple[int, ...]:
+        if self._version is None:
+            _ = self.is_available
+        return self._version
 
     def process(self,
                 config: "BuildConfig",
@@ -88,9 +90,13 @@ class Psyclone(Tool):
             for PSyclone
         :param kernel_roots: optional directories with kernels.
         '''
-
-        if not self.is_available:
-            raise RuntimeError("PSyclone is not available.")
+        try:
+            _ =  self.is_available
+        except RuntimeError as ex:
+            raise RuntimeError(
+                "PSyclone present but version unobtainable."
+                " Is installation broken?"
+            ) from ex
 
         # Convert the old style API nemo to be empty
         if api and api.lower() == "nemo":
@@ -125,7 +131,7 @@ class Psyclone(Tool):
         # transformation tool only, so calling PSyclone without api is
         # actually valid.
         if api:
-            if self._version >= (3, 0, 0):
+            if self.version >= (3, 0, 0):
                 api_param = "--psykal-dsl"
                 # Mapping from old names to new names:
                 mapping = {"dynamo0.3": "lfric",
@@ -145,7 +151,7 @@ class Psyclone(Tool):
             # Make mypy happy - we tested above that transformed_file is
             # specified when no api is specified.
             assert transformed_file
-            if self._version >= (3, 0, 0):
+            if self.version >= (3, 0, 0):
                 # New version: no API, parameter, but -o for output name:
                 parameters.extend(["-o", transformed_file])
             else:

--- a/source/fab/tools/shell.py
+++ b/source/fab/tools/shell.py
@@ -24,9 +24,7 @@ class Shell(Tool):
     :name: the path to the script to run.
     '''
     def __init__(self, name: str):
-        super().__init__(name=name, exec_name=name,
-                         availability_option=["-c", "echo hello"],
-                         category=Category.SHELL)
+        super().__init__(name=name, executable=name, category=Category.SHELL)
 
     def exec(self, command: Union[str, List[Union[Path, str]]]) -> str:
         '''Executes the specified command.

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -3,19 +3,18 @@
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
 ##############################################################################
-
-"""This file contains the base class for all tools, i.e. compiler,
-preprocessor, linker, archiver, Psyclone, rsync, versioning tools.
+"""
+Base of all tools.
 
 Each tool belongs to one category (e.g. FORTRAN_COMPILER). This category
 is used when adding a tool to a ToolRepository or ToolBox.
 It provides basic support for running a binary, and keeping track if
 a tool is actually available.
 """
-
 import logging
 from pathlib import Path
-import subprocess
+from shutil import which as sh_which
+from subprocess import run as subprocess_run
 from typing import Dict, List, Optional, Sequence, Union
 
 from fab.tools.category import Category
@@ -23,29 +22,25 @@ from fab.tools.flags import ProfileFlags
 
 
 class Tool:
-    '''This is the base class for all tools. It stores the name of the tool,
-    the name of the executable, and provides a `run` method.
+    """
+    Embodies a simple tool.
 
-    :param name: name of the tool.
-    :param exec_name: name or full path of the executable to start.
-    :param category: the Category to which this tool belongs.
-    :param availability_option: a command line option for the tool to test
-        if the tool is available on the current system. Defaults to
-        `--version`.
-    '''
+    It stores the name of the tool, the name of the executable, and provides a
+    `run` method.
 
-    def __init__(self, name: str, exec_name: Union[str, Path],
-                 category: Category = Category.MISC,
-                 availability_option: Optional[Union[str, List[str]]] = None):
+    :param name: Unique identifier for tool.
+    :param executable: Full or relative path of this tool's executable.
+                       Relative paths must be a leaf name only.
+    :param category: Sorts this tool into this grouping.
+    """
+
+    def __init__(self, name: str, executable: Union[str, Path],
+                 category: Category = Category.MISC):
         self._logger = logging.getLogger(__name__)
         self._name = name
-        self._exec_path = Path(exec_name)
+        self._executable = Path(executable)
         self._flags = ProfileFlags()
         self._category = category
-        if availability_option:
-            self._availability_option = availability_option
-        else:
-            self._availability_option = "--version"
 
         # This flag keeps track if a tool is available on the system or not.
         # A value of `None` means that it has not been tested if a tool works
@@ -57,39 +52,30 @@ class Tool:
         # to use `run` to determine if a tool is available or not.
         self._is_available: Optional[bool] = None
 
-    def check_available(self) -> bool:
-        '''Run a 'test' command to check if this tool is available in the
-        system.
-        :returns: whether the tool is working (True) or not.
-        '''
-        try:
-            self.run(self._availability_option)
-        except (RuntimeError, FileNotFoundError):
-            return False
-        return True
-
     def set_full_path(self, full_path: Path):
-        '''This function adds the full path to a tool. This allows
-        tools to be used that are not in the user's PATH. The ToolRepository
-        will automatically update the path for a tool if the user specified
-        a full path.
+        """
+        Updates this tool's executable path.
 
-        :param full_path: the full path to the executable.
-        '''
-        self._exec_path = full_path
+        This is useful when a tool's executable is not on $PATH. Calling this
+        will cause a new availability check.
+
+        :param full_path: New executable path.
+        """
+        self._executable = full_path
+        self._is_available = None
+        self._check_availability()
 
     @property
     def is_available(self) -> bool:
-        '''Checks if the tool is available or not. It will call a tool-specific
-        function check_available to determine this, but will cache the results
-        to avoid testing a tool more than once.
+        """
+        Determines this tool's availability.
 
-        :returns: whether the tool is available (i.e. installed and
-            working).
-        '''
-        if self._is_available is None:
-            self._is_available = self.check_available()
-        return self._is_available
+        The tool's executable is sought on $PATH. The result is cached for
+        future inquiries.
+
+        :returns: True if the executable is present, False otherwise.
+        """
+        return self._check_availability()
 
     @property
     def is_compiler(self) -> bool:
@@ -97,24 +83,21 @@ class Tool:
         return self._category.is_compiler
 
     @property
-    def exec_path(self) -> Path:
-        ''':returns: the path of the executable.'''
-        return self._exec_path
+    def executable(self) -> Path:
+        """
+        Gets this tool's executable.
+        """
+        return self._executable
 
     @property
     def exec_name(self) -> str:
         ''':returns: the name of the executable.'''
-        return self.exec_path.name
+        return self.executable.name
 
     @property
     def name(self) -> str:
         ''':returns: the name of the tool.'''
         return self._name
-
-    @property
-    def availability_option(self) -> Union[str, List[str]]:
-        ''':returns: the option to use to check if the tool is available.'''
-        return self._availability_option
 
     @property
     def category(self) -> Category:
@@ -154,7 +137,7 @@ class Tool:
     def __str__(self):
         '''Returns a name for this string.
         '''
-        return f"{type(self).__name__} - {self._name}: {self._exec_path}"
+        return f"{type(self).__name__} - {self._name}: {self._executable}"
 
     def run(self,
             additional_parameters: Optional[
@@ -180,7 +163,7 @@ class Tool:
         :raises RuntimeError: if the code is not available.
         :raises RuntimeError: if the return code of the executable is not 0.
         """
-        command = [str(self.exec_path)] + self.get_flags(profile)
+        command = [str(self.executable)] + self.get_flags(profile)
         if additional_parameters:
             if isinstance(additional_parameters, str):
                 command.append(additional_parameters)
@@ -189,19 +172,12 @@ class Tool:
                 # paths as additional parameter
                 command.extend(str(i) for i in additional_parameters)
 
-        # self._is_available is None when it is not known yet whether a tool
-        # is available or not. Testing for `False` only means this `run`
-        # function can be used to test if a tool is available.
-        if self._is_available is False:
+        if not self._check_availability():
             raise RuntimeError(f"Tool '{self.name}' is not available to run "
-                               f"'{command}'.")
+                               + str(command))
         self._logger.debug(f'run_command: {" ".join(command)}')
-        try:
-            res = subprocess.run(command, capture_output=capture_output,
-                                 env=env, cwd=cwd, check=False)
-        except FileNotFoundError as err:
-            raise RuntimeError("Unable to execute command: "
-                               + str(command)) from err
+        res = subprocess_run(command, capture_output=capture_output,
+                             env=env, cwd=cwd, check=False)
         if res.returncode != 0:
             msg = (f'Command failed with return code {res.returncode}:\n'
                    f'{command}')
@@ -214,24 +190,27 @@ class Tool:
             return res.stdout.decode()
         return ""
 
+    def _check_availability(self) -> bool:
+        if self._is_available is None:
+            self._is_available = sh_which(self._executable) is not None
+        return self._is_available
+
 
 class CompilerSuiteTool(Tool):
     '''A tool that is part of a compiler suite (typically compiler
     and linker).
 
     :param name: name of the tool.
-    :param exec_name: name of the executable to start.
+    :param executable: name of the executable to start.
     :param suite: name of the compiler suite.
     :param category: the Category to which this tool belongs.
     :param availability_option: a command line option for the tool to test
         if the tool is available on the current system. Defaults to
         `--version`.
     '''
-    def __init__(self, name: str, exec_name: Union[str, Path], suite: str,
-                 category: Category,
-                 availability_option: Optional[Union[str, List[str]]] = None):
-        super().__init__(name, exec_name, category,
-                         availability_option=availability_option)
+    def __init__(self, name: str, executable: Union[str, Path], suite: str,
+                 category: Category):
+        super().__init__(name, executable, category)
         self._suite = suite
 
     @property

--- a/source/fab/tools/tool_repository.py
+++ b/source/fab/tools/tool_repository.py
@@ -193,10 +193,11 @@ class ToolRepository(dict):
         # tool returned might be mpif90-ifort when the user has actually
         # mpif90-gfortran available)
         for tool in all_tools:
-            if tool.exec_name == path_name.name and tool.is_available:
+            if tool.exec_name == path_name.name:
                 if path_name.is_absolute():
                     tool.set_full_path(path_name)
-                return tool
+                if tool.is_available:
+                    return tool
 
         raise KeyError(f"Unknown tool '{name}' in category '{category}' "
                        f"in ToolRepository.")

--- a/source/fab/tools/versioning.py
+++ b/source/fab/tools/versioning.py
@@ -28,8 +28,7 @@ class Versioning(Tool, ABC):
         :param exec_name: Executable for this tool.
         :param category: Tool belongs to this category.
         """
-        super().__init__(name, exec_name, category,
-                         availability_option="help")
+        super().__init__(name, exec_name, category)
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ Fixtures and helpers for testing.
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import fixture
 from pytest_subprocess.fake_process import FakeProcess, ProcessRecorder
 
@@ -108,10 +109,11 @@ def subproc_record(fake_process: FakeProcess) -> ExtendedRecorder:
 
 
 @fixture(scope='function')
-def stub_fortran_compiler() -> FortranCompiler:
+def stub_fortran_compiler(fs: FakeFilesystem) -> FortranCompiler:
     """
     Provides a minimal Fortran compiler.
     """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
     compiler = FortranCompiler('some Fortran compiler', 'sfc', 'stub',
                                r'([\d.]+)', openmp_flag='-omp',
                                module_folder_flag='-mods')
@@ -119,10 +121,11 @@ def stub_fortran_compiler() -> FortranCompiler:
 
 
 @fixture(scope='function')
-def stub_c_compiler() -> CCompiler:
+def stub_c_compiler(fs: FakeFilesystem) -> CCompiler:
     """
     Provides a minial C compiler.
     """
+    fs.create_file('/bin/scc', create_missing_dirs=True, st_mode=0o755)
     compiler = CCompiler("some C compiler", "scc", "stub",
                          version_regex=r"([\d.]+)", openmp_flag='-omp')
     return compiler
@@ -149,15 +152,11 @@ def return_true():
 @fixture(scope='function')
 def stub_tool_box(stub_fortran_compiler,
                   stub_c_compiler,
-                  stub_linker,
-                  monkeypatch) -> ToolBox:
+                  stub_linker) -> ToolBox:
     """
     Provides a minimal toolbox containing just Fortran and C compilers and a
     linker.
     """
-    monkeypatch.setattr(stub_fortran_compiler, 'check_available', return_true)
-    monkeypatch.setattr(stub_c_compiler, 'check_available', return_true)
-    monkeypatch.setattr(stub_linker, 'check_available', return_true)
     toolbox = ToolBox()
     toolbox.add_tool(stub_fortran_compiler)
     toolbox.add_tool(stub_c_compiler)
@@ -166,9 +165,9 @@ def stub_tool_box(stub_fortran_compiler,
 
 
 @fixture(scope='function')
-def stub_configuration(stub_tool_box: ToolBox, tmp_path: Path) -> BuildConfig:
+def stub_configuration(stub_tool_box: ToolBox) -> BuildConfig:
     """
     Provides a minimal configuration with stub compilers.
     """
     return BuildConfig("Stub config", stub_tool_box,
-                       fab_workspace=tmp_path / 'fab')
+                       fab_workspace=Path('/home/user/fab'))

--- a/tests/system_tests/svn_fcm/test_svn_fcm_system_test.py
+++ b/tests/system_tests/svn_fcm/test_svn_fcm_system_test.py
@@ -174,23 +174,12 @@ class TestCheckout():
         else:
             assert False
 
-        with mock.patch('fab.tools.tool.subprocess.run',
-                        wraps=fab.tools.tool.subprocess.run) as wrap, \
-             pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-
+        with pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
             checkout_func(config, src=file2_experiment, dst_label='proj', revision='7')
             assert confirm_file2_experiment_r7(config)
-            wrap.assert_called_with([
-                expect_tool, 'checkout', '--revision', '7',
-                file2_experiment, str(config.source_root / 'proj')],
-                capture_output=True, env=None, cwd=None, check=False)
 
             checkout_func(config, src=file2_experiment, dst_label='proj', revision='8')
             assert confirm_file2_experiment_r8(config)
-            wrap.assert_called_with(
-                [expect_tool, 'update', '--revision', '8'],
-                capture_output=True, env=None,
-                cwd=config.source_root / 'proj', check=False)
 
     @pytest.mark.parametrize('export_func,checkout_func', zip(export_funcs, checkout_funcs))
     def test_not_working_copy(self, trunk, config, export_func, checkout_func):

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -30,15 +30,9 @@ class TestArchiveObjects:
         """
         As used when archiving before linking exes.
         """
-        # Make sure that ar has not already been tested
-        # (in which case the --version call will not be executed)
-        ar = ToolRepository().get_tool(Category.AR, "ar")
-        ar._is_available = None
-        version_command = ['ar', '--version']
-        fake_process.register(version_command, stdout='1.2.3')
-        commands = []
-        commands.append(version_command)
+        fs.create_file('/bin/ar', create_missing_dirs=True, st_mode=0o755)
         targets = ['prog1', 'prog2']
+        commands = []
         for target in targets:
             ar_command = ['ar', 'cr', f'/fab/proj/build_output/{target}.a',
                           f'{target}.o', 'util.o']
@@ -72,11 +66,10 @@ class TestArchiveObjects:
         """
         # Make sure that ar has not already been tested
         # (in which case the --version call will not be executed)
+        fs.create_file('/bin/ar', create_missing_dirs=True, st_mode=0o755)
         ar = ToolRepository().get_tool(Category.AR, "ar")
         ar._is_available = None
 
-        help_command = ['ar', '--version']
-        fake_process.register(help_command, stdout='1.0.0')
         ar_command = ['ar', 'cr', '/fab/proj/build_output/mylib.a',
                       'util1.o', 'util2.o']
         fake_process.register(ar_command)
@@ -92,7 +85,7 @@ class TestArchiveObjects:
             archive_objects(config=config,
                             output_fpath=config.build_output / 'mylib.a')
 
-        assert call_list(fake_process) == [help_command, ar_command]
+        assert call_list(fake_process) == [ar_command]
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -9,6 +9,7 @@ Exercises the compiler step.
 from pathlib import Path
 from unittest.mock import Mock
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import fixture, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
 
@@ -71,7 +72,7 @@ class TestCompileC:
     '''Test various functionalities of the C compilation step.'''
 
     def test_vanilla(self, content,
-                     fake_process: FakeProcess) -> None:
+                     fs: FakeFilesystem, fake_process: FakeProcess) -> None:
         """
         Tests correct use of compiler.
         """
@@ -91,9 +92,8 @@ class TestCompileC:
                                                   '-Dhello'])])
 
         # ensure it created the correct artefact collection
-        assert config.artefact_store[ArtefactSet.OBJECT_FILES] == {
-            None: {config.prebuild_folder / 'foo.18f203cab.o', }
-        }
+        assert str(dict(config.artefact_store[ArtefactSet.OBJECT_FILES])) \
+               == str({None: {config.prebuild_folder / 'foo.18f203cab.o', }})
 
     def test_exception_handling(self, content,
                                 fake_process: FakeProcess) -> None:

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -15,8 +15,11 @@ from fab.steps.compile_fortran import (
     store_artefacts
 )
 from fab.tools.category import Category
+from fab.tools.compiler import FortranCompiler
 from fab.tools.tool_box import ToolBox
 from fab.util import CompiledFile
+
+from source.fab.tools.tool_repository import ToolRepository
 
 
 @fixture(scope='function')
@@ -73,8 +76,9 @@ def test_compile_cc_wrong_compiler(stub_tool_box,
 
 class TestCompilePass:
 
-    def test_vanilla(self, analysed_files, stub_tool_box: ToolBox,
-                     tmp_path: Path, fake_process: FakeProcess) -> None:
+    def test_vanilla(self, analysed_files,
+                     tmp_path: Path, fake_process: FakeProcess,
+                     monkeypatch) -> None:
         """
         Tests only uncompiled artefacts are compiled.
 
@@ -83,19 +87,32 @@ class TestCompilePass:
         """
         a, b, c = analysed_files
 
+        bin_dir = tmp_path / 'bin'
+        bin_dir.mkdir()
+        monkeypatch.setenv('PATH', str(bin_dir), ':')
+
+        (bin_dir / 'sfc').touch(0o755)
         fake_process.register(['sfc', '--version'], stdout='1.2.3')
         fake_process.register(['sfc', fake_process.any()])
 
+        ToolRepository._singleton = None
+        tool_box = ToolBox()
+        tool_box.add_tool(FortranCompiler("Some Fortran", 'sfc', 'test',
+                                          r'([\d.]+)'))
+
         uncompiled = {a, b}
         compiled = {
-            c.fpath: CompiledFile(c.fpath,
-                                  tmp_path / 'proj/build_output/_prebuild/' / c.fpath.name)
+            c.fpath: CompiledFile(
+                c.fpath,
+                tmp_path / '/work/proj/build_output/_prebuild/' / c.fpath.name
+            )
         }
 
         # this gets filled in
         mod_hashes: Dict[str, int] = {}
 
-        config = BuildConfig('proj', stub_tool_box, fab_workspace=tmp_path)
+        config = BuildConfig('proj', tool_box,
+                             fab_workspace=tmp_path / 'work')
         mp_common_args = MpCommonArgs(config,
                                       FlagsConfig(),
                                       {},

--- a/tests/unit_tests/steps/test_grab.py
+++ b/tests/unit_tests/steps/test_grab.py
@@ -17,6 +17,8 @@ from fab.steps.grab.fcm import fcm_export
 from fab.steps.grab.folder import grab_folder
 from fab.tools.tool_box import ToolBox
 
+from source.fab.tools.tool_repository import ToolRepository
+
 
 class TestGrabFolder:
     """
@@ -34,6 +36,14 @@ class TestGrabFolder:
         """
         Tests file directory grabbery.
         """
+        # ToolRepository fails if there are no Fortran compilers within, even
+        # when they are unused.
+        #
+        ToolRepository._singleton = None
+        fs.create_file('/bin/gfortran', create_missing_dirs=True, st_mode=0o755)
+        fake_process.register(['gfortran', '--version'], stdout='GNU Fortran (foo) 1.2.3')
+
+        fs.create_file('/bin/rsync', create_missing_dirs=True, st_mode=0o755)
         version_command = ['rsync', '--version']
         fake_process.register(version_command, stdout='1.2.3')
         grab_command = ['rsync', '--times', '--links', '--stats',
@@ -58,6 +68,14 @@ class TestGrabFcm:
         """
         Tests no revision, "head of branch" grab.
         """
+        # ToolRepository fails if there are no Fortran compilers within, even
+        # when they are unused.
+        #
+        ToolRepository._singleton = None
+        fs.create_file('/bin/gfortran', create_missing_dirs=True, st_mode=0o755)
+        fake_process.register(['gfortran', '--version'], stdout='GNU Fortran (foo) 1.2.3')
+
+        fs.create_file('/bin/fcm', create_missing_dirs=True, st_mode=0o755)
         help_command = ['fcm', 'help']
         fake_process.register(help_command)
         grab_command = ['fcm', 'export', '--force', '/www.example.com/bar',
@@ -75,12 +93,19 @@ class TestGrabFcm:
                        dst_label='bar')
         assert fake_process.call_count(grab_command) == 1
 
-    def test_revision(self, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
+    def test_revision(self, fs: FakeFilesystem,
+                      fake_process: FakeProcess) -> None:
         """
         Tests grabbing a specific revision.
         """
-        help_command = ['fcm', 'help']
-        fake_process.register(help_command)
+        # ToolRepository fails if there are no Fortran compilers within, even
+        # when they are unused.
+        #
+        ToolRepository._singleton = None
+        fs.create_file('/bin/gfortran', create_missing_dirs=True, st_mode=0o755)
+        fake_process.register(['gfortran', '--version'], stdout='GNU Fortran (foo) 1.2.3')
+
+        fs.create_file('/bin/fcm', create_missing_dirs=True, st_mode=0o755)
         grab_command = ['fcm', 'export', '--force', '--revision', '42',
                         'http://www.example.com/bar',
                         '/fab/project/source/bar']

--- a/tests/unit_tests/steps/test_link.py
+++ b/tests/unit_tests/steps/test_link.py
@@ -8,10 +8,9 @@ Exercises executable linkage step.
 """
 from pathlib import Path
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import warns
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import call_list
 
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
@@ -20,16 +19,18 @@ from fab.tools.compiler import FortranCompiler
 from fab.tools.linker import Linker
 from fab.tools.tool_box import ToolBox
 
+from tests.conftest import call_list
+
 
 class TestLinkExe:
     """
     Tests linking an executable.
     """
-    def test_run(self, fake_process: FakeProcess, monkeypatch) -> None:
+    def test_run(self, fs: FakeFilesystem, fake_process: FakeProcess, monkeypatch) -> None:
         """
         Tests correct formation of command.
         """
-
+        fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
         version_command = ['sfc', '--version']
         fake_process.register(version_command, stdout='1.2.3')
         link_command = ['sfc', 'bar.o', 'foo.o',

--- a/tests/unit_tests/steps/test_root_inc_files.py
+++ b/tests/unit_tests/steps/test_root_inc_files.py
@@ -56,7 +56,7 @@ class TestRootIncFiles:
         """
         Tests files already in output directory not copied.
         """
-        Path('/foo/source').mkdir(parents=True)
+        fs.create_dir('/foo/source')
         Path('/foo/source/bar.inc').write_text("An include file.")
 
         config = BuildConfig('proj', stub_tool_box, fab_workspace=Path('/fab'))
@@ -84,9 +84,9 @@ class TestRootIncFiles:
         # So we need to ignore /tmp:
         filetree: List[Path] = []
         for path, _, files in os_walk('/'):
+            if path in ('/bin', '/var'):
+                continue
             for file in files:
-                if file == 'tmp':
-                    continue
                 filetree.append(Path(path) / file)
         assert sorted(filetree) == [Path('/fab/proj/build_output/bar.inc'),
                                     Path('/foo/source/bar.inc')]

--- a/tests/unit_tests/tools/test_ar.py
+++ b/tests/unit_tests/tools/test_ar.py
@@ -8,11 +8,13 @@ Tests 'ar' archiver tool.
 """
 from pathlib import Path
 
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark
 from pytest_subprocess.fake_process import FakeProcess
 
-from tests.conftest import ExtendedRecorder, call_list
-
 from fab.tools import Category, Ar
+
+from tests.conftest import ExtendedRecorder, call_list
 
 
 def test_constructor() -> None:
@@ -26,29 +28,17 @@ def test_constructor() -> None:
     assert ar.get_flags() == []
 
 
-def test_check_available(subproc_record: ExtendedRecorder) -> None:
+@mark.parametrize('available', [True, False])
+def test_is_available(available: bool, fs: FakeFilesystem) -> None:
     """
     Tests availability functionality.
     """
+    if available:
+        fs.create_file('/bin/ar', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
     ar = Ar()
-    assert ar.check_available()
-    assert subproc_record.invocations() == [["ar", "--version"]]
-    assert subproc_record.extras() == [{'cwd': None,
-                                        'env': None,
-                                        'stdout': None,
-                                        'stderr': None}]
-
-
-def test_check_unavailable(fake_process: FakeProcess) -> None:
-    """
-    Tests availability failure.
-    """
-    fake_process.register(['ar', '--version'],
-                          returncode=1,
-                          stderr="Something went wrong.")
-    ar = Ar()
-    assert not ar.check_available()
-    assert call_list(fake_process) == [["ar", "--version"]]
+    assert ar.is_available is available
 
 
 def test_ar_create(subproc_record: ExtendedRecorder) -> None:

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -8,8 +8,10 @@ Exercise compiler tools.
 """
 from pathlib import Path
 from textwrap import dedent
+from typing import Tuple
 from unittest import mock
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
 
@@ -56,10 +58,10 @@ def test_compiler_exec_paths() -> None:
     cc = Compiler("gcc", "gcc", "gnu", version_regex="",
                   category=Category.C_COMPILER, openmp_flag="-fopenmp")
     assert cc.exec_name == "gcc"
-    assert cc.exec_path == Path("gcc")
+    assert cc.executable == Path("gcc")
     cc.set_full_path(Path("/usr/bin/gcc"))
     assert cc.exec_name == "gcc"
-    assert cc.exec_path == Path("/usr/bin/gcc")
+    assert cc.executable == Path("/usr/bin/gcc")
 
 
 def test_compiler_openmp() -> None:
@@ -109,20 +111,27 @@ def test_compiler_check_available_runtime_error():
 
 
 def test_compiler_hash():
-    '''Test the hash functionality.'''
-    cc = Gcc()
-    with mock.patch.object(cc, "_version", (5, 6, 7)):
-        hash1 = cc.get_hash()
-        assert hash1 == 2991650113
+    """
+    Tests the hash functionality.
+    """
+    cc1 = Compiler("Some compiler", 'scc', 'test', r'[/d.]+',
+                  Category.C_COMPILER)
+    with mock.patch.object(cc1, "_version", (5, 6, 7)):
+        hash1 = cc1.get_hash()
+        assert hash1 == 2322334684
 
     # A change in the version number must change the hash:
-    with mock.patch.object(cc, "_version", (8, 9)):
-        hash2 = cc.get_hash()
+    cc2 = Compiler("Some compiler", 'scc', 'test', r'[/d.]+',
+                   Category.C_COMPILER)
+    with mock.patch.object(cc2, "_version", (8, 9)):
+        hash2 = cc2.get_hash()
         assert hash2 != hash1
 
-        # A change in the name must change the hash, again:
-        cc._name = "new_name"
-        hash3 = cc.get_hash()
+    # A change in the name must change the hash, again:
+    cc3 = Compiler("Some other compiler", 'scc', 'test', r'[/d.]+',
+                   Category.C_COMPILER)
+    with mock.patch.object(cc3, "_version", (8, 9)):
+        hash3 = cc3.get_hash()
         assert hash3 not in (hash1, hash2)
 
 
@@ -275,164 +284,131 @@ def test_compiler_with_add_args(stub_configuration: BuildConfig,
 # ============================================================================
 # Test version number handling
 # ============================================================================
-def test_get_version_string():
-    '''Tests the get_version_string() method.
-    '''
-    full_output = 'GNU Fortran (gcc) 6.1.0'
-
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        assert c.get_version_string() == "6.1.0"
-
-
-def test_get_version_1_part_version():
-    '''
-    Tests the get_version() method with an invalid format.
-    If the version is just one integer, that is invalid and we must raise an
-    error. '''
-    full_output = dedent("""
-        GNU Fortran (gcc) 777
-        Copyright (C) 2022 Foo Software Foundation, Inc.
-    """)
-    expected_error = "Unexpected version output format for compiler"
-
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with raises(RuntimeError) as err:
-            c.get_version()
-        assert expected_error in str(err.value)
+def test_get_version_string(fs: FakeFilesystem, fake_process: FakeProcess):
+    """
+    Checks extraction of the version string.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout='2.3.4')
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    assert fc.get_version_string() == '2.3.4'
 
 
-def test_get_version_2_part_version():
-    '''
-    Tests the get_version() method with a valid format.
-    Test major.minor format.
-    '''
-    full_output = dedent("""
-        GNU Fortran (gcc) 5.6 123456 (Foo Hat 1.2.3-45)
-        Copyright (C) 2022 Foo Software Foundation, Inc.
-    """)
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        assert c.get_version() == (5, 6)
+@mark.parametrize('version, expected', [
+    ('1.2', (1, 2)),  # major.minor
+    ('3.4.5', (3, 4, 5)),   # major.minor.patch
+    ('6.7.8.9', (6, 7, 8, 9))  # major.minor.patch.revision
+])
+def test_get_version_2_part_version(version: str, expected: Tuple[int, ...],
+                                    fs: FakeFilesystem, fake_process: FakeProcess):
+    """
+    Tests valid version formats.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout=version)
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    assert fc.get_version() == expected
 
 
-def test_get_version_3_part_version():
-    '''
-    Tests the get_version() method with a valid format.
-    Test major.minor.patch format.
-    '''
-    full_output = 'GNU Fortran (gcc) 6.1.0'
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        assert c.get_version() == (6, 1, 0)
-
-
-def test_get_version_4_part_version():
-    '''
-    Tests the get_version() method with a valid format.
-    Test major.minor.patch.revision format.
-    '''
-    full_output = 'GNU Fortran (gcc) 19.0.0.117 20180804'
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        assert c.get_version() == (19, 0, 0, 117)
-
-
-@mark.parametrize("version", ["5.15f.2",
-                              ".0.5.1",
-                              "0.5.1.",
-                              "0.5..1"])
-def test_get_version_non_int_version_format(version):
-    '''
-    Tests the get_version() method with an invalid format.
-    If the version contains non-number characters, we must raise an error.
-    TODO: the current code does not detect an error in case of `1.2..`,
-    i.e. a trailing ".".
-    '''
-    full_output = dedent(f"""
-        GNU Fortran (gcc) {version} (Foo Hat 4.8.5)
-        Copyright (C) 2022 Foo Software Foundation, Inc.
-    """)
-    expected_error = "Unexpected version output format for compiler"
-
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with raises(RuntimeError) as err:
-            c.get_version()
-        assert expected_error in str(err.value)
-
-
-def test_get_version_unknown_version_format():
-    '''
-    Tests the get_version() method with an invalid format.
-    If the version is in an unknown format, we must raise an error.
-    '''
-
-    full_output = dedent("""
-        Foo Fortran version 175
-    """)
-    expected_error = "Unexpected version output format for compiler"
-
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with raises(RuntimeError) as err:
-            c.get_version()
-        assert expected_error in str(err.value)
-
-
-def test_get_version_command_failure():
-    '''If the version command fails, we must raise an error.'''
-    c = Gfortran(exec_name="does_not_exist")
+def test_get_version_1_part_version(fs: FakeFilesystem,
+                                    fake_process: FakeProcess):
+    """
+    Checks a bad, single integer, version.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout='777')
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
     with raises(RuntimeError) as err:
-        c.get_version()
-    assert "Error asking for version of compiler" in str(err.value)
+        fc.get_version()
+    assert str(err.value) == ("Unexpected version output format for compiler"
+                              " 'Some Fortran'. Should have at least two parts,"
+                              " <n.n[.n, ...]>: 777")
 
 
-def test_get_version_unknown_command_response():
-    '''If the full version output is in an unknown format,
-    we must raise an error.'''
-    full_output = 'GNU Fortran  1.2.3'
-    expected_error = "Unexpected version output format for compiler"
+@mark.parametrize("version", [".0.5.1",
+                              "0.5.1.",
+                              "0.5..1",
+                              '0.5.1..'])
+def test_get_version_non_int_version_format(version, fs: FakeFilesystem,
+                                            fake_process: FakeProcess):
+    """
+    Tests the get_version() method with an invalid format.
 
-    c = Gfortran()
-    with mock.patch.object(c, "run", mock.Mock(return_value=full_output)):
-        with raises(RuntimeError) as err:
-            c.get_version()
-        assert expected_error in str(err.value)
+    If the version contains non-number characters, we must raise an error.
 
-
-def test_get_version_good_result_is_cached():
-    '''Checks that the compiler is only run once to extract the version.
-    '''
-    valid_output = "GNU Fortran (gcc) 6.1.0"
-    expected = (6, 1, 0)
-    c = Gfortran()
-    with mock.patch.object(c, 'run', mock.Mock(return_value=valid_output)):
-        assert c.get_version() == expected
-        assert c.run.called
-
-    # Now let the run method raise an exception, to make sure we get a cached
-    # value back (and the run method isn't called again):
-    with mock.patch.object(c, 'run', side_effect=RuntimeError()):
-        assert c.get_version() == expected
-        assert not c.run.called
+    Todo: Not sure about these tests. They mostly seem to be testing the regex.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout=version)
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    with raises(RuntimeError) as err:
+        fc.get_version()
+    assert str(err.value) == ("Unexpected version output format for compiler"
+                              " 'Some Fortran'. Should be numeric"
+                              " <n.n[.n, ...]>: " + version)
 
 
-def test_get_version_bad_result_is_not_cached():
-    '''Checks that the compiler can be re-run after failing to get the version.
-    '''
-    # Set up the compiler to fail the first time
-    c = Gfortran()
-    with mock.patch.object(c, 'run', side_effect=RuntimeError()):
-        with raises(RuntimeError):
-            c.get_version()
+def test_get_version_command_failure(fs: FakeFilesystem,
+                                     fake_process: FakeProcess):
+    """
+    Checks version failure throws an error.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], returncode=1)
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    with raises(RuntimeError) as err:
+        fc.get_version()
+    assert str(err.value) == "Error asking for version of compiler 'Some Fortran'"
 
-    # Now let the run method run successfully and we should get the version.
-    valid_output = "GNU Fortran (gcc) 6.1.0"
-    with mock.patch.object(c, 'run', mock.Mock(return_value=valid_output)):
-        assert c.get_version() == (6, 1, 0)
-        assert c.run.called
+
+def test_get_version_unknown_version(fs: FakeFilesystem,
+                                     fake_process: FakeProcess):
+    """
+    Checks baddly formatted version throws an error
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout="Bad version number")
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    with raises(RuntimeError) as err:
+        fc.get_version()
+    assert str(err.value) == ("Unexpected version output format for compiler"
+                              " 'Some Fortran': Bad version number")
+
+
+def test_get_version_good_result_is_cached(fs: FakeFilesystem,
+                                           fake_process: FakeProcess):
+    """
+    Ensures the compiler is run once only for version details.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout="1.2.3")
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    assert fc.get_version() == (1, 2, 3)
+    assert fc.get_version() == (1, 2, 3)
+    assert call_list(fake_process) == [['sfc', '--version']]
+
+
+def test_get_version_bad_result_is_not_cached(fs: FakeFilesystem,
+                                              fake_process: FakeProcess):
+    """
+    Checks that the compiler can be re-run after failing to get the version.
+    """
+    fs.create_file('/bin/sfc', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['sfc', '--version'], stdout="Bad version")
+    fc = Compiler("Some Fortran", 'sfc', 'test', r'([\d.]+)',
+                  category=Category.FORTRAN_COMPILER)
+    with raises(RuntimeError):
+        fc.get_version()
+    fake_process.register(['sfc', '--version'], stdout="5.6.7")
+    assert fc.get_version() == (5, 6, 7)
+    assert call_list(fake_process) == [['sfc', '--version'], ['sfc', '--version']]
 
 
 # ============================================================================
@@ -806,8 +782,12 @@ def test_nvc():
     assert not nvc.mpi
 
 
-def test_nvc_get_version_23_5_0(fake_process: FakeProcess) -> None:
-    '''Test nvc 23.5.0 version detection.'''
+def test_nvc_get_version_23_5_0(fs: FakeFilesystem,
+                                fake_process: FakeProcess) -> None:
+    """
+    Tests nvc 23.5.0 version detection.
+    """
+    fs.create_file('/bin/nvc', create_missing_dirs=True, st_mode=0o755)
     version_string = dedent("""
 nvc 23.5-0 64-bit target on x86-64 Linux -tp icelake-server
 NVIDIA Compilers and Tools
@@ -845,8 +825,12 @@ def test_nvfortran():
     assert not nvfortran.mpi
 
 
-def test_nvfortran_get_version_23_5_0(fake_process: FakeProcess) -> None:
-    '''Test nvfortran 23.5 version detection.'''
+def test_nvfortran_get_version_23_5_0(fs: FakeFilesystem,
+                                      fake_process: FakeProcess) -> None:
+    """
+    Tests nvfortran 23.5 version detection.
+    """
+    fs.create_file('/bin/nvfortran', create_missing_dirs=True, st_mode=0o755)
     version_string = dedent("""
 nvfortran 23.5-0 64-bit target on x86-64 Linux -tp icelake-server
 NVIDIA Compilers and Tools

--- a/tests/unit_tests/tools/test_compiler_wrapper.py
+++ b/tests/unit_tests/tools/test_compiler_wrapper.py
@@ -8,10 +8,9 @@ Tests the compiler wrapper implementation.
 """
 from pathlib import Path
 
-from pytest import raises, warns
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
 from fab.build_config import BuildConfig
 from fab.tools.category import Category
@@ -19,6 +18,8 @@ from fab.tools.compiler import CCompiler, FortranCompiler
 from fab.tools.compiler_wrapper import (CompilerWrapper,
                                         CrayCcWrapper, CrayFtnWrapper,
                                         Mpicc, Mpif90)
+
+from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
 
 def test_compiler_getter(stub_c_compiler: CCompiler) -> None:
@@ -31,11 +32,13 @@ def test_compiler_getter(stub_c_compiler: CCompiler) -> None:
 
 
 def test_version_and_caching(stub_c_compiler: CCompiler,
+                             fs: FakeFilesystem,
                              fake_process: FakeProcess) -> None:
     """
     Tests that the compiler wrapper reports the right version number
     from the actual compiler.
     """
+    fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
     fake_process.register(['mpicc', '--version'], stdout='1.2.3')
     mpicc = Mpicc(stub_c_compiler)
 
@@ -49,46 +52,32 @@ def test_version_and_caching(stub_c_compiler: CCompiler,
     ]
 
 
-def test_compiler_is_available_ok(stub_c_compiler: CCompiler,
-                                  fake_process: FakeProcess) -> None:
+@mark.parametrize('c_avail, m_avail, expected', [
+    (False, False, False)
+])
+def test_is_available(c_avail: bool, m_avail: bool, expected: bool,
+                      fs: FakeFilesystem) -> None:
     """
-    Tests availability check when everything is okay.
+    Checks availability testing.
     """
-    fake_process.register(['scc', '--version'], stdout='1.2.3')
-    fake_process.register(['mpicc', '--version'], stdout='1.2.3')
-    mpicc = Mpicc(stub_c_compiler)
+    if c_avail:
+        fs.create_file('/bin/scc', create_missing_dirs=True, st_mode=0o755)
+    if m_avail:
+        fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
+    cc = CCompiler("Some C compiler", 'scc', 'test', r'[./d]+')
+    mpicc = Mpicc(cc)
 
     # Just make sure we get the right object:
     assert isinstance(mpicc, CompilerWrapper)
-    assert mpicc.is_available is True
+    assert mpicc.is_available is expected
 
 
-def test_compiler_is_available_no_version(stub_c_compiler: CCompiler,
-                                          fake_process: FakeProcess) -> None:
-    """
-    Make sure a compiler that does not return a valid version
-    is marked as not available.
-    """
-
-    # Test if the wrapped compiler cannot be executed, but the wrapper can.
-    # In this case, the wrapper should be marked as available:
-    fake_process.register(['scc', '--version'], callback=not_found_callback)
-    fake_process.register(['mpicc', '--version'], stdout='1.2.3')
-    mpicc = Mpicc(stub_c_compiler)
-    assert mpicc.is_available
-
-    # Create a new instance (since the above one is marked as available),
-    # make the wrapped compiler available, but not the wrapper:
-    mpicc = Mpicc(stub_c_compiler)
-    fake_process.register(['scc', '--version'], stdout='1.2.3')
-    fake_process.register(['mpicc', '--version'], callback=not_found_callback)
-    assert not mpicc.is_available
-
-
-def test_compiler_hash(fake_process: FakeProcess) -> None:
+def test_compiler_hash(fs: FakeFilesystem, fake_process: FakeProcess) -> None:
     """
     Test the hash functionality.
     """
+    fs.create_file('/bin/tcc', create_missing_dirs=True, st_mode=0o755)
+    fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
     fake_process.register(['tcc', '--version'], stdout='5.6.7')
     fake_process.register(['mpicc', '--version'], stdout='5.6.7')
     cc1 = CCompiler('test C compiler', 'tcc', 'test',
@@ -168,12 +157,14 @@ def test_module_output(stub_fortran_compiler: FortranCompiler,
 
 def test_fortran_with_add_args(stub_fortran_compiler: FortranCompiler,
                                stub_configuration: BuildConfig,
-                               subproc_record: ExtendedRecorder) -> None:
+                               subproc_record: ExtendedRecorder,
+                               fs: FakeFilesystem) -> None:
     """
     Tests that additional arguments are handled as expected in
     a wrapper. Also make sure that the actual compiler wrapper (mpif90)
     is called, not gfortran.'''
     """
+    fs.create_file('/bin/mpif90', create_missing_dirs=True, st_mode=0o755)
     mpif90 = Mpif90(stub_fortran_compiler)
     mpif90.set_module_output_path(Path('/module_out'))
 
@@ -191,11 +182,13 @@ def test_fortran_with_add_args(stub_fortran_compiler: FortranCompiler,
 
 def test_fortran_unnecessary_openmp(stub_fortran_compiler: FortranCompiler,
                                     stub_configuration: BuildConfig,
-                                    subproc_record: ExtendedRecorder) -> None:
+                                    subproc_record: ExtendedRecorder,
+                                    fs: FakeFilesystem) -> None:
     """
     Tests that additional arguments are handled as expected in
     a wrapper if also the openmp flags are specified.
     """
+    fs.create_file('/bin/mpif90', create_missing_dirs=True, st_mode=0o755)
     mpif90 = Mpif90(stub_fortran_compiler)
     mpif90.set_module_output_path(Path('/module_out'))
 
@@ -214,12 +207,14 @@ def test_fortran_unnecessary_openmp(stub_fortran_compiler: FortranCompiler,
 
 def test_c_with_add_args(stub_c_compiler: CCompiler,
                          stub_configuration: BuildConfig,
-                         subproc_record: ExtendedRecorder) -> None:
+                         subproc_record: ExtendedRecorder,
+                         fs: FakeFilesystem) -> None:
     """
     Tests that additional arguments are handled as expected in a
     compiler wrapper. Also verify that requesting Fortran-specific options
     like syntax-only with the C compiler raises a runtime error.
     """
+    fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
     mpicc = Mpicc(stub_c_compiler)
     # Normal invoke of the C compiler, make sure add_flags are
     # passed through:
@@ -254,11 +249,13 @@ def test_c_with_add_args(stub_c_compiler: CCompiler,
 
 def test_flags_independent(stub_c_compiler: CCompiler,
                            stub_configuration: BuildConfig,
-                           subproc_record: ExtendedRecorder) -> None:
+                           subproc_record: ExtendedRecorder,
+                           fs: FakeFilesystem) -> None:
     """
     Tests that flags set in the base compiler will be accessed in the
     wrapper, but not the other way round.
     """
+    fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
     wrapper = Mpicc(stub_c_compiler)
     assert stub_c_compiler.get_flags() == []
     assert wrapper.get_flags() == []
@@ -286,9 +283,12 @@ def test_flags_independent(stub_c_compiler: CCompiler,
 
 def test_compiler_wrapper_flags_with_add_arg(stub_c_compiler: CCompiler,
                                              stub_configuration: BuildConfig,
-                                             subproc_record: ExtendedRecorder):
-    '''Tests that flags set in the base compiler will be accessed in the
-    wrapper if also additional flags are specified.'''
+                                             subproc_record: ExtendedRecorder,
+                                             fs: FakeFilesystem):
+    """
+    Checks compiler argument propagation.
+    """
+    fs.create_file('/bin/mpicc', create_missing_dirs=True, st_mode=0o755)
     mpicc = Mpicc(stub_c_compiler)
     stub_c_compiler.define_profile("default", inherit_from="")
     mpicc.define_profile("default", inherit_from="")
@@ -315,11 +315,13 @@ def test_compiler_wrapper_flags_with_add_arg(stub_c_compiler: CCompiler,
 
 def test_args_without_add_arg(stub_c_compiler: CCompiler,
                               stub_configuration: BuildConfig,
-                              subproc_record: ExtendedRecorder) -> None:
+                              subproc_record: ExtendedRecorder,
+                              fs: FakeFilesystem) -> None:
     """
     Tests that flags set in the base compiler will be accessed in the
     wrapper if no additional flags are specified.
     """
+    fs.create_file('/bin/wrp', create_missing_dirs=True, st_mode=0o755)
     wrapper = CompilerWrapper('wrapper', 'wrp', compiler=stub_c_compiler)
 
     stub_c_compiler.add_flags(["-a", "-b"])

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -9,16 +9,17 @@ Exercises linker tooling.
 from pathlib import Path
 import warnings
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import ExtendedRecorder, not_found_callback
 
 from fab.build_config import BuildConfig
 from fab.tools.category import Category
 from fab.tools.compiler import CCompiler, FortranCompiler
 from fab.tools.compiler_wrapper import CompilerWrapper, Mpif90
 from fab.tools.linker import Linker
+
+from tests.conftest import ExtendedRecorder, not_found_callback
 
 
 def test_c_linker(stub_c_compiler: CCompiler) -> None:
@@ -78,29 +79,26 @@ def test_linker_openmp(openmp: bool) -> None:
     assert wrapped_linker.openmp == openmp
 
 
-def test_check_available(stub_c_compiler: CCompiler,
+@mark.parametrize('available', [True, False])
+def test_check_available(available: bool,
+                         fs: FakeFilesystem,
                          fake_process: FakeProcess) -> None:
     """
     Tests the is_available functionality when compiler is present.
     """
+    if available:
+        fs.create_file('/bin/scc', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
+    cc = CCompiler("Some C compiler", 'scc', 'test', r'[/d.]+')
     fake_process.register(['scc', '--version'], stdout='1.2.3')
-    linker = Linker(stub_c_compiler)
-    assert linker.check_available()
+    linker = Linker(cc)
+    assert linker.is_available is available
 
     # Then test the usage of a linker wrapper. The linker will call the
     # corresponding function in the wrapper linker:
-    wrapped_linker = Linker(stub_c_compiler, linker=linker)
-    assert wrapped_linker.check_available()
-
-
-def test_check_unavailable(stub_c_compiler: CCompiler,
-                           fake_process: FakeProcess) -> None:
-    """
-    Tests is_available functionality when compiler is missing.
-    """
-    fake_process.register(['scc', '--version'], callback=not_found_callback)
-    linker = Linker(stub_c_compiler)
-    assert linker.check_available() is False
+    wrapped_linker = Linker(cc, linker=linker)
+    assert wrapped_linker.is_available is available
 
 
 # ====================

--- a/tests/unit_tests/tools/test_preprocessor.py
+++ b/tests/unit_tests/tools/test_preprocessor.py
@@ -9,6 +9,8 @@ Tests source preprocessor tools.
 from logging import Logger
 from pathlib import Path
 
+from pyfakefs.fake_filesystem import FakeFilesystem
+
 from tests.conftest import ExtendedRecorder
 
 from pytest import mark
@@ -32,17 +34,17 @@ def test_constructor() -> None:
     assert isinstance(tool.logger, Logger)
 
 
-@mark.parametrize('rc', [0, 1])
-def test_fpp_is_available(rc, fake_process: FakeProcess) -> None:
+@mark.parametrize('available', [True, False])
+def test_fpp_is_available(available: bool, fs: FakeFilesystem) -> None:
     """
     Tests availability check for Intel's "fpp" tool.
     """
-    command = ['fpp', '-what']
-    fake_process.register(command, returncode=rc)
-
+    if available:
+        fs.create_file('/bin/fpp', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
     fpp = Fpp()
-    assert fpp.is_available is (rc == 0)
-    assert call_list(fake_process) == [command]
+    assert fpp.is_available is available
 
 
 class TestCpp:
@@ -54,24 +56,28 @@ class TestCpp:
         cpp.run("--version")
         assert subproc_record.invocations() == [['cpp', '--version']]
 
-    def test_is_not_available(self, fake_process: FakeProcess) -> None:
-        fake_process.register(['cpp', '--version'], returncode=1)
+    @mark.parametrize('available', [True, False])
+    def test_is_available(self, available: bool, fs: FakeFilesystem) -> None:
+        if available:
+            fs.create_file('/bin/cpp', create_missing_dirs=True, st_mode=0o755)
+        else:
+            fs.create_dir('/bin')
         cpp = Cpp()
-        assert cpp.is_available is False
-        assert call_list(fake_process) == [['cpp', '--version']]
+        assert cpp.is_available is available
 
 
 class TestCppTraditional:
-    def test_is_not_available(self, fake_process: FakeProcess) -> None:
+    @mark.parametrize('available', [True, False])
+    def test_is_available(self, available: bool, fs: FakeFilesystem) -> None:
         """
         Tests CPP in "traditional" mode.
         """
-        command = ['cpp', '-traditional-cpp', '-P', '--version']
-        fake_process.register(command, returncode=1)
-
+        if available:
+            fs.create_file('/bin/cpp', create_missing_dirs=True, st_mode=0o755)
+        else:
+            fs.create_dir('/bin')
         cppf = CppFortran()
-        assert cppf.is_available is False
-        assert call_list(fake_process) == [command]
+        assert cppf.is_available is available
 
     def test_preprocess(self, subproc_record: ExtendedRecorder) -> None:
         cppf = CppFortran()

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -12,6 +12,7 @@ import typing  # Needed for monkey patching
 from typing import Optional, Tuple
 from unittest.mock import Mock
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises, warns
 from pytest_subprocess.fake_process import FakeProcess
 
@@ -19,6 +20,7 @@ from fab.tools.category import Category
 import fab.tools.psyclone  # Needed for mockery
 from fab.tools.psyclone import Psyclone
 
+from source.fab import FabException
 from tests.conftest import call_list, not_found_callback
 
 
@@ -35,13 +37,15 @@ def test_constructor():
 
 
 @mark.parametrize("version", ["2.4.0", "2.5.0", "3.0.0", "3.1.0"])
-def test_check_available_and_version(version: str,
-                                     fake_process: FakeProcess) -> None:
+def test_is_available_and_version(version: str,
+                                  fs: FakeFilesystem,
+                                  fake_process: FakeProcess) -> None:
     """
-    Tests the is_available functionality and version number detection
-    with PSyclone. Note that the version number is only used internally,
-    so we test with the private attribute.
+    Checks availability check.
+
+    This check includes harvesting the tool's version number.
     """
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
     version_command = ['psyclone', '--version']
     fake_process.register(version_command,
                           stdout='PSyclone version: ' + version)
@@ -49,66 +53,55 @@ def test_check_available_and_version(version: str,
     psyclone = Psyclone()
 
     version_tuple = tuple(int(i) for i in version.split("."))
-    assert psyclone.check_available()
-    assert psyclone._version == version_tuple
+    assert psyclone.is_available is True
+    assert psyclone.version == version_tuple
     assert call_list(fake_process) == [version_command]
 
 
-def test_check_available_errors(fake_process: FakeProcess) -> None:
+def test_not_available(fs: FakeFilesystem) -> None:
     """
     Tests lack of availability.
     """
-    version_command = ['psyclone', '--version']
-    fake_process.register(version_command, callback=not_found_callback)
-
+    fs.create_dir('/bin')
     psyclone = Psyclone()
-    assert psyclone.check_available() is False
+    assert psyclone.is_available is False
 
 
-def test_not_available(fake_process: FakeProcess) -> None:
-    """
-    Tests lack of availability.
-    """
-    fake_process.register(['psyclone', '--version'],
-                          callback=not_found_callback)
-
-    psyclone = Psyclone()
-
-    assert psyclone.check_available() is False
-    assert call_list(fake_process) == [
-        ['psyclone', '--version']
-    ]
-
-
-def test_check_available_bad_version(fake_process: FakeProcess) -> None:
+def test_check_available_bad_version(fs: FakeFilesystem,
+                                     fake_process: FakeProcess) -> None:
     """
     Tests executable which returns an unexpected version string.
     """
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
     fake_process.register(['psyclone', '--version'],
                           stdout='PSyclone version: NOT_A_NUMBER.4.0')
 
     psyclone = Psyclone()
 
-    with warns(UserWarning,
+    with raises(FabException,
                match="Unexpected version information for PSyclone: "
                      "'PSyclone version: NOT_A_NUMBER.4.0'"):
-        assert psyclone.check_available() is False
+        _ = psyclone.is_available
 
 
-def test_check_process_missing(fake_process: FakeProcess) -> None:
+def test_is_available_broken(fs: FakeFilesystem, fake_process: FakeProcess) -> None:
     """
-    Tests processing with a missing executable.
+    Checks a present but broken installation.
     """
-    fake_process.register(['psyclone', '--version'],
-                          callback=not_found_callback)
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
+    fake_process.register(['psyclone', '--version'], returncode=1)
 
     psyclone = Psyclone()
     config = Mock()
 
     with raises(RuntimeError) as err:
         psyclone.process(config,
-                         Path("x90file"))
-    assert str(err.value).startswith("PSyclone is not available")
+                         Path("x90file"),
+                         api='lfric',
+                         psy_file=Path('/home/user/psy.f90'),
+                         alg_file=Path('/home/user/alg.f90'))
+    assert str(err.value) == ("PSyclone present but version unobtainable."
+                              " Is installation broken?")
 
 
 def test_processing_errors_without_api(fake_process: FakeProcess) -> None:
@@ -192,11 +185,14 @@ def test_processing_errors_with_api(api: str,
                           ("gocean", "gocean1.0")
                           ])
 def test_process_api_old_psyclone(api: Tuple[str, str], version: str,
+                                  fs: FakeFilesystem,
                                   fake_process: FakeProcess) -> None:
     """
     Tests old style API support with PSyclone 2.5.0 and earlier.
     """
     api_in, api_out = api
+
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
 
     version_command = ['psyclone', '--version']
     fake_process.register(version_command,
@@ -228,12 +224,15 @@ def test_process_api_old_psyclone(api: Tuple[str, str], version: str,
 @mark.parametrize('version', ['2.4.0', '2.5.0'])
 @mark.parametrize('api', [None, 'nemo'])
 def test_process_nemo_api_old_psyclone(version: str, api: Optional[str],
+                                       fs: FakeFilesystem,
                                        fake_process: FakeProcess) -> None:
     """
     Tests NEMO API with PSyclone 2.5.0 or earlier.
 
     ToDo: The wierd extra bits performed for 2.5.0 look highly dubious.
     """
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
+
     version_command = ['psyclone', '--version']
     fake_process.register(version_command,
                           stdout='PSyclone version: ' + version)
@@ -272,6 +271,7 @@ def test_process_nemo_api_old_psyclone(version: str, api: Optional[str],
                       ("gocean", "gocean")
                   ])
 def test_process_api_new_psyclone(api: Tuple[str, str],
+                                  fs: FakeFilesystem,
                                   fake_process: FakeProcess) -> None:
     """
     Test running PSyclone 3.0.0. It uses new API names, and we need to
@@ -279,9 +279,10 @@ def test_process_api_new_psyclone(api: Tuple[str, str],
     """
     api_in, api_out = api
 
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
+
     version_command = ['psyclone', '--version']
     fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
-
     psyclone_command = ['psyclone', '--psykal-dsl', api_out,
                         '-opsy', 'psy_file', '-oalg', 'alg_file', '-l', 'all',
                         '-s', 'script_called', '-c', 'psyclone.cfg',
@@ -305,14 +306,16 @@ def test_process_api_new_psyclone(api: Tuple[str, str],
     ]
 
 
-def test_process_no_api_new_psyclone(fake_process: FakeProcess) -> None:
+def test_process_no_api_new_psyclone(fs: FakeFilesystem,
+                                     fake_process: FakeProcess) -> None:
     """
     Test running the PSyclone 3.0.0 without an API, i.e. as transformation
     only.
     """
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
+
     version_command = ['psyclone', '--version']
     fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
-
     psyclone_command = ['psyclone', '-o', 'psy_file', '-l', 'all',
                         '-s', 'script_called', '-c', 'psyclone.cfg',
                         '-d', 'root1', '-d', 'root2', 'x90_file']
@@ -334,14 +337,16 @@ def test_process_no_api_new_psyclone(fake_process: FakeProcess) -> None:
     ]
 
 
-def test_process_nemo_api_new_psyclone(fake_process: FakeProcess) -> None:
+def test_process_nemo_api_new_psyclone(fs: FakeFilesystem,
+                                       fake_process: FakeProcess) -> None:
     """
     Test running PSyclone 3.0.0 and test that backwards compatibility of
     using the nemo api works, i.e. '-api nemo' is just removed.
     """
+    fs.create_file('/bin/psyclone', create_missing_dirs=True, st_mode=0o755)
+
     version_command = ['psyclone', '--version']
     fake_process.register(version_command, stdout='PSyclone version: 3.0.0')
-
     psyclone_command = ['psyclone', '-o', 'psy_file', '-l', 'all',
                         '-s', 'script_called', '-c', 'psyclone.cfg',
                         '-d', 'root1', '-d', 'root2', 'x90_file']

--- a/tests/unit_tests/tools/test_rsync.py
+++ b/tests/unit_tests/tools/test_rsync.py
@@ -8,12 +8,14 @@ Tests RSync file tree synchronisation tool.
 """
 from pathlib import Path
 
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import call_list, not_found_callback
 
 from fab.tools.category import Category
 from fab.tools.rsync import Rsync
+
+from tests.conftest import call_list, not_found_callback
 
 
 def test_constructor():
@@ -27,23 +29,18 @@ def test_constructor():
     assert rsync.get_flags() == []
 
 
-def test_check_available(fake_process: FakeProcess) -> None:
+@mark.parametrize('available', [True, False])
+def test_check_available(available: bool, fs: FakeFilesystem) -> None:
     """
     Tests availability checking functionality.
     """
-    fake_process.register(['rsync', '--version'], stdout='1.2.3')
-    fake_process.register(['rsync', '--version'], callback=not_found_callback)
+    if available:
+        fs.create_file('/bin/rsync', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
 
     rsync = Rsync()
-    assert rsync.check_available()
-
-    # Test behaviour if a runtime error happens:
-    assert not rsync.check_available()
-
-    assert call_list(fake_process) == [
-        ['rsync', '--version'],
-        ['rsync', '--version']
-    ]
+    assert rsync.is_available is available
 
 
 def test_rsync_create(fake_process: FakeProcess) -> None:

--- a/tests/unit_tests/tools/test_shell.py
+++ b/tests/unit_tests/tools/test_shell.py
@@ -6,12 +6,14 @@
 """
 Tests Shell tools.
 """
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
 from fab.tools.category import Category
 from fab.tools.shell import Shell
+
+from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
 
 def test_constructor() -> None:
@@ -24,23 +26,17 @@ def test_constructor() -> None:
     assert bash.exec_name == "nish"
 
 
-def test_check_available(fake_process: FakeProcess) -> None:
+@mark.parametrize('available', [True, False])
+def test_check_available(available: bool, fs: FakeFilesystem) -> None:
     """
     Tests availability functionality.
     """
-    fake_process.register(["nish", "-c", "echo hello"])
-    fake_process.register(["nish", "-c", "echo hello"], callback=not_found_callback)
-
+    if available:
+        fs.create_file('/bin/nish', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
     shell = Shell("nish")
-    assert shell.check_available()
-
-    # Test behaviour if a runtime error happens:
-    assert not shell.check_available()
-
-    assert call_list(fake_process) == [
-        ['nish', '-c', 'echo hello'],
-        ['nish', '-c', 'echo hello']
-    ]
+    assert shell.is_available is available
 
 
 def test_exec_single_arg(subproc_record: ExtendedRecorder) -> None:

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -8,15 +8,17 @@ Tests tooling base classes.
 """
 import logging
 from pathlib import Path
+from typing import List
 
-from pytest import raises
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest import mark, raises
 from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import ExtendedRecorder, call_list, not_found_callback
 
 from fab.tools.category import Category
 from fab.tools.flags import ProfileFlags
 from fab.tools.tool import CompilerSuiteTool, Tool
+
+from tests.conftest import ExtendedRecorder, call_list
 
 
 def test_constructor() -> None:
@@ -26,7 +28,7 @@ def test_constructor() -> None:
     tool = Tool("gnu", "gfortran", Category.FORTRAN_COMPILER)
     assert str(tool) == "Tool - gnu: gfortran"
     assert tool.exec_name == "gfortran"
-    assert tool.exec_path == Path("gfortran")
+    assert tool.executable == Path("gfortran")
     assert tool.name == "gnu"
     assert tool.category == Category.FORTRAN_COMPILER
     assert isinstance(tool.logger, logging.Logger)
@@ -45,7 +47,7 @@ def test_constructor() -> None:
     assert mytool.name == "MyTool"
     # A path should be converted to a string, since this
     # is later passed to the subprocess command
-    assert mytool.exec_path == Path("/bin/mytool")
+    assert mytool.executable == Path("/bin/mytool")
     assert mytool.category == Category.MISC
 
     # Check that if we specify no category, we get the default:
@@ -62,69 +64,22 @@ def test_tool_set_path() -> None:
     gfortran = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
     gfortran.set_full_path(Path("/usr/bin/gfortran1.2.3"))
     # Exec name should now return the full path
-    assert gfortran.exec_path == Path("/usr/bin/gfortran1.2.3")
+    assert gfortran.executable == Path("/usr/bin/gfortran1.2.3")
     # Path the name of the compiler is unchanged
     assert gfortran.name == "gfortran"
 
 
-def test_is_available(fake_process: FakeProcess) -> None:
+@mark.parametrize('available', [True, False])
+def test_is_available(available: bool, fs: FakeFilesystem) -> None:
     """
-    Tests tool availability checking.
+    Checks ability to detect tool availability.
     """
-    fake_process.register(['gfortran', '--version'], stdout="1.2.3")
-    tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
-    assert tool.is_available
-
-
-def test_is_not_available(fake_process: FakeProcess) -> None:
-    """
-    Tests a tool that is not available.
-    """
-    fake_process.register(['gfortran', '--version'],
-                          callback=not_found_callback)
-    tool = Tool("gfortran", "gfortran", Category.FORTRAN_COMPILER)
-    assert not tool.is_available
-
-    # When we try to run something with this tool, we should get
-    # an exception now:
-    with raises(RuntimeError) as err:
-        tool.run("--ops")
-    assert ("Tool 'gfortran' is not available to run '['gfortran', '--ops']"
-            in str(err.value))
-
-
-def test_availability_argument(fake_process: FakeProcess) -> None:
-    """
-    Tests setting the argument used to detect availability.
-    """
-    tool = Tool("ftool", "ftool", Category.FORTRAN_COMPILER,
-                availability_option="am_i_here")
-    assert tool.availability_option == "am_i_here"
-    fake_process.register(['ftool', 'am_i_here'], callback=not_found_callback)
-    assert not tool.check_available()
-
-
-def test_run_missing(fake_process: FakeProcess) -> None:
-    """
-    Tests attempting to run a missing tool.
-    """
-    fake_process.register(['stool', '--ops'], callback=not_found_callback)
-    tool = Tool("some tool", "stool", Category.MISC)
-    with raises(RuntimeError) as err:
-        tool.run("--ops")
-    assert str(err.value).startswith(
-        "Unable to execute command: ['stool', '--ops']"
-    )
-
-    # Check that stdout and stderr is returned
-    fake_process.register(['stool', '--ops'], returncode=1,
-                          stdout="this is stdout",
-                          stderr="this is stderr")
-    tool = Tool("some tool", "stool", Category.MISC)
-    with raises(RuntimeError) as err:
-        tool.run("--ops")
-    assert "this is stdout" in str(err.value)
-    assert "this is stderr" in str(err.value)
+    if available:
+        fs.create_file('/bin/test', create_missing_dirs=True, st_mode=0o755)
+    else:
+        fs.create_dir('/bin')
+    tool = Tool('test', 'test', Category.MISC)
+    assert tool.is_available is available
 
 
 def test_tool_flags_no_profile() -> None:
@@ -167,39 +122,46 @@ class TestToolRun:
     """
     Tests tool run method.
     """
-    def test_no_error_no_args(self, fake_process: FakeProcess) -> None:
+    @mark.parametrize('capture', [True, False])
+    def test_capture(self, capture: bool,
+                     fs: FakeFilesystem,
+                     fake_process: FakeProcess) -> None:
         """
-        Tests run with no aruments.
+        Checks output capture.
         """
-        fake_process.register(['stool'], stdout="123")
+        fs.create_file('/bin/stool', create_missing_dirs=True, st_mode=0o755)
         fake_process.register(['stool'], stdout="123")
         tool = Tool("some tool", "stool", Category.MISC)
-        assert tool.run(capture_output=True) == "123"
-        assert tool.run(capture_output=False) == ""
-        assert call_list(fake_process) == [['stool'], ['stool']]
+        if capture:
+            assert tool.run(capture_output=True) == "123"
+        else:
+            assert tool.run(capture_output=False) == ""
+        assert call_list(fake_process) == [['stool']]
 
+    @mark.parametrize('args', [
+        [],
+        ['a'],
+        ['b', 'c']
+    ])
     def test_run_with_single_args(self,
+                                  args: List[str],
+                                  fs: FakeFilesystem,
                                   subproc_record: ExtendedRecorder) -> None:
         """
-        Tets run with single argument.
+        Checks argument passing.
         """
-        tool = Tool("some tool", "tool", Category.MISC)
-        tool.run("a")
-        assert subproc_record.invocations() == [['tool', 'a']]
+        fs.create_file('/bin/stool', create_missing_dirs=True, st_mode=0o755)
+        tool = Tool("some tool", "stool", Category.MISC)
+        tool.run(args)
+        expected = ['stool']
+        expected.extend(args)
+        assert subproc_record.invocations() == [expected]
 
-    def test_run_with_multiple_args(self,
-                                    subproc_record: ExtendedRecorder) -> None:
-        """
-        Tests run with multiple arguments.
-        """
-        tool = Tool("some tool", "tool", Category.MISC)
-        tool.run(["a", "b"])
-        assert subproc_record.invocations() == [['tool', 'a', 'b']]
-
-    def test_error(self, fake_process: FakeProcess) -> None:
+    def test_error(self, fs: FakeFilesystem, fake_process: FakeProcess) -> None:
         """
         Tests running a failing tool.
         """
+        fs.create_file('/bin/tool', create_missing_dirs=True, st_mode=0o755)
         fake_process.register(['tool'], returncode=1, stdout="Beef.")
         tool = Tool("some tool", "tool", Category.MISC)
         with raises(RuntimeError) as err:
@@ -208,16 +170,15 @@ class TestToolRun:
                                   "['tool']\nBeef.")
         assert call_list(fake_process) == [['tool']]
 
-    def test_error_file_not_found(self, fake_process: FakeProcess) -> None:
+    def test_error_tool_not_found(self, fs: FakeFilesystem) -> None:
         """
         Tests running a missing tool.
         """
-        fake_process.register(['tool'], callback=not_found_callback)
+        fs.create_dir('/bin')
         tool = Tool('some tool', 'tool', Category.MISC)
         with raises(RuntimeError) as err:
             tool.run()
-        assert str(err.value) == "Unable to execute command: ['tool']"
-        assert call_list(fake_process) == [['tool']]
+        assert str(err.value) == "Tool 'some tool' is not available to run ['tool']"
 
 
 def test_suite_tool() -> None:

--- a/tests/unit_tests/tools/test_tool_box.py
+++ b/tests/unit_tests/tools/test_tool_box.py
@@ -8,13 +8,12 @@ Tests holding tools in a tool box.
 """
 import warnings
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import raises, warns
-from pytest_subprocess.fake_process import FakeProcess
-
-from tests.conftest import not_found_callback
 
 from fab.tools.category import Category
-from fab.tools.compiler import CCompiler, Gfortran
+from fab.tools.compiler import CCompiler
+from fab.tools.tool import Tool
 from fab.tools.tool_box import ToolBox
 from fab.tools.tool_repository import ToolRepository
 
@@ -77,15 +76,12 @@ def test_tool_replacement() -> None:
         tb.add_tool(mock_compiler1, silent_replace=True)
 
 
-def test_add_unavailable_tool(fake_process: FakeProcess) -> None:
+def test_add_unavailable_tool(fs: FakeFilesystem) -> None:
     """
     Tests unavailable tools are not accepted by toolbox.
     """
-    fake_process.register(['gfortran', '--version'],
-                          callback=not_found_callback)
-
     tb = ToolBox()
-    gfortran = Gfortran()
+    tool = Tool("Some tool", 'stool')
     with raises(RuntimeError) as err:
-        tb.add_tool(gfortran)
-    assert str(err.value).startswith(f"Tool '{gfortran}' is not available")
+        tb.add_tool(tool)
+    assert str(err.value) == f"Tool 'Tool - Some tool: stool' is not available."

--- a/tests/unit_tests/tools/test_tool_repository.py
+++ b/tests/unit_tests/tools/test_tool_repository.py
@@ -7,18 +7,23 @@
 Tests ToolBox class.
 """
 from pathlib import Path
+from typing import Type
+
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises
-from pytest_subprocess.fake_process import FakeProcess
 
 from fab.tools.ar import Ar
 from fab.tools.category import Category
 from fab.tools.compiler import FortranCompiler, Gcc, Gfortran, Ifort
 from fab.tools.compiler_wrapper import Mpif90
+from fab.tools.tool import Tool
 from fab.tools.tool_repository import ToolRepository
 
 
 def test_tool_repository_get_singleton_new():
-    '''Tests the singleton behaviour.'''
+    """
+    Tests the singleton behaviour.
+    """
     ToolRepository._singleton = None
     tr1 = ToolRepository()
     tr2 = ToolRepository()
@@ -29,30 +34,40 @@ def test_tool_repository_get_singleton_new():
 
 
 def test_tool_repository_constructor():
-    '''Tests the ToolRepository constructor.'''
+    """
+    Tests the ToolRepository constructor.
+    """
     tr = ToolRepository()
     assert Category.C_COMPILER in tr
     assert Category.FORTRAN_COMPILER in tr
 
 
-def test_tool_repository_get_tool():
-    '''Tests get_tool.'''
+@mark.parametrize('fortran, expected', [
+    ('gfortran', Gfortran),
+    ('ifort', Ifort)
+])
+def test_tool_repository_get_tool(fortran: str, expected: Type, fs: FakeFilesystem):
+    """
+    Checks basic "get tool" behaviour.
+    """
+    fs.create_file('/bin/' + fortran, create_missing_dirs=True, st_mode=0o755)
+    ToolRepository._singleton = None
     tr = ToolRepository()
-    gfortran = tr.get_tool(Category.FORTRAN_COMPILER, "gfortran")
-    assert isinstance(gfortran, Gfortran)
-
-    ifort = tr.get_tool(Category.FORTRAN_COMPILER, "ifort")
-    assert isinstance(ifort, Ifort)
+    gfortran = tr.get_tool(Category.FORTRAN_COMPILER, fortran)
+    assert isinstance(gfortran, expected)
 
 
-def test_tool_repository_get_tool_with_exec_name(stub_fortran_compiler):
-    '''Tests get_tool when the name of the executable is specified, e.g.
-    mpif90 (instead of the Fab name mpif90-gfortran etc).
+def test_tool_repository_get_tool_with_exec_name(stub_fortran_compiler,
+                                                 fs: FakeFilesystem) -> None:
+    """
+    Checks tool retrieval using executable name.
 
-    '''
+    As opposed to Fab identifier (e.g. mpif90-gfortran).
+
+    Todo: Messing with private state is bad.
+    """
+    ToolRepository._singleton = None
     tr = ToolRepository()
-    # Keep a copy of gfortran for later
-    gfortran = tr.get_tool(Category.FORTRAN_COMPILER, "gfortran")
 
     # First add just one unavailable Fortran compiler and an mpif90 wrapper:
     tr[Category.FORTRAN_COMPILER] = []
@@ -61,39 +76,46 @@ def test_tool_repository_get_tool_with_exec_name(stub_fortran_compiler):
     tr.add_tool(mpif90)
 
     # If mpif90 is not available, an error is raised:
-    mpif90._is_available = False
     try:
         tr.get_tool(Category.FORTRAN_COMPILER, "mpif90")
     except KeyError as err:
         assert "Unknown tool 'mpif90' in category" in str(err)
 
     # When using the exec name, the compiler must be available:
-    mpif90._is_available = True
+    fs.create_file('/bin/mpif90', create_missing_dirs=True, st_mode=0o755)
+    mpif90._is_available = None
     f90 = tr.get_tool(Category.FORTRAN_COMPILER, "mpif90")
     assert f90 is mpif90
 
-    # Now add mpif90-gfortran, set mpif90-gfortran as available,
-    # and mpif90-stub-fortran as unavailable. We need to make sure
-    # we then get mpif90-gfortran:
-    mpif90_gfortran = Mpif90(gfortran)
-    tr.add_tool(mpif90_gfortran)
-    mpif90._is_available = False
-    mpif90_gfortran._is_available = True
+    # Now add a different, available,  mpif90 and make mpif90-stub-fortran
+    # unavailable. We need to make sure we then get mpif90-gfortran:
+    fs.remove('/bin/sfc')
+    stub_fortran_compiler._is_available = None
+    fs.create_file('/bin/tfc', create_missing_dirs=True, st_mode=0o755)
+    fc_new = FortranCompiler("Test Fortran", 'tfc', 'test',
+                             version_regex=r'([\d.]+)')
+    tr.add_tool(fc_new)
+    mpif90_new = Mpif90(fc_new)
+    tr.add_tool(mpif90_new)
     f90 = tr.get_tool(Category.FORTRAN_COMPILER, "mpif90")
-    assert f90 is mpif90_gfortran
+    assert f90 is mpif90_new
 
     # Then verify using the full path
+    fs.remove('/bin/mpif90')
+    fs.create_file('/some/where/mpif90', create_missing_dirs=True, st_mode=0o755)
     f90 = tr.get_tool(Category.FORTRAN_COMPILER, "/some/where/mpif90")
-    assert f90 is mpif90_gfortran
-    assert f90.exec_path == Path("/some/where/mpif90")
+    assert f90 is mpif90_new
+    assert f90.executable == Path("/some/where/mpif90")
     # Reset the repository, since this test messed up the compilers.
     ToolRepository._singleton = None
 
 
-def test_get_tool_error():
+def test_get_tool_error(fs: FakeFilesystem):
     """
-    Tests error handling during tet_tool.
+    Checks tool getting error handling.
     """
+    fs.create_dir('/bin')
+    ToolRepository._singleton = None
     tr = ToolRepository()
     with raises(KeyError) as err:
         tr.get_tool("unknown-category", "something")
@@ -105,8 +127,14 @@ def test_get_tool_error():
             in str(err.value))
 
 
-def test_get_default() -> None:
-    '''Tests get_default.'''
+def test_get_default(fs: FakeFilesystem) -> None:
+    """
+    Checks default compilers.
+    """
+    fs.create_file('/bin/gfortran', create_missing_dirs=True, st_mode=0o755)
+    fs.create_file('/bin/gcc', create_missing_dirs=True, st_mode=0o755)
+    fs.create_file('/bin/ar', create_missing_dirs=True, st_mode=0o755)
+    ToolRepository._singleton = None
     tr = ToolRepository()
     gfortran = tr.get_default(Category.FORTRAN_COMPILER, mpi=False,
                               openmp=False)
@@ -211,14 +239,13 @@ def test_get_default_error_missing_openmp_compiler(monkeypatch) -> None:
 @mark.parametrize('category', [Category.C_COMPILER,
                                Category.FORTRAN_COMPILER,
                                Category.LINKER])
-def test_default_gcc_suite(category, fake_process: FakeProcess) -> None:
+def test_default_gcc_suite(category, fs: FakeFilesystem) -> None:
     """
     Tests setting default suite to "GCC" produces correct tools.
     """
-    fake_process.register(['gcc', '--version'], stdout='gcc (foo) 1.2.3')
-    fake_process.register(['gfortran', '--version'],
-                          stdout='GNU Fortran (foo) 1.2.3')
-
+    fs.create_file('/bin/gcc', create_missing_dirs=True, st_mode=0o755)
+    fs.create_file('/bin/gfortran', create_missing_dirs=True, st_mode=0o755)
+    ToolRepository._singleton = None
     tr = ToolRepository()
     tr.set_default_compiler_suite('gnu')
     def_tool = tr.get_default(category, mpi=False, openmp=False)
@@ -228,14 +255,13 @@ def test_default_gcc_suite(category, fake_process: FakeProcess) -> None:
 @mark.parametrize('category', [Category.C_COMPILER,
                                Category.FORTRAN_COMPILER,
                                Category.LINKER])
-def test_default_intel_suite(category, fake_process: FakeProcess) -> None:
+def test_default_intel_suite(category, fs: FakeFilesystem) -> None:
     """
     Tests setting default suite to "classic-intel" produces correct tools.
     """
-    fake_process.register(['icc', '--version'], stdout='icc (ICC) 1.2.3 foo')
-    fake_process.register(['ifort', '--version'],
-                          stdout='ifort (IFORT) 1.2.3 foo')
-
+    fs.create_file('/bin/icc', create_missing_dirs=True, st_mode=0o755)
+    fs.create_file('/bin/ifort', create_missing_dirs=True, st_mode=0o755)
+    ToolRepository._singleton = None
     tr = ToolRepository()
     tr.set_default_compiler_suite('intel-classic')
     def_tool = tr.get_default(category, mpi=False, openmp=False)
@@ -246,6 +272,7 @@ def test_default_suite_unknown() -> None:
     """
     Tests handling if a compiler suite is selected that does not exist.
     """
+    ToolRepository._singleton = None
     repo = ToolRepository()
     with raises(RuntimeError) as err:
         repo.set_default_compiler_suite("does-not-exist")
@@ -253,14 +280,11 @@ def test_default_suite_unknown() -> None:
                               "the suite 'does-not-exist'.")
 
 
-def test_no_tool_available(fake_process: FakeProcess) -> None:
+def test_no_tool_available(fs: FakeFilesystem) -> None:
     """
     Tests error handling if no tool is available.
     """
-    # All attempted subprocesses fail.
-    #
-    fake_process.register([FakeProcess.any()], returncode=1)
-
+    ToolRepository._singleton = None
     tr = ToolRepository()
     tr.set_default_compiler_suite("gnu")
 
@@ -270,17 +294,18 @@ def test_no_tool_available(fake_process: FakeProcess) -> None:
                               "'sh'.")
 
 
-def test_tool_repository_full_path(fake_process: FakeProcess) -> None:
-    '''Tests that a user can request a tool with a full path,
-    in which case the right tool should be returned with an updated
-    exec name that uses the path.
-    '''
-    tr = ToolRepository()
-    gfortran = tr.get_tool(Category.FORTRAN_COMPILER, "/usr/bin/gfortran")
-    assert isinstance(gfortran, Gfortran)
-    assert gfortran.name == "gfortran"
-    assert gfortran.exec_name == "gfortran"
-    assert gfortran.exec_path == Path("/usr/bin/gfortran")
+def test_tool_repository_full_path(fs: FakeFilesystem) -> None:
+    """
+    Checks full path request.
 
-    fake_process.register(['/usr/bin/gfortran', 'a'])
-    gfortran.run("a")
+    The appropriate tool should be returned with updated executable path.
+    """
+    fs.create_file('/opt/test/bin/ttool', create_missing_dirs=True, st_mode=0o755)
+    ToolRepository._singleton = None
+    tr = ToolRepository()
+    tr.add_tool(Tool("Test tool", 'ttool', category=Category.MISC))
+    tool = tr.get_tool(Category.MISC, '/opt/test/bin/ttool')
+    assert isinstance(tool, Tool)
+    assert tool.name == "Test tool"
+    assert tool.exec_name == "ttool"
+    assert tool.executable == Path("/opt/test/bin/ttool")

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -13,14 +13,15 @@ from subprocess import Popen, run
 from time import sleep
 from typing import List, Tuple
 
+from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import TempPathFactory, fixture, mark, raises
 from pytest_subprocess.fake_process import FakeProcess
 
-from tests.conftest import (ExtendedRecorder,
-                            arg_list, call_list, not_found_callback)
-
 from fab.tools.category import Category
 from fab.tools.versioning import Fcm, Git, Subversion
+
+from tests.conftest import (ExtendedRecorder,
+                            arg_list, call_list, not_found_callback)
 
 
 class TestGit:
@@ -33,21 +34,17 @@ class TestGit:
         assert git.category == Category.GIT
         assert git.get_flags() == []
 
-    def test_git_check_available(self, fake_process: FakeProcess) -> None:
+    @mark.parametrize('available', [True, False])
+    def test_git_check_available(self, available: bool, fs: FakeFilesystem) -> None:
         """
         Tests availability check.
         """
-        fake_process.register(['git', 'help'], stdout='1.2.3')
-
+        if available:
+            fs.create_file('/bin/git', create_missing_dirs=True, st_mode=0o755)
+        else:
+            fs.create_dir('/bin')
         git = Git()
-        assert git.check_available()
-
-        fake_process.register(['git', 'help'], callback=not_found_callback)
-        assert not git.check_available()
-
-        assert call_list(fake_process) == [
-            ['git', 'help'], ['git', 'help']
-        ]
+        assert git.is_available is available
 
     def test_git_current_commit(self, fake_process: FakeProcess) -> None:
         """


### PR DESCRIPTION
PSyclone and compilers still manage version numbers as before as they are interesting to us. This should also address BoM's concern regarding broken Python installations.

Also notice that the `ToolRepository` causes a lot of trouble but fixing (or potentially just removing) that is a larger issue.