### PR TITLE
Fix a trivial CUI argument handling bug

### DIFF
--- a/source/fab/cui/__main__.py
+++ b/source/fab/cui/__main__.py
@@ -58,7 +58,7 @@ def main(argv: Optional[List[str]] = None):
 
     if argv is None:
         # Use system argument if none have been provided
-        argv = sys.argv
+        argv = sys.argv[1:]
 
     parser = FabArgumentParser(description=__doc__)
     file_args = parser.parse_fabfile_only(argv)


### PR DESCRIPTION
The command line argument list passed to argparse is incorrect and can give rise to spurious errors in some cases.  This corrects the problem by removing the first element (the command name itself) from the list of arguments passed to argparse.

This resolves issue #536