### PR TITLE
Honor type hinting deprecation 

### DIFF
--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import auto, Enum
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Iterable, Optional, Union
 
 from fab.dep_tree import filter_source_tree, AnalysedDependent
 from fab.util import suffix_filter
@@ -98,7 +98,7 @@ class ArtefactStore(dict):
 
     def copy_artefacts(self, source: Union[str, ArtefactSet],
                        dest: Union[str, ArtefactSet],
-                       suffixes: Optional[Union[str, List[str]]] = None):
+                       suffixes: Optional[Union[str, list[str]]] = None):
         '''Copies all artefacts from `source` to `destination`. If a
         suffix_fiter is specified, only files with the given suffix
         will be copied.
@@ -115,8 +115,8 @@ class ArtefactStore(dict):
             self.add(dest, self[source])
 
     def replace(self, artefact: Union[str, ArtefactSet],
-                remove_files: List[Union[str, Path]],
-                add_files: Union[List[Union[str, Path]], dict]):
+                remove_files: list[Union[str, Path]],
+                add_files: Union[list[Union[str, Path]], dict]):
         '''Replaces artefacts in one artefact set with other artefacts. This
         can be used e.g to replace files that have been preprocessed
         and renamed. There is no requirement for these lists to have the
@@ -230,7 +230,7 @@ class SuffixFilter(ArtefactsGetter):
     """
     def __init__(self,
                  collection_name: Union[str, ArtefactSet],
-                 suffix: Union[str, List[str]]):
+                 suffix: Union[str, list[str]]):
         """
         :param collection_name:
             The name of the artefact collection.
@@ -258,10 +258,10 @@ class FilterBuildTrees(ArtefactsGetter):
         DEFAULT_SOURCE_GETTER = FilterBuildTrees(suffix='.f90')
 
     :returns: one list of files to compile per build tree, of the form
-        Dict[name, List[AnalysedDependent]]
+        Dict[name, list[AnalysedDependent]]
 
     """
-    def __init__(self, suffix: Union[str, List[str]]):
+    def __init__(self, suffix: Union[str, list[str]]):
         """
         :param suffix:
             A suffix string, or iterable of, including the preceding dot.
@@ -273,7 +273,7 @@ class FilterBuildTrees(ArtefactsGetter):
 
         build_trees = artefact_store[ArtefactSet.BUILD_TREES]
 
-        build_lists: Dict[str, List[AnalysedDependent]] = {}
+        build_lists: dict[str, list[AnalysedDependent]] = {}
         for root, tree in build_trees.items():
             build_lists[root] = filter_source_tree(source_tree=tree,
                                                    suffixes=self.suffixes)

--- a/source/fab/build_config.py
+++ b/source/fab/build_config.py
@@ -18,7 +18,7 @@ from logging.handlers import RotatingFileHandler
 from multiprocessing import cpu_count
 from pathlib import Path
 from string import Template
-from typing import List, Optional, Iterable
+from typing import Optional, Iterable
 
 from fab.artefacts import ArtefactSet, ArtefactStore
 from fab.constants import BUILD_OUTPUT, SOURCE_ROOT, PREBUILD
@@ -294,7 +294,7 @@ class AddFlags():
     Generally used inside a :class:`~fab.build_config.FlagsConfig`.
 
     """
-    def __init__(self, match: str, flags: List[str]):
+    def __init__(self, match: str, flags: list[str]):
         """
         :param match:
             The string to match against each file path.
@@ -318,11 +318,11 @@ class AddFlags():
 
         """
         self.match: str = match
-        self.flags: List[str] = flags
+        self.flags: list[str] = flags
 
     # todo: we don't need the project_workspace, we could just pass in the
     # output folder
-    def run(self, fpath: Path, input_flags: List[str], config):
+    def run(self, fpath: Path, input_flags: list[str], config):
         """
         Check if our filter matches a given file. If it does, add our flags.
 
@@ -357,13 +357,13 @@ class FlagsConfig():
     remove flags.
 
     """
-    def __init__(self, common_flags: Optional[List[str]] = None,
-                 path_flags: Optional[List[AddFlags]] = None):
+    def __init__(self, common_flags: Optional[list[str]] = None,
+                 path_flags: Optional[list[AddFlags]] = None):
         """
         :param common_flags:
-            List of flags to apply to all files. E.g `['-O2']`.
+            list of flags to apply to all files. E.g `['-O2']`.
         :param path_flags:
-            List of :class:`~fab.build_config.AddFlags` objects which apply
+            list of :class:`~fab.build_config.AddFlags` objects which apply
             flags to selected paths.
 
         """

--- a/source/fab/cli.py
+++ b/source/fab/cli.py
@@ -9,7 +9,7 @@
 
 import sys
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from fab.artefacts import ArtefactSet, CollectionGetter
 from fab.build_config import BuildConfig
@@ -65,7 +65,7 @@ def _generic_build_config(folder: Path, kwargs=None) -> BuildConfig:
     return config
 
 
-def cli_fab(folder: Optional[Path] = None, kwargs: Optional[Dict] = None):
+def cli_fab(folder: Optional[Path] = None, kwargs: Optional[dict] = None):
     """
     Running Fab from the command line will attempt to build the project in the current or
     given folder. The following params are used for testing. When run normally any parameters

--- a/source/fab/cui/__main__.py
+++ b/source/fab/cui/__main__.py
@@ -13,7 +13,7 @@ from importlib.util import module_from_spec, spec_from_loader
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import ModuleType
-from typing import List, Optional
+from typing import Optional
 
 
 from .arguments import FabArgumentParser
@@ -50,7 +50,7 @@ def import_from_path(module_name: str, file_path: Path) -> Optional[ModuleType]:
     return module
 
 
-def main(argv: Optional[List[str]] = None):
+def main(argv: Optional[list[str]] = None):
     """Main function.
 
     :param argv: list of command line arguments.  Use sys.argv if not specified.

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -1,4 +1,4 @@
-t##############################################################################
+##############################################################################
 # (c) Crown copyright Met Office. All rights reserved.
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution

--- a/source/fab/dep_tree.py
+++ b/source/fab/dep_tree.py
@@ -1,4 +1,4 @@
-##############################################################################
+t##############################################################################
 # (c) Crown copyright Met Office. All rights reserved.
 # For further details please refer to the file COPYRIGHT
 # which you should have received as part of this distribution
@@ -12,7 +12,7 @@ Classes and helper functions related to the dependency tree, as created by the a
 from abc import ABC
 import logging
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, Union
+from typing import Any, Iterable, Optional, Union
 
 from fab.parse import AnalysedFile
 
@@ -50,9 +50,9 @@ class AnalysedDependent(AnalysedFile, ABC):
         """
         super().__init__(fpath=fpath, file_hash=file_hash)
 
-        self.symbol_defs: Set[str] = set(symbol_defs or {})
-        self.symbol_deps: Set[str] = set(symbol_deps or {})
-        self.file_deps: Set[Path] = set(file_deps or [])
+        self.symbol_defs: set[str] = set(symbol_defs or {})
+        self.symbol_deps: set[str] = set(symbol_deps or {})
+        self.file_deps: set[Path] = set(file_deps or [])
 
         assert all([d and len(d) for d in self.symbol_defs]), "bad symbol definitions"
         assert all([d and len(d) for d in self.symbol_deps]), "bad symbol dependencies"
@@ -76,7 +76,7 @@ class AnalysedDependent(AnalysedFile, ABC):
             'file_deps',
         ]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = super().to_dict()
         result.update({
             "symbol_defs": list(sorted(self.symbol_defs)),
@@ -98,9 +98,9 @@ class AnalysedDependent(AnalysedFile, ABC):
         return result
 
 
-def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent],
+def extract_sub_tree(source_tree: dict[Path, AnalysedDependent],
                      root: Path, verbose=False)\
-        -> Dict[Path, AnalysedDependent]:
+        -> dict[Path, AnalysedDependent]:
     """
     Extract the subtree required to build the target, from the full source tree of all analysed source files.
 
@@ -112,8 +112,8 @@ def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent],
         Log missing dependencies.
 
     """
-    result: Dict[Path, AnalysedDependent] = dict()
-    missing: Set[Path] = set()
+    result: dict[Path, AnalysedDependent] = dict()
+    missing: set[Path] = set()
 
     _extract_sub_tree(src_tree=source_tree,
                       key=root,
@@ -127,10 +127,10 @@ def extract_sub_tree(source_tree: Dict[Path, AnalysedDependent],
     return result
 
 
-def _extract_sub_tree(src_tree: Dict[Path, AnalysedDependent],
+def _extract_sub_tree(src_tree: dict[Path, AnalysedDependent],
                       key: Path,
-                      dst_tree: Dict[Path, AnalysedDependent],
-                      missing: Set[Path],
+                      dst_tree: dict[Path, AnalysedDependent],
+                      missing: set[Path],
                       verbose: bool,
                       indent: int = 0):
     # is this node already in the sub tree?
@@ -160,7 +160,7 @@ def _extract_sub_tree(src_tree: Dict[Path, AnalysedDependent],
             src_tree=src_tree, key=file_dep, dst_tree=dst_tree, missing=missing, verbose=verbose, indent=indent + 1)
 
 
-def filter_source_tree(source_tree: Dict[Path, AnalysedDependent], suffixes: Iterable[str]) -> List[AnalysedDependent]:
+def filter_source_tree(source_tree: dict[Path, AnalysedDependent], suffixes: Iterable[str]) -> list[AnalysedDependent]:
     """
     Pull out files with the given extensions from a source tree.
 

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -17,7 +17,7 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import List, Optional, Union, Iterable
+from typing import Optional, Union, Iterable
 
 from fab.build_config import AddFlags, BuildConfig
 from fab.steps.analyse import analyse
@@ -61,18 +61,18 @@ class FabBase:
         self._target = ""
         # Set the given name as root symbol, it can be set explicitly
         # using set_root_symbol()
-        self._root_symbol: List[str] = [name]
+        self._root_symbol: list[str] = [name]
 
         # The preprocessor flags to be used. One stores the common flags
         # (without path-specific component), the other the path-specific
         # flags (which are still handled separately in Fab)
-        self._preprocessor_flags_common: List[str] = []
-        self._preprocessor_flags_path: List[AddFlags] = []
+        self._preprocessor_flags_common: list[str] = []
+        self._preprocessor_flags_path: list[AddFlags] = []
 
         # The compiler and linker flags from the command line
-        self._fortran_compiler_flags_commandline: List[str] = []
-        self._c_compiler_flags_commandline: List[str] = []
-        self._linker_flags_commandline: List[str] = []
+        self._fortran_compiler_flags_commandline: list[str] = []
+        self._c_compiler_flags_commandline: list[str] = []
+        self._linker_flags_commandline: list[str] = []
 
         # We have to determine the site-specific setup first, so that e.g.
         # new compilers can be added before command line options are handled
@@ -148,7 +148,7 @@ class FabBase:
         label = f"{name}-{self.args.profile}-$compiler"
         return label
 
-    def set_root_symbol(self, root_symbol: Union[List[str], str]) -> None:
+    def set_root_symbol(self, root_symbol: Union[list[str], str]) -> None:
         '''Defines the root symbol. It defaults to the name given in
         the constructor.
 
@@ -161,7 +161,7 @@ class FabBase:
             self._root_symbol = root_symbol
 
     @property
-    def root_symbol(self) -> List[str]:
+    def root_symbol(self) -> list[str]:
         '''
         :returns: the list of root symbols.
         '''
@@ -221,35 +221,35 @@ class FabBase:
         return self._config.project_workspace
 
     @property
-    def preprocess_flags_common(self) -> List[str]:
+    def preprocess_flags_common(self) -> list[str]:
         """
         :returns: the list of all common preprocessor flags.
         """
         return self._preprocessor_flags_common
 
     @property
-    def preprocess_flags_path(self) -> List[AddFlags]:
+    def preprocess_flags_path(self) -> list[AddFlags]:
         """
         :returns: the list of all path-specific flags.
         """
         return self._preprocessor_flags_path
 
     @property
-    def fortran_compiler_flags_commandline(self) -> List[str]:
+    def fortran_compiler_flags_commandline(self) -> list[str]:
         """
         :returns: the list of flags specified through --fflags.
         """
         return self._fortran_compiler_flags_commandline
 
     @property
-    def c_compiler_flags_commandline(self) -> List[str]:
+    def c_compiler_flags_commandline(self) -> list[str]:
         """
         :returns: the list of flags specified through --cflags.
         """
         return self._c_compiler_flags_commandline
 
     @property
-    def linker_flags_commandline(self) -> List[str]:
+    def linker_flags_commandline(self) -> list[str]:
         """
         :returns: the list of flags specified through --ldflags.
         """
@@ -559,7 +559,7 @@ class FabBase:
         implementation does nothing, should be overwritten.
         '''
 
-    def get_linker_flags(self) -> List[str]:
+    def get_linker_flags(self) -> list[str]:
         '''
         Base class for setting linker flags. This base implementation
         for now just returns an empty list.
@@ -570,7 +570,7 @@ class FabBase:
 
     def add_preprocessor_flags(
             self,
-            list_of_flags: Union[AddFlags, str, List[AddFlags], List[str]]
+            list_of_flags: Union[AddFlags, str, list[AddFlags], list[str]]
             ) -> None:
         """
         This function appends a preprocessor flags to the internal list of
@@ -671,15 +671,15 @@ class FabBase:
 
     def compile_c_step(
             self,
-            common_flags: Optional[List[str]] = None,
-            path_flags: Optional[List[AddFlags]] = None
+            common_flags: Optional[list[str]] = None,
+            path_flags: Optional[list[AddFlags]] = None
             ) -> None:
         """
         Calls Fab's compile_c. It passes the config for Fab to compile
         all C files. Optionally, common flags, path-specific flags and
         alternative source can also be passed to Fab for compilation.
         """
-        site_path_flags: List[AddFlags] = []
+        site_path_flags: list[AddFlags] = []
         if self._site_config:
             site_path_flags = self._site_config.get_path_flags(self._config)
         if not common_flags:
@@ -695,8 +695,8 @@ class FabBase:
 
     def compile_fortran_step(
             self,
-            common_flags: Optional[List[str]] = None,
-            path_flags: Optional[List[AddFlags]] = None
+            common_flags: Optional[list[str]] = None,
+            path_flags: Optional[list[AddFlags]] = None
             ) -> None:
         """
         Calls Fab's compile_fortran. It passes the config for Fab to
@@ -707,7 +707,7 @@ class FabBase:
         :param path_flags: optional list of path-specific flags to be passed
             to Fab compile_fortran, default is None.
         """
-        site_path_flags: List[AddFlags] = []
+        site_path_flags: list[AddFlags] = []
         if self._site_config:
             site_path_flags = self._site_config.get_path_flags(self._config)
         if not common_flags:

--- a/source/fab/fab_base/site_specific/default/config.py
+++ b/source/fab/fab_base/site_specific/default/config.py
@@ -6,7 +6,7 @@ This module contains the default Baf configuration class.
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import AddFlags, BuildConfig, Category, Compiler, ToolRepository
 
@@ -32,7 +32,7 @@ class Config:
         # Stores for each compiler suite a mapping of profiles to the list of
         # path-specific flags to use.
         # _path_flags[suite][profile]
-        self._path_flags: Dict[str, Dict[str, List[AddFlags]]] = {}
+        self._path_flags: dict[str, dict[str, list[AddFlags]]] = {}
 
     @property
     def args(self) -> argparse.Namespace:
@@ -41,7 +41,7 @@ class Config:
         '''
         return self._args
 
-    def get_valid_profiles(self) -> List[str]:
+    def get_valid_profiles(self) -> list[str]:
         '''
         Determines the list of all allowed compiler profiles. The first
         entry in this list is the default profile to be used. This method
@@ -119,7 +119,7 @@ class Config:
         self.setup_nvidia(build_config)
         self.setup_cray(build_config)
 
-    def get_path_flags(self, build_config: BuildConfig) -> List[AddFlags]:
+    def get_path_flags(self, build_config: BuildConfig) -> list[AddFlags]:
         '''
         Returns the path-specific flags to be used.
         TODO #313: Ideally we have only one kind of flag, but as a quick

--- a/source/fab/fab_base/site_specific/default/setup_cray.py
+++ b/source/fab/fab_base/site_specific/default/setup_cray.py
@@ -8,14 +8,14 @@ This function gets called from the default site-specific config file
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
 def setup_cray(build_config: BuildConfig,
-               args: argparse.Namespace) -> Dict[str, List[AddFlags]]:
+               args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-branches
     '''
     Defines the default flags for ftn.

--- a/source/fab/fab_base/site_specific/default/setup_gnu.py
+++ b/source/fab/fab_base/site_specific/default/setup_gnu.py
@@ -8,13 +8,13 @@ This function gets called from the default site-specific config file
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import AddFlags, BuildConfig, Category, Linker, ToolRepository
 
 
 def setup_gnu(build_config: BuildConfig,
-              args: argparse.Namespace) -> Dict[str, List[AddFlags]]:
+              args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for all GNU compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_intel_classic.py
+++ b/source/fab/fab_base/site_specific/default/setup_intel_classic.py
@@ -8,14 +8,14 @@ This function gets called from the default site-specific config file
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
 def setup_intel_classic(build_config: BuildConfig,
-                        args: argparse.Namespace) -> Dict[str, List[AddFlags]]:
+                        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel classic compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_intel_llvm.py
+++ b/source/fab/fab_base/site_specific/default/setup_intel_llvm.py
@@ -8,14 +8,14 @@ This function gets called from the default site-specific config file
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
 def setup_intel_llvm(build_config: BuildConfig,
-                     args: argparse.Namespace) -> Dict[str, List[AddFlags]]:
+                     args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel llvm compilers.

--- a/source/fab/fab_base/site_specific/default/setup_nvidia.py
+++ b/source/fab/fab_base/site_specific/default/setup_nvidia.py
@@ -8,14 +8,14 @@ This function gets called from the default site-specific config file
 '''
 
 import argparse
-from typing import cast, Dict, List
+from typing import cast
 
 from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
 def setup_nvidia(build_config: BuildConfig,
-                 args: argparse.Namespace) -> Dict[str, List[AddFlags]]:
+                 args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for nvfortran.

--- a/source/fab/metrics.py
+++ b/source/fab/metrics.py
@@ -34,7 +34,7 @@ from collections import defaultdict
 from multiprocessing import Process, Pipe
 from multiprocessing.connection import Connection
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Optional
 
 JSON_FILENAME = 'metrics.json'
 
@@ -88,7 +88,7 @@ def _read_metric(metrics_folder: Path):
 
     """
     # An example metric is the time taken to preprocess a file; metrics['preprocess c']['my_file.c']
-    metrics: Dict[str, Dict[str, float]] = defaultdict(dict)
+    metrics: dict[str, dict[str, float]] = defaultdict(dict)
 
     # todo: can we do this better?
     # we run in a subprocess, so we get a copy of _metric_send_conn before it closes.

--- a/source/fab/mo.py
+++ b/source/fab/mo.py
@@ -10,7 +10,7 @@ be integrated into Fab's internals.
 """
 
 from pathlib import Path
-from typing import Dict, Iterable, Optional
+from typing import Iterable, Optional
 
 from fab.dep_tree import AnalysedDependent, logger
 from fab.parse.c import AnalysedC
@@ -18,7 +18,7 @@ from fab.parse.fortran import AnalysedFortran
 
 
 def add_mo_commented_file_deps(
-       source_tree: Dict[Path, AnalysedDependent],
+       source_tree: dict[Path, AnalysedDependent],
         ignore_dependencies: Optional[Iterable[str]] = None) -> None:
     """
     Handle dependencies from Met Office "DEPENDS ON:" code comments which

--- a/source/fab/parse/__init__.py
+++ b/source/fab/parse/__init__.py
@@ -7,7 +7,7 @@ import json
 import logging
 from abc import ABC
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Union
+from typing import Any, Optional, Union
 
 from fab.util import file_checksum
 
@@ -50,7 +50,7 @@ class AnalysedFile(ABC):
         return vars(self) == vars(other)
 
     # persistence
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Create a dict representing the object.
 
@@ -114,9 +114,9 @@ class AnalysedFile(ABC):
         things = set()
         for field_name in self.field_names():
             thing = getattr(self, field_name)
-            if isinstance(thing, Dict):
+            if isinstance(thing, dict):
                 things.add(tuple(sorted(thing.items())))
-            elif isinstance(thing, Set):
+            elif isinstance(thing, set):
                 things.add(tuple(sorted(thing)))
             else:
                 things.add(thing)

--- a/source/fab/parse/c.py
+++ b/source/fab/parse/c.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 from collections import deque
 from pathlib import Path
-from typing import List, Optional, Union, Tuple
+from typing import Optional, Union
 
 try:
     import clang  # type: ignore
@@ -52,7 +52,7 @@ class CAnalyser:
 
         # runtime
         self._config = config
-        self._include_region: List[Tuple[int, str]] = []
+        self._include_region: list[tuple[int, str]] = []
 
     # todo: simplifiy by passing in the file path instead of the analysed tokens?
     def _locate_include_regions(self, trans_unit) -> None:
@@ -107,7 +107,7 @@ class CAnalyser:
         return None
 
     def run(self, fpath: Path) \
-            -> Union[Tuple[AnalysedC, Path], Tuple[Exception, None]]:
+            -> Union[tuple[AnalysedC, Path], tuple[Exception, None]]:
 
         if not clang:
             msg = 'clang not available, C analysis disabled'
@@ -143,7 +143,7 @@ class CAnalyser:
 
         # Now walk the actual nodes and find all relevant external symbols
         try:
-            usr_symbols: List[str] = []
+            usr_symbols: list[str] = []
             for node in translation_unit.cursor.walk_preorder():
                 if not node.spelling:
                     continue

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -9,7 +9,7 @@ Fortran language handling classes.
 """
 import logging
 from pathlib import Path
-from typing import Union, Optional, Iterable, Dict, Any, Set
+from typing import Union, Optional, Iterable, Any
 
 from fparser.two.Fortran2003 import (  # type: ignore
     Entity_Decl_List, Use_Stmt, Module_Stmt, Program_Stmt, Subroutine_Stmt,
@@ -52,7 +52,7 @@ class AnalysedFortran(AnalysedDependent):
                  symbol_deps: Optional[Iterable[str]] = None,
                  mo_commented_file_deps: Optional[Iterable[str]] = None,
                  file_deps: Optional[Iterable[Path]] = None,
-                 psyclone_kernels: Optional[Dict[str, int]] = None):
+                 psyclone_kernels: Optional[dict[str, int]] = None):
         """
         :param fpath:
             The source file that was analysed.
@@ -85,16 +85,16 @@ class AnalysedFortran(AnalysedDependent):
         super().__init__(fpath=fpath, file_hash=file_hash,
                          symbol_defs=symbol_defs, symbol_deps=symbol_deps, file_deps=file_deps)
 
-        self.program_defs: Set[str] = set(program_defs or [])
-        self.module_defs: Set[str] = set(module_defs or [])
-        self.module_deps: Set[str] = set(module_deps or [])
-        self.mo_commented_file_deps: Set[str] = \
+        self.program_defs: set[str] = set(program_defs or [])
+        self.module_defs: set[str] = set(module_defs or [])
+        self.module_deps: set[str] = set(module_deps or [])
+        self.mo_commented_file_deps: set[str] = \
             set(mo_commented_file_deps or [])
 
         # Todo: Ideally Psyclone stuff would not be part of this general
         #       fortran analysis code. Instead, perhaps we could inject
         #       bespoke node handling into the fortran analyser.
-        self.psyclone_kernels: Dict[str, int] = psyclone_kernels or {}
+        self.psyclone_kernels: dict[str, int] = psyclone_kernels or {}
 
         self.validate()
 
@@ -130,7 +130,7 @@ class AnalysedFortran(AnalysedDependent):
             'psyclone_kernels',
         ]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # These dicts will be written to json files, so can't contain sets.
         # We sort the lists for reproducibility in testing.
         result = super().to_dict()
@@ -459,11 +459,11 @@ class FortranParserWorkaround():
 
         """
         self.fpath = fpath
-        self.module_defs: Set[str] = set(module_defs or {})
-        self.symbol_defs: Set[str] = set(symbol_defs or {})
-        self.module_deps: Set[str] = set(module_deps or {})
-        self.symbol_deps: Set[str] = set(symbol_deps or {})
-        self.mo_commented_file_deps: Set[str] = \
+        self.module_defs: set[str] = set(module_defs or {})
+        self.symbol_defs: set[str] = set(symbol_defs or {})
+        self.module_deps: set[str] = set(module_deps or {})
+        self.symbol_deps: set[str] = set(symbol_deps or {})
+        self.mo_commented_file_deps: set[str] = \
             set(mo_commented_file_deps or [])
 
     def as_analysed_fortran(self):

--- a/source/fab/parse/fortran_common.py
+++ b/source/fab/parse/fortran_common.py
@@ -10,7 +10,7 @@ Common functionality for both Fortran and (sanitised) X90 processing.
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional, Tuple, Type, Union
+from typing import Optional,Union
 
 from fparser.common.readfortran import FortranFileReader  # type: ignore
 from fparser.two.parser import ParserFactory  # type: ignore
@@ -26,7 +26,7 @@ from fab.util import log_or_dot, file_checksum
 logger = logging.getLogger(__name__)
 
 
-def _typed_child(parent, child_type: Type, must_exist=False):
+def _typed_child(parent, child_type: type, must_exist=False):
     # Look for a child of a certain type.
     # Returns the child or None.
     # Raises ValueError if more than one child of the given type is found.
@@ -74,9 +74,9 @@ class FortranAnalyserBase(ABC):
         return self._config
 
     def run(self, fpath: Path) \
-            -> Union[Tuple[AnalysedDependent, Path],
-                     Tuple[EmptySourceFile, None],
-                     Tuple[Exception, None]]:
+            -> Union[tuple[AnalysedDependent, Path],
+                     tuple[EmptySourceFile, None],
+                     tuple[Exception, None]]:
         """
         Parse the source file and record what we're interested in (subclass
         specific).

--- a/source/fab/parse/fortran_common.py
+++ b/source/fab/parse/fortran_common.py
@@ -10,7 +10,7 @@ Common functionality for both Fortran and (sanitised) X90 processing.
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional,Union
+from typing import Optional, Union
 
 from fparser.common.readfortran import FortranFileReader  # type: ignore
 from fparser.two.parser import ParserFactory  # type: ignore

--- a/source/fab/parse/x90.py
+++ b/source/fab/parse/x90.py
@@ -4,7 +4,7 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 from pathlib import Path
-from typing import Iterable, Set, Union, Optional, Dict, Any
+from typing import Iterable, Union, Optional, Any
 
 from fparser.two.Fortran2003 import Use_Stmt, Call_Stmt, Name, Only_List, Actual_Arg_Spec_List, Part_Ref  # type: ignore
 from fparser.two.utils import walk  # type: ignore
@@ -35,9 +35,9 @@ class AnalysedX90(AnalysedFile):
         super().__init__(fpath=fpath, file_hash=file_hash)
 
         # Maps used kernel metadata (type def names) to the modules they're found in
-        self.kernel_deps: Set[str] = set(kernel_deps or {})
+        self.kernel_deps: set[str] = set(kernel_deps or {})
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = super().to_dict()
         result.update({
             "kernel_deps": sorted(self.kernel_deps),
@@ -72,7 +72,7 @@ class X90Analyser(FortranAnalyserBase):
     def walk_nodes(self, fpath, file_hash, node_tree) -> AnalysedX90:  # type: ignore
 
         analysed_file = AnalysedX90(fpath=fpath, file_hash=file_hash)
-        symbol_deps: Dict[str, str] = {}
+        symbol_deps: dict[str, str] = {}
 
         for obj in walk(node_tree):
             obj_type = type(obj)
@@ -92,7 +92,7 @@ class X90Analyser(FortranAnalyserBase):
 
         return analysed_file
 
-    def _process_use_statement(self, symbol_deps: Dict[str, str], obj):
+    def _process_use_statement(self, symbol_deps: dict[str, str], obj):
         # Record the modules in which potential kernels live.
         # We'll find out if they're kernels later.
         module_dep = _typed_child(obj, Name, must_exist=True)
@@ -104,7 +104,7 @@ class X90Analyser(FortranAnalyserBase):
         for name in name_nodes:
             symbol_deps[name.string] = module_dep.string
 
-    def _process_call_statement(self, symbol_deps: Dict[str, str], analysed_file, obj):
+    def _process_call_statement(self, symbol_deps: dict[str, str], analysed_file, obj):
         # if we're calling invoke, record the names of the args.
         # sanity check they end with "_type".
         called_name = _typed_child(obj, Name)

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -38,7 +38,7 @@ import logging
 import sys
 import warnings
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Set, Union
+from typing import Iterable, Optional, Union
 
 from fab import FabException
 from fab.artefacts import ArtefactsGetter, ArtefactSet, CollectionConcat
@@ -65,7 +65,7 @@ DEFAULT_SOURCE_GETTER = CollectionConcat([
 def analyse(
         config,
         source: Optional[ArtefactsGetter] = None,
-        root_symbol: Optional[Union[str, List[str]]] = None,
+        root_symbol: Optional[Union[str, list[str]]] = None,
         find_programs: bool = False,
         std: str = "f2008",
         special_measure_analysis_results: Optional[Iterable[FortranParserWorkaround]] = None,
@@ -124,7 +124,7 @@ def analyse(
         raise ValueError("find_programs and root_symbol can't be used together")
 
     source_getter = source or DEFAULT_SOURCE_GETTER
-    root_symbols: Optional[List[str]] = [root_symbol] if isinstance(root_symbol, str) else root_symbol
+    root_symbols: Optional[list[str]] = [root_symbol] if isinstance(root_symbol, str) else root_symbol
     special_measure_analysis_results = list(special_measure_analysis_results or [])
     unreferenced_deps = list(unreferenced_deps or [])
 
@@ -146,7 +146,7 @@ def analyse(
     #     - (Optionally) Extract a sub tree for every root symbol, if provided. For building executables.
 
     # parse
-    files: List[Path] = source_getter(config.artefact_store)
+    files: list[Path] = source_getter(config.artefact_store)
     analysed_files = _parse_files(config, files=files, fortran_analyser=fortran_analyser, c_analyser=c_analyser)
     _add_manual_results(special_measure_analysis_results, analysed_files)
 
@@ -195,14 +195,14 @@ def _analyse_dependencies(analysed_files: Iterable[AnalysedDependent]):
     """
     with TimerLogger("converting symbol dependencies to file dependencies"):
         # map symbols to the files they're in
-        symbol_table: Dict[str, Path] = _gen_symbol_table(analysed_files)
+        symbol_table: dict[str, Path] = _gen_symbol_table(analysed_files)
 
         # fill in the file deps attribute in the analysed file objects
         _gen_file_deps(analysed_files, symbol_table)
 
     # build the tree
     # the nodes refer to other nodes via the file dependencies we just made, which are keys into this dict
-    source_tree: Dict[Path, AnalysedDependent] = {a.fpath: a for a in analysed_files}
+    source_tree: dict[Path, AnalysedDependent] = {a.fpath: a for a in analysed_files}
 
     return source_tree, symbol_table
 
@@ -227,7 +227,7 @@ def _extract_build_trees(root_symbols, project_source_tree, symbol_table):
     return build_trees
 
 
-def _parse_files(config, files: List[Path], fortran_analyser, c_analyser) -> Set[AnalysedDependent]:
+def _parse_files(config, files: list[Path], fortran_analyser, c_analyser) -> set[AnalysedDependent]:
     """
     Determine the symbols which are defined in, and used by, each file.
 
@@ -274,7 +274,7 @@ def _parse_files(config, files: List[Path], fortran_analyser, c_analyser) -> Set
     return non_empty
 
 
-def _add_manual_results(special_measure_analysis_results, analysed_files: Set[AnalysedDependent]):
+def _add_manual_results(special_measure_analysis_results, analysed_files: set[AnalysedDependent]):
     # add manual analysis results for files which could not be parsed
     if special_measure_analysis_results:
         warnings.warn("SPECIAL MEASURE: injecting user-defined analysis results")
@@ -291,12 +291,12 @@ def _add_manual_results(special_measure_analysis_results, analysed_files: Set[An
         logger.info(f'added {len(special_measure_analysis_results)} manual analysis results')
 
 
-def _gen_symbol_table(analysed_files: Iterable[AnalysedDependent]) -> Dict[str, Path]:
+def _gen_symbol_table(analysed_files: Iterable[AnalysedDependent]) -> dict[str, Path]:
     """
     Create a dictionary mapping symbol names to the files in which they appear.
 
     """
-    symbols: Dict[str, Path] = {}
+    symbols: dict[str, Path] = {}
     duplicates = False
     for analysed_file in analysed_files:
         for symbol_def in analysed_file.symbol_defs:
@@ -319,7 +319,7 @@ def _gen_symbol_table(analysed_files: Iterable[AnalysedDependent]) -> Dict[str, 
     return symbols
 
 
-def _gen_file_deps(analysed_files: Iterable[AnalysedDependent], symbols: Dict[str, Path]):
+def _gen_file_deps(analysed_files: Iterable[AnalysedDependent], symbols: dict[str, Path]):
     """
     Use the symbol table to convert symbol dependencies into file dependencies.
 
@@ -342,9 +342,9 @@ def _gen_file_deps(analysed_files: Iterable[AnalysedDependent], symbols: Dict[st
         logger.info(f"{len(deps_not_found)} deps not found")
 
 
-def _add_unreferenced_deps(unreferenced_deps, symbol_table: Dict[str, Path],
-                           all_analysed_files: Dict[Path, AnalysedDependent],
-                           build_tree: Dict[Path, AnalysedDependent]):
+def _add_unreferenced_deps(unreferenced_deps, symbol_table: dict[str, Path],
+                           all_analysed_files: dict[Path, AnalysedDependent],
+                           build_tree: dict[Path, AnalysedDependent]):
     """
     Add files to the build tree.
 

--- a/source/fab/steps/cleanup_prebuilds.py
+++ b/source/fab/steps/cleanup_prebuilds.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import timedelta, datetime
 from pathlib import Path
-from typing import Dict, Optional, Iterable, Set
+from typing import Optional, Iterable
 
 from fab.artefacts import ArtefactSet
 from fab.steps import run_mp, step
@@ -87,7 +87,7 @@ def cleanup_prebuilds(
 
 
 def by_age(older_than: Optional[timedelta],
-           prebuilds_ts: Dict[Path, datetime], current_files: Iterable[Path]) -> Set[Path]:
+           prebuilds_ts: dict[Path, datetime], current_files: Iterable[Path]) -> set[Path]:
     to_delete = set()
 
     if older_than:
@@ -106,7 +106,7 @@ def by_age(older_than: Optional[timedelta],
     return to_delete
 
 
-def by_version_age(n_versions: int, prebuilds_ts: Dict[Path, datetime], current_files: Iterable[Path]) -> Set[Path]:
+def by_version_age(n_versions: int, prebuilds_ts: dict[Path, datetime], current_files: Iterable[Path]) -> set[Path]:
     to_delete = set()
 
     if n_versions:

--- a/source/fab/steps/compile_c.py
+++ b/source/fab/steps/compile_c.py
@@ -9,7 +9,7 @@ C file compilation.
 """
 import logging
 from dataclasses import dataclass
-from typing import cast, Dict, List, Optional, Tuple
+from typing import cast, Optional
 
 from fab import FabException
 from fab.artefacts import (ArtefactsGetter, ArtefactSet, ArtefactStore,
@@ -37,8 +37,8 @@ class MpCommonArgs:
 
 
 @step
-def compile_c(config, common_flags: Optional[List[str]] = None,
-              path_flags: Optional[List] = None,
+def compile_c(config, common_flags: Optional[list[str]] = None,
+              path_flags: Optional[list] = None,
               source: Optional[ArtefactsGetter] = None):
     """
     Compiles all C files in all build trees, creating or extending a set of
@@ -73,7 +73,7 @@ def compile_c(config, common_flags: Optional[List[str]] = None,
     source_getter = source or DEFAULT_SOURCE_GETTER
 
     # gather all the source to compile, for all build trees, into one big lump
-    build_lists: Dict = source_getter(config.artefact_store)
+    build_lists: dict = source_getter(config.artefact_store)
     to_compile: list = sum(build_lists.values(), [])
     logger.info(f"compiling {len(to_compile)} c files")
 
@@ -104,8 +104,8 @@ def compile_c(config, common_flags: Optional[List[str]] = None,
 
 
 # todo: very similar code in fortran compiler
-def store_artefacts(compiled_files: List[CompiledFile],
-                    build_lists: Dict[str, List],
+def store_artefacts(compiled_files: list[CompiledFile],
+                    build_lists: dict[str, list],
                     artefact_store: ArtefactStore):
     """
     Create our artefact collection; object files for each compiled file,
@@ -119,7 +119,7 @@ def store_artefacts(compiled_files: List[CompiledFile],
         artefact_store.update_dict(ArtefactSet.OBJECT_FILES, new_objects, root)
 
 
-def _compile_file(arg: Tuple[AnalysedC, MpCommonArgs]):
+def _compile_file(arg: tuple[AnalysedC, MpCommonArgs]):
 
     analysed_file, mp_payload = arg
     config = mp_payload.config

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -13,7 +13,7 @@ import shutil
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
-from typing import cast, Dict, List, Optional, Set, Tuple, Union
+from typing import cast, Optional, Union
 
 from fab.artefacts import (ArtefactsGetter, ArtefactSet, ArtefactStore,
                            FilterBuildTrees)
@@ -38,14 +38,14 @@ class MpCommonArgs:
     alongside the filenames."""
     config: BuildConfig
     flags: FlagsConfig
-    mod_hashes: Dict[str, int]
+    mod_hashes: dict[str, int]
     syntax_only: bool
 
 
 @step
 def compile_fortran(config: BuildConfig,
-                    common_flags: Optional[List[str]] = None,
-                    path_flags: Optional[List] = None,
+                    common_flags: Optional[list[str]] = None,
+                    path_flags: Optional[list] = None,
                     source: Optional[ArtefactsGetter] = None):
     """
     Compiles all Fortran files in all build trees, creating/extending a set
@@ -73,14 +73,14 @@ def compile_fortran(config: BuildConfig,
     """
 
     source_getter = source or DEFAULT_SOURCE_GETTER
-    mod_hashes: Dict[str, int] = {}
+    mod_hashes: dict[str, int] = {}
 
     # get all the source to compile, for all build trees, into one big lump
-    build_lists: Dict[str, List] = source_getter(config.artefact_store)
+    build_lists: dict[str, list] = source_getter(config.artefact_store)
 
     # compile everything in multiple passes
-    compiled: Dict[Path, CompiledFile] = {}
-    uncompiled: Set[AnalysedFortran] = set(sum(build_lists.values(), []))
+    compiled: dict[Path, CompiledFile] = {}
+    uncompiled: set[AnalysedFortran] = set(sum(build_lists.values(), []))
     logger.info(f"compiling {len(uncompiled)} fortran files")
 
     # No need to do anything else if there are no files to compile
@@ -151,9 +151,9 @@ def handle_compiler_args(config: BuildConfig, common_flags=None,
     return compiler, flags_config
 
 
-def compile_pass(config, compiled: Dict[Path, CompiledFile],
-                 uncompiled: Set[AnalysedFortran],
-                 mp_common_args: MpCommonArgs, mod_hashes: Dict[str, int]):
+def compile_pass(config, compiled: dict[Path, CompiledFile],
+                 uncompiled: set[AnalysedFortran],
+                 mp_common_args: MpCommonArgs, mod_hashes: dict[str, int]):
     # what can we compile next?
     compile_next = get_compile_next(compiled, uncompiled)
 
@@ -188,15 +188,15 @@ def compile_pass(config, compiled: Dict[Path, CompiledFile],
     return uncompiled
 
 
-def get_compile_next(compiled: Dict[Path, CompiledFile],
-                     uncompiled: Set[AnalysedFortran]) -> Set[AnalysedFortran]:
+def get_compile_next(compiled: dict[Path, CompiledFile],
+                     uncompiled: set[AnalysedFortran]) -> set[AnalysedFortran]:
     '''Find what to compile next.
     :param compiled: A dictionary with already compiled files.
     :param uncompiled: The set of still to be compiled files.
     :returns: A set with all files that can now be compiled.
     '''
     compile_next = set()
-    not_ready: Dict[Path, List[Path]] = {}
+    not_ready: dict[Path, list[Path]] = {}
     for af in uncompiled:
         # all deps ready?
         unfulfilled = [dep for dep in af.file_deps
@@ -219,8 +219,8 @@ def get_compile_next(compiled: Dict[Path, CompiledFile],
     return compile_next
 
 
-def store_artefacts(compiled_files: Dict[Path, CompiledFile],
-                    build_lists: Dict[str, List],
+def store_artefacts(compiled_files: dict[Path, CompiledFile],
+                    build_lists: dict[str, list],
                     artefact_store: ArtefactStore):
     """
     Create our artefact collection; object files for each compiled file, per
@@ -234,8 +234,8 @@ def store_artefacts(compiled_files: Dict[Path, CompiledFile],
         artefact_store.update_dict(ArtefactSet.OBJECT_FILES, new_objects, root)
 
 
-def process_file(arg: Tuple[AnalysedFortran, MpCommonArgs]) \
-        -> Union[Tuple[CompiledFile, List[Path]], Tuple[Exception, None]]:
+def process_file(arg: tuple[AnalysedFortran, MpCommonArgs]) \
+        -> Union[tuple[CompiledFile, list[Path]], tuple[Exception, None]]:
     """
     Prepare to compile a fortran file, and compile it if anything has changed
     since it was last compiled.
@@ -400,8 +400,8 @@ def compile_file(analysed_file, flags, output_fpath, mp_common_args):
                           syntax_only=mp_common_args.syntax_only)
 
 
-def get_mod_hashes(analysed_files: Set[AnalysedFortran],
-                   config: BuildConfig) -> Dict[str, int]:
+def get_mod_hashes(analysed_files: set[AnalysedFortran],
+                   config: BuildConfig) -> dict[str, int]:
     """
     Get the hash of every module file defined in the list of analysed files.
 

--- a/source/fab/steps/grab/svn.py
+++ b/source/fab/steps/grab/svn.py
@@ -10,7 +10,7 @@ from the tool box.
 '''
 
 from pathlib import Path
-from typing import Optional, Union, Tuple
+from typing import Optional, Union
 import xml.etree.ElementTree as ET
 
 from fab.steps import step
@@ -18,7 +18,7 @@ from fab.tools.category import Category
 from fab.tools.versioning import Versioning
 
 
-def _get_revision(src, revision=None) -> Tuple[str, Union[str, None]]:
+def _get_revision(src, revision=None) -> tuple[str, Union[str, None]]:
     """
     Pull out the revision if it's part of the url.
 
@@ -48,7 +48,7 @@ def _get_revision(src, revision=None) -> Tuple[str, Union[str, None]]:
 
 def _svn_prep_common(config, src: str,
                      dst_label: Optional[str],
-                     revision: Optional[str]) -> Tuple[str, Path,
+                     revision: Optional[str]) -> tuple[str, Path,
                                                        Optional[str]]:
     src, revision = _get_revision(src, revision)
     if not config.source_root.exists():

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -9,7 +9,7 @@ Link an executable.
 """
 import logging
 from string import Template
-from typing import List, Optional
+from typing import Optional
 
 from fab.artefacts import (ArtefactsGetter, ArtefactSet, ArtefactStore,
                            CollectionGetter)
@@ -35,8 +35,8 @@ class DefaultLinkerSource(ArtefactsGetter):
 
 @step
 def link_exe(config,
-             libs: Optional[List[str]] = None,
-             flags: Optional[List[str]] = None,
+             libs: Optional[list[str]] = None,
+             flags: Optional[list[str]] = None,
              source: Optional[ArtefactsGetter] = None) -> None:
     """
     Link object files into an executable for every build target.
@@ -104,7 +104,7 @@ def link_exe(config,
 @step
 def link_shared_object(config,
                        output_fpath: str,
-                       flags: Optional[List[str]] = None,
+                       flags: Optional[list[str]] = None,
                        source: Optional[ArtefactsGetter] = None):
     """
     Produce a shared object (*.so*) file from the given build target.

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -11,7 +11,7 @@ import logging
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Collection, List, Optional, Tuple, Union
+from typing import Collection, Optional, Union
 
 from fab.artefacts import (ArtefactSet, ArtefactsGetter, SuffixFilter,
                            CollectionGetter)
@@ -40,8 +40,8 @@ def pre_processor(config: BuildConfig, preprocessor: Preprocessor,
                   files: Collection[Path],
                   output_collection: Union[str, ArtefactSet],
                   output_suffix,
-                  common_flags: Optional[List[str]] = None,
-                  path_flags: Optional[List] = None,
+                  common_flags: Optional[list[str]] = None,
+                  path_flags: Optional[list] = None,
                   name="preprocess"):
     """
     Preprocess Fortran or C files.
@@ -93,7 +93,7 @@ def pre_processor(config: BuildConfig, preprocessor: Preprocessor,
     config.artefact_store.add(output_collection, set(by_type(results, Path)))
 
 
-def process_artefact(arg: Tuple[Path, MpCommonArgs]):
+def process_artefact(arg: tuple[Path, MpCommonArgs]):
     """
     Expects an input file in the source folder.
     Writes the output file to the output folder, with a lower case extension.

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -15,7 +15,7 @@ import shutil
 import warnings
 from itertools import chain
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Callable, Iterable, Optional, Union
 
 from fab.build_config import BuildConfig
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 # todo: should this be part of the psyclone step?
-def preprocess_x90(config, common_flags: Optional[List[str]] = None):
+def preprocess_x90(config, common_flags: Optional[list[str]] = None):
     common_flags = common_flags or []
 
     fpp = config.tool_box.get_tool(Category.FORTRAN_PREPROCESSOR)
@@ -67,13 +67,13 @@ class MpCommonArgs:
     config: BuildConfig
     analysed_x90: Dict[Path, AnalysedX90]
 
-    kernel_roots: List[Union[str, Path]]
+    kernel_roots: list[Union[str, Path]]
     transformation_script: Optional[Callable[[Path, BuildConfig], Path]]
-    cli_args: List[str]
+    cli_args: list[str]
     api: Union[str, None]
     all_kernel_hashes: Dict[str, int]
     overrides_folder: Optional[Path]
-    override_files: List[str]  # filenames (not paths) of hand crafted overrides
+    override_files: list[str]  # filenames (not paths) of hand crafted overrides
 
 
 # any already preprocessed x90 we pulled in
@@ -82,9 +82,9 @@ DEFAULT_SOURCE_GETTER = SuffixFilter(ArtefactSet.X90_COMPILER_FILES, '.x90')
 
 @step
 def psyclone(config: BuildConfig,
-             kernel_roots: Optional[List[Path]] = None,
+             kernel_roots: Optional[list[Path]] = None,
              transformation_script: Optional[Callable[[Path, BuildConfig], Path]] = None,
-             cli_args: Optional[List[str]] = None,
+             cli_args: Optional[list[str]] = None,
              source_getter: Optional[ArtefactsGetter] = None,
              overrides_folder: Optional[Path] = None,
              api: Optional[str] = None,
@@ -153,8 +153,8 @@ def psyclone(config: BuildConfig,
     check_for_errors(outputs, caller_label='psyclone')
 
     # flatten the list of lists we got back from run_mp
-    output_files: Set[Path] = set(chain(*by_type(outputs, List)))
-    prebuild_files: List[Path] = list(chain(*by_type(prebuilds, List)))
+    output_files: set[Path] = set(chain(*by_type(outputs, list)))
+    prebuild_files: list[Path] = list(chain(*by_type(prebuilds, list)))
 
     # record the output files in the artefact store for further processing
     config.artefact_store.add(ArtefactSet.FORTRAN_COMPILER_FILES, output_files)
@@ -174,7 +174,7 @@ def psyclone(config: BuildConfig,
 def _generate_mp_payload(config, analysed_x90, all_kernel_hashes, overrides_folder, kernel_roots,
                          transformation_script, cli_args,
                          api: Union[str, None]) -> MpCommonArgs:
-    override_files: List[str] = []
+    override_files: list[str] = []
     if overrides_folder:
         override_files = [f.name for f in file_walk(overrides_folder)]
 
@@ -192,7 +192,7 @@ def _generate_mp_payload(config, analysed_x90, all_kernel_hashes, overrides_fold
 
 
 def _analyse_x90s(config: BuildConfig,
-                  x90s: Set[Path]) -> Dict[Path, AnalysedX90]:
+                  x90s: set[Path]) -> Dict[Path, AnalysedX90]:
     """
     Analyse parsable versions of the x90s, finding kernel dependencies.
     """
@@ -228,7 +228,7 @@ def _analyse_x90s(config: BuildConfig,
 
 def _analyse_kernels(
         config: BuildConfig,
-        kernel_roots: List[Path],
+        kernel_roots: list[Path],
         ignore_dependencies: Optional[Iterable[str]] = None) -> Dict[str, int]:
     """
     We want to hash the kernel metadata (type defs).
@@ -257,8 +257,8 @@ def _analyse_kernels(
     """
     # Ignore the prebuild folder. Todo: test the prebuild folder is ignored, in case someone breaks this.
     file_lists = [list(file_walk(root, ignore_folders=[config.prebuild_folder])) for root in kernel_roots]
-    all_kernel_files: Set[Path] = set(sum(file_lists, []))
-    kernel_files: List[Path] = suffix_filter(all_kernel_files, ['.f90'])
+    all_kernel_files: set[Path] = set(sum(file_lists, []))
+    kernel_files: list[Path] = suffix_filter(all_kernel_files, ['.f90'])
 
     # We use the normal Fortran analyser, which records psyclone kernel metadata.
     # todo: We'd like to separate that from the general fortran analyser at some point, to reduce coupling.
@@ -271,7 +271,7 @@ def _analyse_kernels(
     log_or_dot_finish(logger)
     fortran_analyses, fortran_artefacts = zip(*fortran_results) if fortran_results else (tuple(), tuple())
 
-    errors: List[Exception] = list(by_type(fortran_analyses, Exception))
+    errors: list[Exception] = list(by_type(fortran_analyses, Exception))
     if errors:
         errs_str = '\n\n'.join(map(str, errors))
         logger.error(f"There were {len(errors)} errors while parsing kernels:\n\n{errs_str}")
@@ -280,7 +280,7 @@ def _analyse_kernels(
     prebuild_files = list(by_type(fortran_artefacts, Path))
     config.add_current_prebuilds(prebuild_files)
 
-    analysed_fortran: List[AnalysedFortran] = list(by_type(fortran_analyses, AnalysedFortran))
+    analysed_fortran: list[AnalysedFortran] = list(by_type(fortran_analyses, AnalysedFortran))
 
     # gather all kernel hashes into one big lump
     all_kernel_hashes: Dict[str, int] = {}
@@ -292,7 +292,7 @@ def _analyse_kernels(
     return all_kernel_hashes
 
 
-def do_one_file(arg: Tuple[Path, MpCommonArgs]):
+def do_one_file(arg: tuple[Path, MpCommonArgs]):
     x90_file, mp_payload = arg
     prebuild_hash = _gen_prebuild_hash(x90_file, mp_payload)
 
@@ -351,13 +351,13 @@ def do_one_file(arg: Tuple[Path, MpCommonArgs]):
     psy_file = _check_override(psy_file, mp_payload)
 
     # return the output files from psyclone
-    result: List[Path] = [modified_alg]
+    result: list[Path] = [modified_alg]
     if Path(psy_file).exists():
         result.append(psy_file)
 
     # we also want to return the prebuild artefact files we created,
     # which are just copies, in the prebuild folder, with hashes in the filenames.
-    prebuild_result: List[Path] = [prebuilt_alg, prebuilt_gen]
+    prebuild_result: list[Path] = [prebuilt_alg, prebuilt_gen]
 
     return result, prebuild_result
 

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -64,13 +64,13 @@ class MpCommonArgs:
 
     """
     config: BuildConfig
-    analysed_x90: Dict[Path, AnalysedX90]
+    analysed_x90: dict[Path, AnalysedX90]
 
     kernel_roots: list[Union[str, Path]]
     transformation_script: Optional[Callable[[Path, BuildConfig], Path]]
     cli_args: list[str]
     api: Union[str, None]
-    all_kernel_hashes: Dict[str, int]
+    all_kernel_hashes: dict[str, int]
     overrides_folder: Optional[Path]
     override_files: list[str]  # filenames (not paths) of hand crafted overrides
 
@@ -191,7 +191,7 @@ def _generate_mp_payload(config, analysed_x90, all_kernel_hashes, overrides_fold
 
 
 def _analyse_x90s(config: BuildConfig,
-                  x90s: set[Path]) -> Dict[Path, AnalysedX90]:
+                  x90s: set[Path]) -> dict[Path, AnalysedX90]:
     """
     Analyse the x90s, finding kernel dependencies.
     """
@@ -224,7 +224,7 @@ def _analyse_x90s(config: BuildConfig,
 def _analyse_kernels(
         config: BuildConfig,
         kernel_roots: list[Path],
-        ignore_dependencies: Optional[Iterable[str]] = None) -> Dict[str, int]:
+        ignore_dependencies: Optional[Iterable[str]] = None) -> dict[str, int]:
     """
     We want to hash the kernel metadata (type defs).
 
@@ -278,7 +278,7 @@ def _analyse_kernels(
     analysed_fortran: list[AnalysedFortran] = list(by_type(fortran_analyses, AnalysedFortran))
 
     # gather all kernel hashes into one big lump
-    all_kernel_hashes: Dict[str, int] = {}
+    all_kernel_hashes: dict[str, int] = {}
     for af in analysed_fortran:
         assert set(af.psyclone_kernels).isdisjoint(all_kernel_hashes), \
             f"duplicate kernel name(s): {set(af.psyclone_kernels) & set(all_kernel_hashes)}"

--- a/source/fab/steps/root_inc_files.py
+++ b/source/fab/steps/root_inc_files.py
@@ -11,7 +11,7 @@ for easy include by the preprocessor.
 import logging
 from pathlib import Path
 import shutil
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from fab.artefacts import ArtefactSet
 from fab.build_config import BuildConfig
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 @step
 def root_inc_files(config: BuildConfig,
-                   suffix_list: Optional[Union[List[str], str]] = None):
+                   suffix_list: Optional[Union[list[str], str]] = None):
 
     """
     Copy include files with a specific suffix into the workspace

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -8,7 +8,7 @@
 """
 
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -22,7 +22,7 @@ class Ar(Tool):
         super().__init__("ar", "ar", Category.AR)
 
     def create(self, output_fpath: Path,
-               members: List[Union[Path, str]]):
+               members: list[Union[Path, str]]):
         '''Create the archive with the specified name, containing the
         listed members.
 
@@ -31,6 +31,6 @@ class Ar(Tool):
         '''
         # Explicit type is required to avoid mypy errors :(
         output_fpath.unlink(missing_ok=True)
-        parameters: List[Union[Path, str]] = ["cr", output_fpath]
+        parameters: list[Union[Path, str]] = ["cr", output_fpath]
         parameters.extend(map(str, members))
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -11,7 +11,7 @@ classes for gcc, gfortran, icc, ifort
 import re
 from pathlib import Path
 import warnings
-from typing import cast, List, Optional, Tuple, Union
+from typing import cast, Optional, Union
 import zlib
 from fab.build_config import BuildConfig
 
@@ -57,10 +57,10 @@ class Compiler(CompilerSuiteTool):
                  output_flag: Optional[str] = None,
                  openmp_flag: Optional[str] = None,
                  version_argument: Optional[str] = None,
-                 availability_option: Optional[Union[str, List[str]]] = None):
+                 availability_option: Optional[Union[str, list[str]]] = None):
         super().__init__(name, exec_name, suite, category=category,
                          availability_option=availability_option)
-        self._version: Union[Tuple[int, ...], None] = None
+        self._version: Union[tuple[int, ...], None] = None
         self._mpi = mpi
         self._compile_flag = compile_flag if compile_flag else "-c"
         self._output_flag = output_flag if output_flag else "-o"
@@ -111,7 +111,7 @@ class Compiler(CompilerSuiteTool):
                 zlib.crc32(str(self.get_flags(profile)).encode()) +
                 zlib.crc32(self.get_version_string().encode()))
 
-    def get_flags(self, profile: Optional[str] = None) -> List[str]:
+    def get_flags(self, profile: Optional[str] = None) -> list[str]:
         '''Determines the flags to be used.
 
         :returns: the flags to be used with this tool.'''
@@ -122,7 +122,7 @@ class Compiler(CompilerSuiteTool):
             config: "BuildConfig",
             input_file: Path,
             output_file: Path,
-            add_flags:  Union[None, List[str]] = None) -> List[str]:
+            add_flags:  Union[None, list[str]] = None) -> list[str]:
         '''This function returns all command line options for a compiler
         (but not the executable name). It is used by a compiler wrapper
         to pass the right flags to the wrapper.
@@ -138,7 +138,7 @@ class Compiler(CompilerSuiteTool):
 
         :returns: all command line options for compilation.
         '''
-        params: List[str] = [self._compile_flag]
+        params: list[str] = [self._compile_flag]
 
         if config.openmp:
             params.append(self.openmp_flag)
@@ -156,7 +156,7 @@ class Compiler(CompilerSuiteTool):
     def compile_file(self, input_file: Path,
                      output_file: Path,
                      config: "BuildConfig",
-                     add_flags: Union[None, List[str]] = None):
+                     add_flags: Union[None, list[str]] = None):
         '''Compiles a file. It will add the flag for compilation-only
         automatically, as well as the output directives. The current working
         directory for the command is set to the folder where the source file
@@ -195,7 +195,7 @@ class Compiler(CompilerSuiteTool):
             self.logger.error(f'Error getting compiler version: {err}')
             return False
 
-    def get_version(self) -> Tuple[int, ...]:
+    def get_version(self) -> tuple[int, ...]:
         """
         Try to get the version of the given compiler.
 
@@ -225,7 +225,7 @@ class Compiler(CompilerSuiteTool):
         # Expect the version to be dot-separated integers.
         try:
             # Make mypy happy:
-            version = cast(Tuple[int],
+            version = cast(tuple[int],
                            tuple(int(x) for x in version_string.split('.')))
         except ValueError as err:
             raise RuntimeError(f"Unexpected version output format for "
@@ -376,8 +376,8 @@ class FortranCompiler(Compiler):
             config: "BuildConfig",
             input_file: Path,
             output_file: Path,
-            add_flags:  Union[None, List[str]] = None,
-            syntax_only: Optional[bool] = False) -> List[str]:
+            add_flags:  Union[None, list[str]] = None,
+            syntax_only: Optional[bool] = False) -> list[str]:
         '''This function returns all command line options for a Fortran
         compiler (but not the executable name). It is used by a compiler
         wrapper to pass the right flags to the wrapper.
@@ -431,7 +431,7 @@ class FortranCompiler(Compiler):
     def compile_file(self, input_file: Path,
                      output_file: Path,
                      config: "BuildConfig",
-                     add_flags: Union[None, List[str]] = None,
+                     add_flags: Union[None, list[str]] = None,
                      syntax_only: Optional[bool] = False):
         '''Compiles a file. This basically re-implements `compile_file` of
         the base class, but passes the syntax_only flag in

--- a/source/fab/tools/compiler_wrapper.py
+++ b/source/fab/tools/compiler_wrapper.py
@@ -9,7 +9,7 @@ the derived classes for mpif90, mpicc, and CrayFtnWrapper and CrayCcWrapper.
 """
 
 from pathlib import Path
-from typing import cast, List, Optional, Union
+from typing import cast, Optional, Union
 
 from fab.build_config import BuildConfig
 from fab.tools.category import Category
@@ -70,7 +70,7 @@ class CompilerWrapper(Compiler):
         raise RuntimeError(f"Compiler '{self._compiler.name}' has "
                            f"no has_syntax_only.")
 
-    def get_flags(self, profile: Optional[str] = None) -> List[str]:
+    def get_flags(self, profile: Optional[str] = None) -> list[str]:
         ''':returns: the ProfileFlags for the given profile, combined
             from the wrapped compiler and this wrapper.
 
@@ -98,8 +98,8 @@ class CompilerWrapper(Compiler):
             config: "BuildConfig",
             input_file: Path,
             output_file: Path,
-            add_flags:  Union[None, List[str]] = None,
-            syntax_only: Optional[bool] = False) -> List[str]:
+            add_flags:  Union[None, list[str]] = None,
+            syntax_only: Optional[bool] = False) -> list[str]:
         '''This function returns all command line options for a
         compiler wrapper. The syntax_only flag is only accepted,
         if the wrapped compiler is a Fortran compiler. Otherwise,
@@ -150,7 +150,7 @@ class CompilerWrapper(Compiler):
     def compile_file(self, input_file: Path,
                      output_file: Path,
                      config: "BuildConfig",
-                     add_flags: Union[None, List[str]] = None,
+                     add_flags: Union[None, list[str]] = None,
                      syntax_only: Optional[bool] = None):
         # pylint: disable=too-many-arguments
         '''Compiles a file using the wrapper compiler.

--- a/source/fab/tools/flags.py
+++ b/source/fab/tools/flags.py
@@ -10,7 +10,7 @@ PR.
 '''
 
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 import warnings
 
 from fab.util import string_checksum
@@ -22,10 +22,10 @@ class Flags(list):
 
     TODO #22: This class and build_config.FlagsConfig should be combined.
 
-    :param list_of_flags: List of parameters to initialise this object with.
+    :param list_of_flags: list of parameters to initialise this object with.
     '''
 
-    def __init__(self, list_of_flags: Optional[List[str]] = None):
+    def __init__(self, list_of_flags: Optional[list[str]] = None):
         self._logger = logging.getLogger(__name__)
         super().__init__()
         if list_of_flags:
@@ -38,7 +38,7 @@ class Flags(list):
         """
         return string_checksum(str(self))
 
-    def add_flags(self, new_flags: Union[str, List[str]]):
+    def add_flags(self, new_flags: Union[str, list[str]]):
         '''Adds the specified flags to the list of flags.
 
         :param new_flags: A single string or list of strings which are the
@@ -103,13 +103,13 @@ class ProfileFlags:
     def __init__(self: "ProfileFlags"):
         # Stores the flags for each profile mode. The key is the (lower case)
         # name of the profile mode, and it contains a list of flags
-        self._profiles: Dict[str, Flags] = {"": Flags()}
+        self._profiles: dict[str, Flags] = {"": Flags()}
 
         # This dictionary stores an optional inheritance, where one mode
         # 'inherits' the flags from a different mode (recursively)
-        self._inherit_from: Dict[str, str] = {}
+        self._inherit_from: dict[str, str] = {}
 
-    def __getitem__(self, profile: Optional[str] = None) -> List[str]:
+    def __getitem__(self, profile: Optional[str] = None) -> list[str]:
         '''Returns the flags for the requested profile. If profile is not
         specified, the empty profile ("") will be used. It will also take
         inheritance into account, so add flags (recursively) from inherited
@@ -165,7 +165,7 @@ class ProfileFlags:
             self._inherit_from[name.lower()] = inherit_from.lower()
 
     def add_flags(self,
-                  new_flags: Union[str, List[str]],
+                  new_flags: Union[str, list[str]],
                   profile: Optional[str] = None):
         '''Adds the specified flags to the list of flags.
 

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 import warnings
 
 from fab.build_config import BuildConfig
@@ -54,7 +54,7 @@ class Linker(CompilerSuiteTool):
             category=Category.LINKER)
 
         # Maintain a set of flags for common libraries.
-        self._lib_flags: Dict[str, List[str]] = {}
+        self._lib_flags: dict[str, list[str]] = {}
         # Allow flags to include before or after any library-specific flags.
         self._pre_lib_flags = ProfileFlags()
         self._post_lib_flags = ProfileFlags()
@@ -114,7 +114,7 @@ class Linker(CompilerSuiteTool):
         self._pre_lib_flags.define_profile(name, inherit_from)
         self._post_lib_flags.define_profile(name, inherit_from)
 
-    def get_profile_flags(self, profile: str) -> List[str]:
+    def get_profile_flags(self, profile: str) -> list[str]:
         '''
         :returns: the ProfileFlags for the given profile, combined
             from the wrapped compiler and this wrapper.
@@ -127,7 +127,7 @@ class Linker(CompilerSuiteTool):
             flags = []
         return flags + self._compiler.get_flags(profile)
 
-    def get_lib_flags(self, lib: str) -> List[str]:
+    def get_lib_flags(self, lib: str) -> list[str]:
         '''Gets the standard flags for a standard library
 
         :param lib: the library name
@@ -145,7 +145,7 @@ class Linker(CompilerSuiteTool):
                 return self._linker.get_lib_flags(lib)
             raise RuntimeError(f"Unknown library name: '{lib}'") from err
 
-    def add_lib_flags(self, lib: str, flags: List[str],
+    def add_lib_flags(self, lib: str, flags: list[str],
                       silent_replace: bool = False):
         '''Add a set of flags for a standard library
 
@@ -162,7 +162,7 @@ class Linker(CompilerSuiteTool):
         # Make a copy to avoid modifying the caller's list
         self._lib_flags[lib] = flags[:]
 
-    def add_pre_lib_flags(self, flags: List[str],
+    def add_pre_lib_flags(self, flags: list[str],
                           profile: Optional[str] = None):
         '''Add a set of flags to use before any library-specific flags
 
@@ -170,7 +170,7 @@ class Linker(CompilerSuiteTool):
         '''
         self._pre_lib_flags.add_flags(flags, profile)
 
-    def add_post_lib_flags(self, flags: List[str],
+    def add_post_lib_flags(self, flags: list[str],
                            profile: Optional[str] = None):
         '''Add a set of flags to use after any library-specific flags
 
@@ -178,7 +178,7 @@ class Linker(CompilerSuiteTool):
         '''
         self._post_lib_flags.add_flags(flags, profile)
 
-    def get_pre_link_flags(self, config: "BuildConfig") -> List[str]:
+    def get_pre_link_flags(self, config: "BuildConfig") -> list[str]:
         '''Returns the list of pre-link flags. It will concatenate the
         flags for this instance with all potentially wrapped linkers.
         This wrapper's flag will come first - the assumption is that
@@ -186,10 +186,10 @@ class Linker(CompilerSuiteTool):
         be able to put a search path before the paths from a wrapped
         linker.
 
-        :returns: List of pre-link flags of this linker and all
+        :returns: list of pre-link flags of this linker and all
             wrapped linkers
         '''
-        params: List[str] = []
+        params: list[str] = []
         if self._pre_lib_flags:
             params.extend(self._pre_lib_flags[config.profile])
         if self._linker:
@@ -200,15 +200,15 @@ class Linker(CompilerSuiteTool):
             params.extend(self._linker.get_pre_link_flags(config))
         return params
 
-    def get_post_link_flags(self, config: "BuildConfig") -> List[str]:
+    def get_post_link_flags(self, config: "BuildConfig") -> list[str]:
         '''Returns the list of post-link flags. It will concatenate the
         flags for this instance with all potentially wrapped linkers.
         This wrapper's flag will be added to the end.
 
-        :returns: List of post-link flags of this linker and all
+        :returns: list of post-link flags of this linker and all
             wrapped linkers
         '''
-        params: List[str] = []
+        params: list[str] = []
         if self._linker:
             # If we are wrapping a linker, get the wrapped linker's
             # post-link flags and add them first (so this linker
@@ -219,10 +219,10 @@ class Linker(CompilerSuiteTool):
             params.extend(self._post_lib_flags[config.profile])
         return params
 
-    def link(self, input_files: List[Path], output_file: Path,
+    def link(self, input_files: list[Path], output_file: Path,
              config: "BuildConfig",
-             libs: Optional[List[str]] = None,
-             add_flags: Optional[List[str]] = None) -> str:
+             libs: Optional[list[str]] = None,
+             add_flags: Optional[list[str]] = None) -> str:
         '''Executes the linker with the specified input files,
         creating `output_file`.
 
@@ -235,7 +235,7 @@ class Linker(CompilerSuiteTool):
         :returns: the stdout of the link command
         '''
 
-        params: List[Union[str, Path]] = []
+        params: list[Union[str, Path]] = []
 
         params.extend(self._compiler.get_flags(config.profile))
 

--- a/source/fab/tools/preprocessor.py
+++ b/source/fab/tools/preprocessor.py
@@ -10,7 +10,7 @@ classes for cpp and fpp.
 """
 
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -32,15 +32,15 @@ class Preprocessor(Tool):
         self._version = None
 
     def preprocess(self, input_file: Path, output_file: Path,
-                   add_flags: Union[None, List[Union[Path, str]]] = None):
+                   add_flags: Union[None, list[Union[Path, str]]] = None):
         '''Calls the preprocessor to process the specified input file,
         creating the requested output file.
 
         :param input_file: input file.
         :param output_file: the output filename.
-        :param add_flags: List with additional flags to be used.
+        :param add_flags: list with additional flags to be used.
         '''
-        params: List[Union[str, Path]] = []
+        params: list[Union[str, Path]] = []
         if add_flags:
             # Make a copy to avoid modifying the caller's list
             params = add_flags[:]

--- a/source/fab/tools/psyclone.py
+++ b/source/fab/tools/psyclone.py
@@ -9,7 +9,7 @@
 
 from pathlib import Path
 import re
-from typing import Callable, List, Optional, Union
+from typing import Callable, Optional, Union
 import warnings
 
 from fab.build_config import BuildConfig
@@ -61,8 +61,8 @@ class Psyclone(Tool):
                 transformed_file: Optional[Path] = None,
                 transformation_script: Optional[Callable[[Path, "BuildConfig"],
                                                          Path]] = None,
-                additional_parameters: Optional[List[str]] = None,
-                kernel_roots: Optional[List[Union[str, Path]]] = None,
+                additional_parameters: Optional[list[str]] = None,
+                kernel_roots: Optional[list[Union[str, Path]]] = None,
                 api: Optional[str] = None,
                 ):
         # pylint: disable=too-many-arguments, too-many-branches
@@ -114,7 +114,7 @@ class Psyclone(Tool):
                 raise RuntimeError("PSyclone called without api, but "
                                    "transformed_file is not specified.")
 
-        parameters: List[Union[str, Path]] = []
+        parameters: list[Union[str, Path]] = []
         # If an api is defined in this call (or in the constructor) add it
         # as parameter. No API is required if PSyclone works as
         # transformation tool only, so calling PSyclone without api is
@@ -157,7 +157,7 @@ class Psyclone(Tool):
         if additional_parameters:
             parameters.extend(additional_parameters)
         if kernel_roots:
-            roots_with_dash_d: List[str] = sum([['-d', str(k)]
+            roots_with_dash_d: list[str] = sum([['-d', str(k)]
                                                 for k in kernel_roots], [])
             parameters.extend(roots_with_dash_d)
         parameters.append(str(x90_file))

--- a/source/fab/tools/rsync.py
+++ b/source/fab/tools/rsync.py
@@ -9,7 +9,7 @@
 
 import os
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -35,6 +35,6 @@ class Rsync(Tool):
         if not src_str.endswith('/'):
             src_str += '/'
 
-        parameters: List[Union[str, Path]] = [
+        parameters: list[Union[str, Path]] = [
             '--times', '--links', '--stats', '-ru', src_str, dst]
         return self.run(additional_parameters=parameters)

--- a/source/fab/tools/shell.py
+++ b/source/fab/tools/shell.py
@@ -9,7 +9,7 @@ other scripts.
 """
 
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -28,7 +28,7 @@ class Shell(Tool):
                          availability_option=["-c", "echo hello"],
                          category=Category.SHELL)
 
-    def exec(self, command: Union[str, List[Union[Path, str]]]) -> str:
+    def exec(self, command: Union[str, list[Union[Path, str]]]) -> str:
         '''Executes the specified command.
 
         :param command: the command and potential parameters to execute.
@@ -36,7 +36,7 @@ class Shell(Tool):
         :returns: stdout of the result.
         '''
         # Make mypy happy:
-        params: List[Union[str, Path]]
+        params: list[Union[str, Path]]
         if isinstance(command, str):
             params = ["-c", command]
         else:

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -16,7 +16,7 @@ a tool is actually available.
 import logging
 from pathlib import Path
 import subprocess
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Optional, Sequence, Union
 
 from fab.tools.category import Category
 from fab.tools.flags import ProfileFlags
@@ -36,7 +36,7 @@ class Tool:
 
     def __init__(self, name: str, exec_name: Union[str, Path],
                  category: Category = Category.MISC,
-                 availability_option: Optional[Union[str, List[str]]] = None):
+                 availability_option: Optional[Union[str, list[str]]] = None):
         self._logger = logging.getLogger(__name__)
         self._name = name
         self._exec_path = Path(exec_name)
@@ -112,7 +112,7 @@ class Tool:
         return self._name
 
     @property
-    def availability_option(self) -> Union[str, List[str]]:
+    def availability_option(self) -> Union[str, list[str]]:
         ''':returns: the option to use to check if the tool is available.'''
         return self._availability_option
 
@@ -125,7 +125,7 @@ class Tool:
         ''':returns: the flags to be used with this tool.'''
         return self._flags[profile]
 
-    def add_flags(self, new_flags: Union[str, List[str]],
+    def add_flags(self, new_flags: Union[str, list[str]],
                   profile: Optional[str] = None):
         '''Adds the specified flags to the list of flags.
 
@@ -160,14 +160,14 @@ class Tool:
             additional_parameters: Optional[
                 Union[str, Sequence[Union[Path, str]]]] = None,
             profile: Optional[str] = None,
-            env: Optional[Dict[str, str]] = None,
+            env: Optional[dict[str, str]] = None,
             cwd: Optional[Union[Path, str]] = None,
             capture_output=True) -> str:
         """
         Run the binary as a subprocess.
 
         :param additional_parameters:
-            List of strings or paths to be sent to :func:`subprocess.run`
+            list of strings or paths to be sent to :func:`subprocess.run`
             as additional parameters for the command. Any path will be
             converted to a normal string.
         :param env:
@@ -229,7 +229,7 @@ class CompilerSuiteTool(Tool):
     '''
     def __init__(self, name: str, exec_name: Union[str, Path], suite: str,
                  category: Category,
-                 availability_option: Optional[Union[str, List[str]]] = None):
+                 availability_option: Optional[Union[str, list[str]]] = None):
         super().__init__(name, exec_name, category,
                          availability_option=availability_option)
         self._suite = suite

--- a/source/fab/tools/tool_box.py
+++ b/source/fab/tools/tool_box.py
@@ -8,7 +8,7 @@
 '''
 
 import warnings
-from typing import Dict, Optional
+from typing import Optional
 
 from fab.tools.abstract_tool_box import AbstractToolBox
 from fab.tools.category import Category
@@ -22,7 +22,7 @@ class ToolBox(AbstractToolBox):
     '''
 
     def __init__(self) -> None:
-        self._all_tools: Dict[Category, Tool] = {}
+        self._all_tools: dict[Category, Tool] = {}
 
     def has(self, category: Category) -> bool:
         '''

--- a/source/fab/tools/versioning.py
+++ b/source/fab/tools/versioning.py
@@ -8,7 +8,7 @@ Versioning tools such as Subversion and Git.
 """
 from abc import ABC
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from fab.tools.category import Category
 from fab.tools.tool import Tool
@@ -77,7 +77,7 @@ class Git(Versioning):
         :param dst: the directory in which to run fetch.
         '''
         # todo: allow shallow fetch with --depth 1
-        command: List[Union[str, Path]] = ['fetch', str(src)]
+        command: list[Union[str, Path]] = ['fetch', str(src)]
         if revision:
             command.append(revision)
         self.run(command, cwd=str(dst), capture_output=False)
@@ -135,25 +135,25 @@ class Subversion(Versioning):
         super().__init__(name, exec_name, category=category)
 
     # pylint: disable-next=too-many-arguments
-    def execute(self, pre_commands: Optional[List[str]] = None,
+    def execute(self, pre_commands: Optional[list[str]] = None,
                 revision: Optional[Union[int, str]] = None,
-                post_commands: Optional[List[str]] = None,
-                env: Optional[Dict[str, str]] = None,
+                post_commands: Optional[list[str]] = None,
+                env: Optional[dict[str, str]] = None,
                 cwd: Optional[Union[Path, str]] = None,
                 capture_output=True) -> str:
         '''Executes a svn command.
 
-        :param pre_commands: List of strings to be sent to
+        :param pre_commands: list of strings to be sent to
             :func:`subprocess.run` as the command.
         :param revision: optional revision number as argument
-        :param post_commands: List of additional strings to be sent to
+        :param post_commands: list of additional strings to be sent to
             :func:`subprocess.run` after the optional revision number.
         :param env: Optional env for the command. By default it will use
             the current session's environment.
         :param capture_output: If True, capture and return stdout. If False,
             the command will print its output directly to the console.
         '''
-        command: List[Union[str, Path]] = []
+        command: list[Union[str, Path]] = []
         if pre_commands:
             command.extend(pre_commands)
         if revision:

--- a/source/fab/util.py
+++ b/source/fab/util.py
@@ -17,7 +17,7 @@ from argparse import ArgumentParser
 from collections import namedtuple, defaultdict
 from pathlib import Path
 from time import perf_counter
-from typing import Iterator, Iterable, Optional, Dict, Set, Union, List
+from typing import Iterator, Iterable, Optional, Union
 
 import fab
 
@@ -76,7 +76,7 @@ def string_checksum(s: str):
     return zlib.crc32(s.encode())
 
 
-def file_walk(path: Union[str, Path], ignore_folders: Optional[List[Path]] = None) -> Iterator[Path]:
+def file_walk(path: Union[str, Path], ignore_folders: Optional[list[Path]] = None) -> Iterator[Path]:
     """
     Return every file in *path* and its sub-folders.
 
@@ -263,7 +263,7 @@ def get_fab_workspace() -> Path:
     return Path(workspace)
 
 
-def get_prebuild_file_groups(prebuild_files: Iterable[Path]) -> Dict[str, Set]:
+def get_prebuild_file_groups(prebuild_files: Iterable[Path]) -> dict[str, set]:
     """
     Group prebuild filenames by originating artefact.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ Fixtures and helpers for testing.
 """
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pytest import fixture
 from pytest_subprocess.fake_process import FakeProcess, ProcessRecorder
@@ -31,19 +31,19 @@ def not_found_callback(process):
     raise FileNotFoundError("Executable file missing")
 
 
-def call_list(fake_process: FakeProcess) -> List[List[str]]:
+def call_list(fake_process: FakeProcess) -> list[list[str]]:
     """
     Converts FakeProcess calls to strings.
 
     :returns: List of argument strings per call.
     """
-    result: List[List[str]] = []
+    result: list[list[str]] = []
     for call in fake_process.calls:
         result.append([str(arg) for arg in call])
     return result
 
 
-def arg_list(record: ProcessRecorder) -> List[Dict[str, str]]:
+def arg_list(record: ProcessRecorder) -> list[dict[str, str]]:
     """
     Converts ProcessRecorder calls to subprocess arguments.
 
@@ -51,7 +51,7 @@ def arg_list(record: ProcessRecorder) -> List[Dict[str, str]]:
 
     :returns: Dictionary of argument passed to subprocess per call.
     """
-    result: List[Dict[str, str]] = []
+    result: list[dict[str, str]] = []
     for call in record.calls:
         if call.kwargs is None:
             args = {}
@@ -68,7 +68,7 @@ class ExtendedRecorder:
     def __init__(self, recorder: ProcessRecorder):
         self.recorder = recorder
 
-    def invocations(self) -> List[List[str]]:
+    def invocations(self) -> list[list[str]]:
         """
         Lists invocations as simple string lists.
         """
@@ -77,15 +77,15 @@ class ExtendedRecorder:
             calls.append([str(arg) for arg in call.args])
         return calls
 
-    def extras(self) -> List[Dict[str, Optional[str]]]:
+    def extras(self) -> list[dict[str, Optional[str]]]:
         """
         Lists arguments passed to subprocess.
 
         This allows .e.g. pwd to be seen, if set.
         """
-        args: List[Dict[str, Optional[str]]] = []
+        args: list[dict[str, Optional[str]]] = []
         for call in self.recorder.calls:
-            things: Dict[str, Optional[str]] = {}
+            things: dict[str, Optional[str]] = {}
             if call.kwargs is None:
                 continue
             for key, value in call.kwargs.items():

--- a/tests/system_tests/incremental_fortran/test_incremental_fortran.py
+++ b/tests/system_tests/incremental_fortran/test_incremental_fortran.py
@@ -2,7 +2,6 @@ from datetime import timedelta, datetime
 import logging
 import os
 from pathlib import Path
-from typing import List
 from unittest.mock import Mock
 import zlib
 
@@ -257,7 +256,7 @@ class TestCleanupPrebuilds:
         return configuration
 
     @staticmethod
-    def prebuilt_files(configuration: BuildConfig) -> List[str]:
+    def prebuilt_files(configuration: BuildConfig) -> list[str]:
         """
         Determines a list of files in the pre-build directory.
 

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -4,7 +4,6 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 from pathlib import Path
-import shutil
 from typing import Any
 from unittest import mock
 

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -7,7 +7,7 @@ import filecmp
 from os import unlink
 from pathlib import Path
 import shutil
-from typing import Any, Dict
+from typing import Any
 from unittest import mock
 
 from pytest import fixture, mark, warns
@@ -184,8 +184,8 @@ class TestPsyclone:
         assert all(list(config.build_output.glob(f)) != [] for f in expect_build_files)
 
     @staticmethod
-    def __file_stats(path: Path) -> Dict[str, Dict[str, Any]]:
-        stat_map: Dict[str, Dict[str, Any]] = {}
+    def __file_stats(path: Path) -> dict[str, dict[str, Any]]:
+        stat_map: dict[str, dict[str, Any]] = {}
         for file in path.iterdir():
             stats = file.stat()
             stat_map[str(file)] = {key: getattr(stats, key) for key in dir(stats) if key.startswith('st_')}

--- a/tests/system_tests/svn_fcm/test_svn_fcm_system_test.py
+++ b/tests/system_tests/svn_fcm/test_svn_fcm_system_test.py
@@ -9,7 +9,7 @@ Test svn and fcm steps, if their underlying cli tools are available.
 """
 import shutil
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable
 from unittest import mock
 import warnings
 
@@ -27,7 +27,7 @@ from fab.steps.grab.svn import svn_checkout, svn_export, svn_merge
 # Which tools are available?
 export_funcs = []
 checkout_funcs = []
-merge_funcs: List[Callable] = []
+merge_funcs: list[Callable] = []
 
 svn = Subversion()
 if svn.is_available:

--- a/tests/unit_tests/fab_base/site_specific/default/config.py
+++ b/tests/unit_tests/fab_base/site_specific/default/config.py
@@ -6,7 +6,6 @@ This module contains the default Baf configuration class.
 '''
 
 import argparse
-from typing import List
 
 from fab.build_config import AddFlags, BuildConfig
 from fab.tools.category import Category
@@ -31,14 +30,14 @@ class Config:
         '''
         return self._args
 
-    def get_valid_profiles(self) -> List[str]:
+    def get_valid_profiles(self) -> list[str]:
         '''
         Determines the list of all allowed compiler profiles. The first
         entry in this list is the default profile to be used. This method
         can be overwritten by site configs to add or modify the supported
         profiles.
 
-        :returns List[str]: list of all supported compiler profiles.
+        :returns list[str]: list of all supported compiler profiles.
         '''
         return ["default-profile", "full-debug", "fast-debug", "production"]
 
@@ -94,7 +93,7 @@ class Config:
         # initialising compilers
         self._args = args
 
-    def get_path_flags(self, build_config: BuildConfig) -> List[AddFlags]:
+    def get_path_flags(self, build_config: BuildConfig) -> list[AddFlags]:
         '''
         Returns the path-specific flags to be used.
         TODO #313: Ideally we have only one kind of flag, but as a quick

--- a/tests/unit_tests/parse/c/test_c_analyser.py
+++ b/tests/unit_tests/parse/c/test_c_analyser.py
@@ -3,7 +3,6 @@ Test CAnalyser.
 
 """
 from pathlib import Path
-from typing import List, Tuple
 from unittest import mock
 from unittest.mock import Mock
 
@@ -41,7 +40,7 @@ def test_simple_result(tmp_path: Path,
 class Test__locate_include_regions:
 
     def test_vanilla(self) -> None:
-        lines: List[Tuple[int, str]] = [
+        lines: list[tuple[int, str]] = [
             (5, "foo"),
             (10, "# pragma FAB SysIncludeStart"),
             (15, "foo"),

--- a/tests/unit_tests/steps/grab/test_svn_fcm_unit_test.py
+++ b/tests/unit_tests/steps/grab/test_svn_fcm_unit_test.py
@@ -10,7 +10,7 @@ Most of the testing happens at the task level.
 
 ToDo: Messing with "private" members.
 """
-from typing import Optional, Tuple
+from typing import Optional
 
 from pytest import mark, raises
 
@@ -29,7 +29,7 @@ class TestRevision(object):
         ]
     )
     def test_no_revision(self, url: str,
-                         expected: Tuple[str, Optional[str]]) -> None:
+                         expected: tuple[str, Optional[str]]) -> None:
         """
         Tests revision argument not given.
         """
@@ -43,7 +43,7 @@ class TestRevision(object):
         ]
     )
     def test_revision_param(self, url: str, revision: str,
-                            expected: Tuple[str, Optional[str]]):
+                            expected: tuple[str, Optional[str]]):
         """
         Tests revision argument given.
         """

--- a/tests/unit_tests/steps/test_analyse.py
+++ b/tests/unit_tests/steps/test_analyse.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict, List, Set
 from unittest.mock import Mock
 
 from pytest import fixture, warns, raises
@@ -19,13 +18,13 @@ class Test_gen_symbol_table(object):
     Tests source symbol management.
     """
     @fixture
-    def analysed_files(self) -> List[AnalysedDependent]:
+    def analysed_files(self) -> list[AnalysedDependent]:
         return [AnalysedDependent(fpath=Path('foo.c'),
                                   symbol_defs=['foo_1', 'foo_2'], file_hash=1),
                 AnalysedDependent(fpath=Path('bar.c'),
                                   symbol_defs=['bar_1', 'bar_2'], file_hash=2)]
 
-    def test_vanilla(self, analysed_files: List[AnalysedDependent]) -> None:
+    def test_vanilla(self, analysed_files: list[AnalysedDependent]) -> None:
         """
         Tests symbol table generation.
         """
@@ -39,7 +38,7 @@ class Test_gen_symbol_table(object):
         }
 
     def test_duplicate_symbol(self,
-                              analysed_files: List[AnalysedDependent]) -> None:
+                              analysed_files: list[AnalysedDependent]) -> None:
         """
         Tests duplicate symbols in different files.
         """
@@ -107,7 +106,7 @@ class Test_add_unreferenced_deps(object):
         }
 
         # we extracted the build tree
-        build_tree: Dict[Path, AnalysedDependent] = {
+        build_tree: dict[Path, AnalysedDependent] = {
             Path('root.f90'): AnalysedFortran(fpath=Path(), file_hash=1),
             Path('root_dep.f90'): AnalysedFortran(fpath=Path(), file_hash=2),
         }
@@ -117,7 +116,7 @@ class Test_add_unreferenced_deps(object):
         unreferenced_deps = ['util']
 
         # the stuff to add to the build tree will be found in here
-        all_analysed_files: Dict[Path, AnalysedDependent] = {
+        all_analysed_files: dict[Path, AnalysedDependent] = {
             # root.f90 and root_util.f90 would also be in here but the test
             # doesn't need them
             Path('util.f90'): AnalysedFortran(fpath=Path('util.f90'),
@@ -188,7 +187,7 @@ class TestAddManualResults:
         """
         workaround = FortranParserWorkaround(fpath=Path('foo.f'),
                                              symbol_defs={'foo', })
-        analysed_files: Set[AnalysedDependent] = set()
+        analysed_files: set[AnalysedDependent] = set()
 
         monkeypatch.setattr('fab.parse.fortran.file_checksum',
                             lambda x: HashedFile(None, 123))

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Dict
 from unittest.mock import Mock
 
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -93,7 +92,7 @@ class TestCompilePass:
         }
 
         # this gets filled in
-        mod_hashes: Dict[str, int] = {}
+        mod_hashes: dict[str, int] = {}
 
         config = BuildConfig('proj', stub_tool_box, fab_workspace=tmp_path)
         mp_common_args = MpCommonArgs(config,

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -4,7 +4,6 @@
 #  which you should have received as part of this distribution
 # ##############################################################################
 from pathlib import Path
-from typing import Tuple
 from unittest.mock import Mock
 
 from pytest import fixture, warns
@@ -21,7 +20,7 @@ class TestGenPrebuildHash:
 
     """
     @fixture(scope='function')
-    def data(self, tmp_path) -> Tuple[MpCommonArgs, Path]:
+    def data(self, tmp_path) -> tuple[MpCommonArgs, Path]:
 
         x90_file = Path('foo.x90')
         analysed_x90 = {

--- a/tests/unit_tests/steps/test_root_inc_files.py
+++ b/tests/unit_tests/steps/test_root_inc_files.py
@@ -8,7 +8,6 @@ Exercises
 """
 from os import walk as os_walk
 from pathlib import Path
-from typing import List
 
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises, warns
@@ -71,7 +70,7 @@ class TestRootIncFiles:
         #   always have a directory named /tmp when running on POSIX
         #   systems.
         # So we need to ignore /tmp:
-        filetree: List[Path] = []
+        filetree: list[Path] = []
         for path, _, files in os_walk('/'):
             for file in files:
                 if file == 'tmp':

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -7,7 +7,7 @@
 Tests the PSyclone tool.
 """
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 from unittest.mock import Mock
 
 from pytest import mark, raises, warns
@@ -189,7 +189,7 @@ def test_processing_errors_with_api(api: str,
                           ("gocean1.0", "gocean1.0"),
                           ("gocean", "gocean1.0")
                           ])
-def test_process_api_old_psyclone(api: Tuple[str, str], version: str,
+def test_process_api_old_psyclone(api: tuple[str, str], version: str,
                                   fake_process: FakeProcess) -> None:
     """
     Tests old style API support with PSyclone 2.5.0 and earlier.
@@ -269,7 +269,7 @@ def test_process_nemo_api_old_psyclone(version: str, api: Optional[str],
                       ("gocean1.0", "gocean"),
                       ("gocean", "gocean")
                   ])
-def test_process_api_new_psyclone(api: Tuple[str, str],
+def test_process_api_new_psyclone(api: tuple[str, str],
                                   fake_process: FakeProcess) -> None:
     """
     Test running PSyclone 3.0.0. It uses new API names, and we need to

--- a/tests/unit_tests/tools/test_versioning.py
+++ b/tests/unit_tests/tools/test_versioning.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from shutil import which
 from subprocess import Popen, run
 from time import sleep
-from typing import List, Tuple
 
 from pytest import TempPathFactory, fixture, mark, raises
 from pytest_subprocess.fake_process import FakeProcess
@@ -328,7 +327,7 @@ class TestSubversionReal:
     Tests the Subversion interface against a real executable.
     """
     @fixture(scope='class')
-    def repo(self, tmp_path_factory: TempPathFactory) -> Tuple[Path, Path]:
+    def repo(self, tmp_path_factory: TempPathFactory) -> tuple[Path, Path]:
         """
         Set up a repository and return its path along with the path of the
         original file tree.
@@ -345,7 +344,7 @@ class TestSubversionReal:
         assert run(command).returncode == 0
         return repo_path, tree_path
 
-    def test_extract_from_file(self, repo: Tuple[Path, Path], tmp_path: Path):
+    def test_extract_from_file(self, repo: tuple[Path, Path], tmp_path: Path):
         """
         Checks that a source tree can be extracted from a Subversion
         repository stored on disc.
@@ -355,12 +354,12 @@ class TestSubversionReal:
         _tree_compare(repo[1], tmp_path)
         assert not (tmp_path / '.svn').exists()
 
-    def test_extract_from_svn(self, repo: Tuple[Path, Path], tmp_path: Path):
+    def test_extract_from_svn(self, repo: tuple[Path, Path], tmp_path: Path):
         """
         Checks that a source tree can be extracted from a Subversion
         repository accessed through its own protocol.
         """
-        command: List[str] = ['svnserve', '-r', str(repo[0]), '-X']
+        command: list[str] = ['svnserve', '-r', str(repo[0]), '-X']
         process = Popen(command)
 
         test_unit = Subversion()
@@ -387,7 +386,7 @@ class TestSubversionReal:
         assert process.returncode == 0
 
     @mark.skip(reason="Too hard to test at the moment.")
-    def test_extract_from_http(self, repo: Tuple[Path, Path], tmp_path: Path):
+    def test_extract_from_http(self, repo: tuple[Path, Path], tmp_path: Path):
         """
         Checks that a source tree can be extracted from a Subversion
         repository accessed through HTTP.


### PR DESCRIPTION
This PR honors the deprecation of types in the `typing` python library in favor of built in types in python 3.9+ .

closes #524 