### PR TITLE
#311 Make Categories extendable

### DIFF
--- a/run_configs/build_all.py
+++ b/run_configs/build_all.py
@@ -22,7 +22,7 @@ class Script(Tool):
     '''
     def __init__(self, name: Path):
         super().__init__(name=name.name, exec_name=name,
-                         category=Category.MISC)
+                         category=Category.SHELL)
 
     def check_available(self):
         '''Since there typically is no command line option we could test for

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -16,7 +16,7 @@ class Script(Tool):
     '''
     def __init__(self, name: Path):
         super().__init__(name=name.name, exec_name=str(name),
-                         category=Category.MISC)
+                         category=Category.SHELL)
 
     def check_available(self):
         return True

--- a/source/fab/tools/ar.py
+++ b/source/fab/tools/ar.py
@@ -18,6 +18,8 @@ class Ar(Tool):
     '''This is the base class for `ar`.
     '''
 
+    Category.add("AR")
+
     def __init__(self):
         super().__init__("ar", "ar", Category.AR)
 

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -7,6 +7,8 @@
 '''This simple module defines an Enum for all allowed categories.
 '''
 
+from __future__ import annotations
+
 from typing import Optional
 
 
@@ -42,14 +44,16 @@ class Category(int, metaclass=CategoryMeta):
             # Called via __reduce__ (i.e. pickle), restore
             # the original int value
             obj = super().__new__(cls, val)
+        # New name. If it already exists, return the existing
+        # object
+        elif name in cls._values:
+            obj = cls._values[name]
         else:
-            # New name. Verify that it doesn't exist yet
-            if name in cls._values:
-                raise ValueError(f"Category '{name}' already exists.")
             # Get a new id for the name. Use +1 to avoid using a zero
             # (just in case)
             obj = super().__new__(cls, len(cls._values) + 1)
-        cls._values[name] = obj
+            cls._values[name] = obj
+
         return obj
 
     def __reduce__(self):
@@ -71,6 +75,15 @@ class Category(int, metaclass=CategoryMeta):
         # an attribute with the same name
         self._name = name
         setattr(Category, name, self)
+
+    @staticmethod
+    def add(name: str) -> None:
+        """
+        Adds a new category.
+        """
+        # We don't need to store the instance, it is added as an attribute
+        # to this class anyway.
+        Category(name)
 
     def __str__(self):
         return self._name
@@ -95,32 +108,32 @@ class Category(int, metaclass=CategoryMeta):
     # We need to declare all attributes here, otherwise mypy
     # is not happy. The actual values will be set below (we cannot
     # call the Category constructor here)
-    AR: "Category"
-    C_COMPILER: "Category"
-    C_PREPROCESSOR: "Category"
-    FCM: "Category"
-    FORTRAN_COMPILER: "Category"
-    FORTRAN_PREPROCESSOR: "Category"
-    GIT: "Category"
-    LINKER: "Category"
-    MISC: "Category"
-    PSYCLONE: "Category"
-    RSYNC: "Category"
-    SHELL: "Category"
-    SUBVERSION: "Category"
+    AR: Category
+    C_COMPILER: Category
+    C_PREPROCESSOR: Category
+    FCM: Category
+    FORTRAN_COMPILER: Category
+    FORTRAN_PREPROCESSOR: Category
+    GIT: Category
+    LINKER: Category
+    MISC: Category
+    PSYCLONE: Category
+    RSYNC: Category
+    SHELL: Category
+    SUBVERSION: Category
 
 
 # Now create the default categories that Fab needs
-Category("AR")
-Category("C_COMPILER")
-Category("C_PREPROCESSOR")
-Category("FCM")
-Category("FORTRAN_COMPILER")
-Category("FORTRAN_PREPROCESSOR")
-Category("GIT")
-Category("LINKER")
-Category("MISC")
-Category("PSYCLONE")
-Category("RSYNC")
-Category("SHELL")
-Category("SUBVERSION")
+Category.add("AR")
+Category.add("C_COMPILER")
+Category.add("C_PREPROCESSOR")
+Category.add("FCM")
+Category.add("FORTRAN_COMPILER")
+Category.add("FORTRAN_PREPROCESSOR")
+Category.add("GIT")
+Category.add("LINKER")
+Category.add("MISC")
+Category.add("PSYCLONE")
+Category.add("RSYNC")
+Category.add("SHELL")
+Category.add("SUBVERSION")

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -67,6 +67,11 @@ class Category(int, metaclass=CategoryMeta):
     def __str__(self):
         return self._name
 
+    def __eq__(self, other):
+        if isinstance(other, Category):
+            return self._name == other._name
+        return NotImplemented
+
     def __hash__(self):
         return hash(self._name)
 

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -131,6 +131,3 @@ Category.add("C_PREPROCESSOR")
 Category.add("FORTRAN_COMPILER")
 Category.add("FORTRAN_PREPROCESSOR")
 Category.add("LINKER")
-
-# Special category only used for unit tests
-Category.add("CATEGORY_FOR_UNIT_TESTS")

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -116,24 +116,21 @@ class Category(int, metaclass=CategoryMeta):
     FORTRAN_PREPROCESSOR: Category
     GIT: Category
     LINKER: Category
-    MISC: Category
     PSYCLONE: Category
     RSYNC: Category
     SHELL: Category
     SUBVERSION: Category
+    # In order to make mypy happy, we add this category for
+    # unit tests.
+    CATEGORY_FOR_UNIT_TESTS: Category
 
 
 # Now create the default categories that Fab needs
-Category.add("AR")
 Category.add("C_COMPILER")
 Category.add("C_PREPROCESSOR")
-Category.add("FCM")
 Category.add("FORTRAN_COMPILER")
 Category.add("FORTRAN_PREPROCESSOR")
-Category.add("GIT")
 Category.add("LINKER")
-Category.add("MISC")
-Category.add("PSYCLONE")
-Category.add("RSYNC")
-Category.add("SHELL")
-Category.add("SUBVERSION")
+
+# Special category only used for unit tests
+Category.add("CATEGORY_FOR_UNIT_TESTS")

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -7,6 +7,8 @@
 '''This simple module defines an Enum for all allowed categories.
 '''
 
+from typing import Optional
+
 
 class CategoryMeta(type):
     """
@@ -14,11 +16,14 @@ class CategoryMeta(type):
     that provides an API to allow to iterate over all categories.
     """
 
+    # A dictionary used for iterating over all enums.
+    _values: dict[str, "Category"] = {}
+
     def __iter__(cls):
         return iter(cls._values.values())
 
 
-class Category(metaclass=CategoryMeta):
+class Category(int, metaclass=CategoryMeta):
     """
     This class defines the allowed tool categories. It presents
     an interface similar to a Python enum, but it allows to extend
@@ -33,13 +38,30 @@ class Category(metaclass=CategoryMeta):
     used as keys in dictionaries (e.g. `ToolBox`) and comparisons.
     """
 
-    _values: dict[str, "Category"] = {}
+    def __new__(cls, name: str, val: Optional[int] = None):
+        # choose a numeric value for the int part
+        if val is not None:
+            # Called via __reduce__ (i.e. pickle), restore
+            # the original int value
+            obj = super().__new__(cls, val)
+        else:
+            # New name. Verify that it doesn't exist yet
+            if name in cls._values:
+                raise ValueError(f"Category '{name}' already exists.")
+            # Get a new id for the name. Use +1 to avoid using a zero
+            # (just in case)
+            obj = super().__new__(cls, len(cls._values) + 1)
+        cls._values[name] = obj
+        return obj
 
-    def __init__(self, name: str):
-        if name in Category._values:
-            raise ValueError(f"Category '{name}' already exists.")
+    def __reduce__(self):
+        # return (callable, args) so pickle can reconstruct the object
+        return (Category, (self._name, int(self)))
+
+    def __init__(self, name: str, int: Optional[int] = None):
+        # Store the name for the name attribute, and create
+        # an attribute with the same name
         self._name = name
-        Category._values[name] = self
         setattr(Category, name, self)
 
     def __str__(self):
@@ -48,12 +70,11 @@ class Category(metaclass=CategoryMeta):
     def __hash__(self):
         return hash(self._name)
 
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, Category) and self._name == other._name
-
     @property
     def name(self) -> str:
         """
+        Compatibility to enum feature:
+
         :returns: the name of this Category as string.
         """
         return self._name
@@ -63,8 +84,8 @@ class Category(metaclass=CategoryMeta):
         """
         :returns: if this Category is a Fortran or C compiler.
         """
-        return self in [Category._values["C_COMPILER"],
-                        Category._values["FORTRAN_COMPILER"]]
+        return self in [Category.C_COMPILER,
+                        Category.FORTRAN_COMPILER]
 
     # We need to declare all attributes here, otherwise mypy
     # is not happy. The actual values will be set below (we cannot

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -32,10 +32,8 @@ class Category(int, metaclass=CategoryMeta):
     A enum is created by just creating an instance, e.g.:
     `Category("PSYCLONE")` (and it is checked that all names
     are unique). This will create `Category.PSYCLONE`. It also
-    allows iterating over all catogories, e.g. `for cat in Categories`.
+    allows iterating over all categories, e.g. `for cat in Categories`.
 
-    The category adds `__hash__` and `__eq__`, which allows it to be
-    used as keys in dictionaries (e.g. `ToolBox`) and comparisons.
     """
 
     def __new__(cls, name: str, val: Optional[int] = None):
@@ -58,7 +56,17 @@ class Category(int, metaclass=CategoryMeta):
         # return (callable, args) so pickle can reconstruct the object
         return (Category, (self._name, int(self)))
 
-    def __init__(self, name: str, int: Optional[int] = None):
+    def __init__(self, name: str, value: Optional[int] = None):
+        """
+        Creates the instance, and also sets it as class attribute of the
+        Category class. The `value` parameter is only required for
+        pickling (which is used when starting sub-processes)/
+
+        :param name: The name of the category to create, which will also
+            become an attribute of Category.
+        :param value: the integer value (which will be set in __new__,
+            and is otherwise required for pickling only).
+        """
         # Store the name for the name attribute, and create
         # an attribute with the same name
         self._name = name
@@ -66,14 +74,6 @@ class Category(int, metaclass=CategoryMeta):
 
     def __str__(self):
         return self._name
-
-    def __eq__(self, other):
-        if isinstance(other, Category):
-            return self._name == other._name
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self._name)
 
     @property
     def name(self) -> str:

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -7,33 +7,94 @@
 '''This simple module defines an Enum for all allowed categories.
 '''
 
-from enum import auto, Enum
+
+class CategoryMeta(type):
+    """
+    A meta class for a simple, enum-like Category class,
+    that provides an API to allow to iterate over all categories.
+    """
+
+    def __iter__(cls):
+        return iter(cls._values.values())
 
 
-class Category(Enum):
-    '''This class defines the allowed tool categories.'''
-    # TODO 311: Allow support for users to add their own tools.
+class Category(metaclass=CategoryMeta):
+    """
+    This class defines the allowed tool categories. It presents
+    an interface similar to a Python enum, but it allows to extend
+    an enum.
 
-    C_COMPILER = auto()
-    C_PREPROCESSOR = auto()
-    FORTRAN_COMPILER = auto()
-    FORTRAN_PREPROCESSOR = auto()
-    LINKER = auto()
-    PSYCLONE = auto()
-    FCM = auto()
-    GIT = auto()
-    SUBVERSION = auto()
-    AR = auto()
-    RSYNC = auto()
-    SHELL = auto()
-    MISC = auto()
+    A enum is created by just creating an instance, e.g.:
+    `Category("PSYCLONE")` (and it is checked that all names
+    are unique). This will create `Category.PSYCLONE`. It also
+    allows iterating over all catogories, e.g. `for cat in Categories`.
+
+    The category adds `__hash__` and `__eq__`, which allows it to be
+    used as keys in dictionaries (e.g. `ToolBox`) and comparisons.
+    """
+
+    _values: dict[str, "Category"] = {}
+
+    def __init__(self, name: str):
+        if name in Category._values:
+            raise ValueError(f"Category '{name}' already exists.")
+        self._name = name
+        Category._values[name] = self
+        setattr(Category, name, self)
 
     def __str__(self):
-        '''Simplify the str output by using only the name (e.g. `C_COMPILER`
-        instead of `Category.C_COMPILER)`.'''
-        return str(self.name)
+        return self._name
+
+    def __hash__(self):
+        return hash(self._name)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Category) and self._name == other._name
 
     @property
-    def is_compiler(self):
-        '''Returns if the category is either a C or a Fortran compiler.'''
-        return self in [Category.FORTRAN_COMPILER, Category.C_COMPILER]
+    def name(self) -> str:
+        """
+        :returns: the name of this Category as string.
+        """
+        return self._name
+
+    @property
+    def is_compiler(self) -> bool:
+        """
+        :returns: if this Category is a Fortran or C compiler.
+        """
+        return self in [Category._values["C_COMPILER"],
+                        Category._values["FORTRAN_COMPILER"]]
+
+    # We need to declare all attributes here, otherwise mypy
+    # is not happy. The actual values will be set below (we cannot
+    # call the Category constructor here)
+    AR: "Category"
+    C_COMPILER: "Category"
+    C_PREPROCESSOR: "Category"
+    FCM: "Category"
+    FORTRAN_COMPILER: "Category"
+    FORTRAN_PREPROCESSOR: "Category"
+    GIT: "Category"
+    LINKER: "Category"
+    MISC: "Category"
+    PSYCLONE: "Category"
+    RSYNC: "Category"
+    SHELL: "Category"
+    SUBVERSION: "Category"
+
+
+# Now create the default categories that Fab needs
+Category("AR")
+Category("C_COMPILER")
+Category("C_PREPROCESSOR")
+Category("FCM")
+Category("FORTRAN_COMPILER")
+Category("FORTRAN_PREPROCESSOR")
+Category("GIT")
+Category("LINKER")
+Category("MISC")
+Category("PSYCLONE")
+Category("RSYNC")
+Category("SHELL")
+Category("SUBVERSION")

--- a/source/fab/tools/psyclone.py
+++ b/source/fab/tools/psyclone.py
@@ -21,6 +21,8 @@ class Psyclone(Tool):
     '''This is the base class for `PSyclone`.
     '''
 
+    Category.add("PSYCLONE")
+
     def __init__(self):
         super().__init__("psyclone", "psyclone", Category.PSYCLONE)
         self._version = None

--- a/source/fab/tools/rsync.py
+++ b/source/fab/tools/rsync.py
@@ -19,6 +19,8 @@ class Rsync(Tool):
     '''This is the base class for `rsync`.
     '''
 
+    Category.add("RSYNC")
+
     def __init__(self):
         super().__init__("rsync", "rsync", Category.RSYNC)
 

--- a/source/fab/tools/shell.py
+++ b/source/fab/tools/shell.py
@@ -23,6 +23,9 @@ class Shell(Tool):
 
     :name: the path to the script to run.
     '''
+
+    Category.add("SHELL")
+
     def __init__(self, name: str):
         super().__init__(name=name, exec_name=name,
                          availability_option=["-c", "echo hello"],

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -35,7 +35,7 @@ class Tool:
     '''
 
     def __init__(self, name: str, exec_name: Union[str, Path],
-                 category: Category = Category.MISC,
+                 category: Category,
                  availability_option: Optional[Union[str, list[str]]] = None):
         self._logger = logging.getLogger(__name__)
         self._name = name

--- a/source/fab/tools/versioning.py
+++ b/source/fab/tools/versioning.py
@@ -38,6 +38,8 @@ class Git(Versioning):
     Interface to Git version control system.
     """
 
+    Category.add("GIT")
+
     def __init__(self):
         super().__init__("git", "git",
                          category=Category.GIT)
@@ -117,6 +119,9 @@ class Subversion(Versioning):
     """
     Interface to the Subversion version control system.
     """
+
+    Category.add("SUBVERSION")
+
     def __init__(self, name: Optional[str] = None,
                  exec_name: Optional[Union[str, Path]] = None,
                  category: Category = Category.SUBVERSION):
@@ -220,6 +225,8 @@ class Fcm(Subversion):
     '''This is the base class for FCM. All commands will be mapped back
     to the corresponding subversion commands.
     '''
+
+    Category.add("FCM")
 
     def __init__(self):
         super().__init__("FCM", "fcm", Category.FCM)

--- a/tests/unit_tests/tools/test_category.py
+++ b/tests/unit_tests/tools/test_category.py
@@ -6,8 +6,29 @@
 
 '''This module tests the Categories.
 '''
+from pytest import raises
+
 
 from fab.tools.category import Category
+
+
+def test_duplicate_categories():
+    """
+    Tests that we get an error if we try to duplicate a category.
+    """
+
+    with raises(ValueError) as err:
+        Category("FORTRAN_COMPILER")
+
+    assert "Category 'FORTRAN_COMPILER' already exists." in str(err.value)
+
+
+def test_hash():
+    """
+    Test the hash functionality.
+    """
+
+    assert hash(Category.FORTRAN_COMPILER) == hash("FORTRAN_COMPILER")
 
 
 def test_category():

--- a/tests/unit_tests/tools/test_category.py
+++ b/tests/unit_tests/tools/test_category.py
@@ -4,8 +4,12 @@
 # which you should have received as part of this distribution
 ##############################################################################
 
-'''This module tests the Categories.
-'''
+"""
+This module tests the Categories.
+"""
+
+import pickle
+
 from pytest import raises
 
 
@@ -46,3 +50,15 @@ def test_is_compiler():
             assert cat.is_compiler
         else:
             assert not cat.is_compiler
+
+
+def test_category_pickle():
+    """
+    Test that pickling will return an object with the same
+    integer representation.
+    """
+
+    c = Category.AR
+    data = pickle.dumps(c)
+    c2 = pickle.loads(data)
+    assert c2 == c

--- a/tests/unit_tests/tools/test_category.py
+++ b/tests/unit_tests/tools/test_category.py
@@ -10,21 +10,19 @@ This module tests the Categories.
 
 import pickle
 
-from pytest import raises
-
 
 from fab.tools.category import Category
 
 
 def test_duplicate_categories():
     """
-    Tests that we get an error if we try to duplicate a category.
+    Tests that trying to create a new Category that already exists,
+    we get the existing object.
     """
 
-    with raises(ValueError) as err:
-        Category("FORTRAN_COMPILER")
-
-    assert "Category 'FORTRAN_COMPILER' already exists." in str(err.value)
+    old_ftn_cat = Category.FORTRAN_COMPILER
+    new_ftn_cat = Category("FORTRAN_COMPILER")
+    assert old_ftn_cat is new_ftn_cat
 
 
 def test_category():

--- a/tests/unit_tests/tools/test_category.py
+++ b/tests/unit_tests/tools/test_category.py
@@ -27,14 +27,6 @@ def test_duplicate_categories():
     assert "Category 'FORTRAN_COMPILER' already exists." in str(err.value)
 
 
-def test_hash():
-    """
-    Test the hash functionality.
-    """
-
-    assert hash(Category.FORTRAN_COMPILER) == hash("FORTRAN_COMPILER")
-
-
 def test_category():
     '''Tests the categories.'''
     # Make sure that str of a category only prints the name (which is more

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -19,6 +19,9 @@ from fab.tools.flags import ProfileFlags
 from fab.tools.tool import CompilerSuiteTool, Tool
 
 
+Category.add("CATEGORY_FOR_UNIT_TESTS")
+
+
 def test_constructor() -> None:
     """
     Tests construction from argument list.

--- a/tests/unit_tests/tools/test_tool.py
+++ b/tests/unit_tests/tools/test_tool.py
@@ -41,18 +41,13 @@ def test_constructor() -> None:
     assert not linker.is_compiler
 
     # Check that a path is accepted
-    mytool = Tool("MyTool", Path("/bin/mytool"))
+    mytool = Tool("MyTool", Path("/bin/mytool"),
+                  Category.CATEGORY_FOR_UNIT_TESTS)
     assert mytool.name == "MyTool"
     # A path should be converted to a string, since this
     # is later passed to the subprocess command
     assert mytool.exec_path == Path("/bin/mytool")
-    assert mytool.category == Category.MISC
-
-    # Check that if we specify no category, we get the default:
-    misc = Tool("misc", "misc")
-    assert misc.exec_name == "misc"
-    assert misc.name == "misc"
-    assert misc.category == Category.MISC
+    assert mytool.category == Category.CATEGORY_FOR_UNIT_TESTS
 
 
 def test_tool_set_path() -> None:
@@ -109,7 +104,7 @@ def test_run_missing(fake_process: FakeProcess) -> None:
     Tests attempting to run a missing tool.
     """
     fake_process.register(['stool', '--ops'], callback=not_found_callback)
-    tool = Tool("some tool", "stool", Category.MISC)
+    tool = Tool("some tool", "stool", Category.CATEGORY_FOR_UNIT_TESTS)
     with raises(RuntimeError) as err:
         tool.run("--ops")
     assert str(err.value).startswith(
@@ -120,7 +115,7 @@ def test_run_missing(fake_process: FakeProcess) -> None:
     fake_process.register(['stool', '--ops'], returncode=1,
                           stdout="this is stdout",
                           stderr="this is stderr")
-    tool = Tool("some tool", "stool", Category.MISC)
+    tool = Tool("some tool", "stool", Category.CATEGORY_FOR_UNIT_TESTS)
     with raises(RuntimeError) as err:
         tool.run("--ops")
     assert "this is stdout" in str(err.value)
@@ -131,7 +126,7 @@ def test_tool_flags_no_profile() -> None:
     """
     Test that flags without using a profile work as expected.
     """
-    tool = Tool("some tool", "stool", Category.MISC)
+    tool = Tool("some tool", "stool", Category.CATEGORY_FOR_UNIT_TESTS)
     assert tool.get_flags() == []
     tool.add_flags("-a")
     assert tool.get_flags() == ["-a"]
@@ -173,7 +168,7 @@ class TestToolRun:
         """
         fake_process.register(['stool'], stdout="123")
         fake_process.register(['stool'], stdout="123")
-        tool = Tool("some tool", "stool", Category.MISC)
+        tool = Tool("some tool", "stool", Category.CATEGORY_FOR_UNIT_TESTS)
         assert tool.run(capture_output=True) == "123"
         assert tool.run(capture_output=False) == ""
         assert call_list(fake_process) == [['stool'], ['stool']]
@@ -183,7 +178,7 @@ class TestToolRun:
         """
         Tets run with single argument.
         """
-        tool = Tool("some tool", "tool", Category.MISC)
+        tool = Tool("some tool", "tool", Category.CATEGORY_FOR_UNIT_TESTS)
         tool.run("a")
         assert subproc_record.invocations() == [['tool', 'a']]
 
@@ -192,7 +187,7 @@ class TestToolRun:
         """
         Tests run with multiple arguments.
         """
-        tool = Tool("some tool", "tool", Category.MISC)
+        tool = Tool("some tool", "tool", Category.CATEGORY_FOR_UNIT_TESTS)
         tool.run(["a", "b"])
         assert subproc_record.invocations() == [['tool', 'a', 'b']]
 
@@ -201,7 +196,7 @@ class TestToolRun:
         Tests running a failing tool.
         """
         fake_process.register(['tool'], returncode=1, stdout="Beef.")
-        tool = Tool("some tool", "tool", Category.MISC)
+        tool = Tool("some tool", "tool", Category.CATEGORY_FOR_UNIT_TESTS)
         with raises(RuntimeError) as err:
             tool.run()
         assert str(err.value) == ("Command failed with return code 1:\n"
@@ -213,7 +208,7 @@ class TestToolRun:
         Tests running a missing tool.
         """
         fake_process.register(['tool'], callback=not_found_callback)
-        tool = Tool('some tool', 'tool', Category.MISC)
+        tool = Tool('some tool', 'tool', Category.CATEGORY_FOR_UNIT_TESTS)
         with raises(RuntimeError) as err:
             tool.run()
         assert str(err.value) == "Unable to execute command: ['tool']"


### PR DESCRIPTION
This makes the `Category` 'enum' extendable, i.e. allows application to put its own tools into the tool repository. Original use case is adding a pFUnit tool (for lfric_core pFUnit support).

Alternatively, we could re-type all `category` arguments to be `Category|str`, but that feels very hacky to me. This implementation supports the same API as an enum (i.e. it's a bit more complicated than strictly necessary, but means no other code needs to be adjusted). I have successfully used this in an lfric_core branch.