### PR TITLE
557 contained subroutines are not external

### DIFF
--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -16,7 +16,7 @@ from fparser.two.Fortran2003 import (  # type: ignore
     Function_Stmt, Language_Binding_Spec, Char_Literal_Constant,
     Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def,
     Derived_Type_Stmt, Type_Attr_Spec_List, Type_Attr_Spec, Type_Name,
-    Subroutine_Subprogram, Function_Subprogram)
+    Subroutine_Subprogram, Function_Subprogram, Internal_Subprogram_Part)
 from fparser.two.utils import walk  # type: ignore
 
 # todo: what else should we be importing from 2008 instead of 2003? This seems fragile.
@@ -406,13 +406,17 @@ class FortranAnalyser(FortranAnalyserBase):
             else:
                 analysed_file.add_symbol_def(bind_name)
 
-        # not bound, just record the presence of the fortran symbol
-        # we don't need to record stuff in modules (we think!)
+        # Not bound, just record the presence of the Fortran symbol.
+        # We don't need to record stuff in modules. Do not record
+        # any functions/subroutine that are part of a module, contained,
+        # or an interface block (since these symbols will not be external
+        # visible, and might otherwise trigger duplicated symbols in Fab)
         elif (not self._find_ancestor(obj, Module) and
+              not self._find_ancestor(obj, Internal_Subprogram_Part) and
               not self._find_ancestor(obj, Interface_Block)):
             if isinstance(obj, Subroutine_Stmt):
                 analysed_file.add_symbol_def(str(obj.get_name()))
-            if isinstance(obj, Function_Stmt):
+            elif isinstance(obj, Function_Stmt):
                 _, name, _, _ = obj.items
                 analysed_file.add_symbol_def(name.string)
 

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine.py
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine.py
@@ -52,15 +52,16 @@ def test_contained_subroutine(tmp_path):
         analyse(config, root_symbol='main')
         build_tree = config.artefact_store[ArtefactSet.BUILD_TREES]["main"]
 
-        af_mod_with_contain = None
-        for file_name in build_tree:
-            if "mod_with_contain" in str(file_name):
-                af_mod_with_contain = build_tree[file_name]
-                break
+        source_path = tmp_path / "contained_subroutine" / "source"
 
+        af_mod_with_contain = build_tree[source_path / "mod_with_contain.f90"]
         # The module should not contain any dependencies, the dependency to
         # `contained` is resolved from the subroutine it contains.
         assert af_mod_with_contain.symbol_deps == set()
+
+        # The contained subroutine in main should not be exported
+        af_main = build_tree[source_path / "main.f90"]
+        assert af_main.symbol_defs == set(["main"])
 
         # Just in case, also compile and link
         compile_fortran(config)

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine/main.f90
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine/main.f90
@@ -1,3 +1,7 @@
 program main
     use mod_with_contain, only: my_sub
+
+contains
+    subroutine should_not_be_exported
+    end subroutine should_not_be_exported
 end program main

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -146,9 +146,6 @@ class TestAnalyser:
             module_expected._file_hash = 325155675
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
-            module_expected.symbol_defs.update({'internal_func',
-                                                'internal_sub',
-                                                'openmp_sentinel'})
 
             assert analysis == module_expected
             assert isinstance(analysis, AnalysedFortran)

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -11,7 +11,7 @@
 from pathlib import Path
 from unittest import mock
 
-from fparser.common.readfortran import FortranFileReader  # type: ignore
+from fparser.common.readfortran import FortranStringReader  # type: ignore
 from fparser.two.Fortran2008 import Type_Declaration_Stmt  # type: ignore
 from fparser.two.parser import ParserFactory  # type: ignore
 from fparser.two.utils import walk  # type: ignore
@@ -21,19 +21,18 @@ from fab.build_config import BuildConfig
 from fab.parse import EmptySourceFile
 from fab.parse.fortran import FortranAnalyser, AnalysedFortran
 from fab.tools.tool_box import ToolBox
-from fab.tools.tool_repository import ToolRepository
 
 # todo: test function binding
 
 
-@pytest.fixture
-def module_fpath() -> Path:
+@pytest.fixture(name="module_fpath")
+def module_fpath_fixture() -> Path:
     '''Simple fixture that sets the name of the module test file.'''
     return Path(__file__).parent / "test_fortran_analyser.f90"
 
 
-@pytest.fixture
-def module_expected(module_fpath: Path) -> AnalysedFortran:
+@pytest.fixture(name="module_expected")
+def module_expected_fixture(module_fpath: Path) -> AnalysedFortran:
     '''Returns the expected AnalysedFortran instance for the Fortran
     test module.'''
     return AnalysedFortran(
@@ -49,12 +48,17 @@ def module_expected(module_fpath: Path) -> AnalysedFortran:
 
 
 class TestAnalyser:
+    """
+    Tests the Fortran analyser in various combinations.
+    """
 
     @pytest.fixture
     def fortran_analyser(
              self,
-             tmp_path: Path,
-             stub_tool_repository: ToolRepository) -> FortranAnalyser:
+             tmp_path: Path) -> FortranAnalyser:
+        """
+        A simple fixture that enables OpenMP and runs the analyser
+        """
         # Enable openmp, so fparser will handle the lines with omp sentinels
         config = BuildConfig('proj', ToolBox(),
                              fab_workspace=tmp_path, openmp=True)
@@ -62,7 +66,9 @@ class TestAnalyser:
         return fortran_analyser
 
     def test_empty_file(self, fortran_analyser: FortranAnalyser) -> None:
-        # make sure we get back an EmptySourceFile
+        """
+        Make sure we get back an EmptySourceFile if an empty file is given.
+        """
         with mock.patch('fab.parse.AnalysedFile.save'):
             analysis, artefact = fortran_analyser.run(
                 fpath=Path(Path(__file__).parent / "empty.f90"))
@@ -71,6 +77,10 @@ class TestAnalyser:
 
     def test_module_file(self, fortran_analyser, module_fpath,
                          module_expected):
+        """
+        Tests handling of module statement, including making sure that
+        subroutines in a module are not exported as external symbols.
+        """
         with mock.patch('fab.parse.AnalysedFile.save'):
             analysis, artefact = fortran_analyser.run(fpath=module_fpath)
         assert analysis == module_expected
@@ -132,7 +142,10 @@ class TestAnalyser:
                           fortran_analyser: FortranAnalyser,
                           module_fpath: Path,
                           module_expected: AnalysedFortran) -> None:
-        # same as test_module_file() but replacing MODULE with PROGRAM
+        """
+        Test the handling of a Program. This test replaces 'MODULE'
+        in the standard test here with 'PROGRAM'.
+        """
         prog_path = tmp_path / "prog.f90"
         with prog_path.open('w') as tmp_file:
             tmp_file.write(module_fpath.open().read().replace("MODULE",
@@ -161,12 +174,11 @@ class TestProcessVariableBinding:
 
     # todo: define and depend, with and without bind name
 
-    def test_define_without_bind_name(self, tmp_path: Path,
+    def test_define_without_bind_name(self,
                                       stub_configuration: BuildConfig) -> None:
         '''Test usage of bind'''
-        fpath = tmp_path / 'temp.f90'
 
-        open(fpath, 'wt').write("""
+        code = """
             MODULE f_var
 
             USE, INTRINSIC :: ISO_C_BINDING
@@ -179,10 +191,10 @@ class TestProcessVariableBinding:
                 helloworld=['H','e','L','l','O',' ','w','O','r','L','d','?']
 
             END MODULE f_var
-        """)
+        """
 
         # parse
-        reader = FortranFileReader(str(fpath), ignore_comments=False)
+        reader = FortranStringReader(code, ignore_comments=False)
         f2008_parser = ParserFactory().create(std="f2008")
         tree = f2008_parser(reader)
 


### PR DESCRIPTION
Prevents subroutines/functions that are 'contained' in another subroutine to be exported as defined external symbols. This is a requirement for Socrates, which has dozen of subroutines which each define their own `subroutine nf(...)`, which atm results in Fab complaining about duplicated symbols.

We already exclude subroutines in modules and interfaces, so it is just a small change to also exclude anything that's an `Internal_Subprogram_Part` (i.e. it is `contained` in another program unit).

I also did some cleanup of pylint errors in a test file.