### PR TITLE
Fab for lfric

### DIFF
--- a/Documentation/source/advanced_config.rst
+++ b/Documentation/source/advanced_config.rst
@@ -598,7 +598,7 @@ symbol and add it, *and all its dependencies*, to every :term:`Build Tree`.
     :linenos:
 
     ...
-    analyse(state, root_symbol='my_prog', unreferenced_deps=['my_func'])
+    analyse(state, root_symbols='my_prog', unreferenced_deps=['my_func'])
     ...
 
 Unparsable Files
@@ -623,7 +623,7 @@ definitions and dependencies found in one source file.
     ...
     analyse(
         config,
-        root_symbol='my_prog',
+        root_symbols='my_prog',
         special_measure_analysis_results=[
             FortranParserWorkaround(
                 fpath=Path(state.build_output / "path/to/file.f90"),

--- a/Documentation/source/fab_base/processing.rst
+++ b/Documentation/source/fab_base/processing.rst
@@ -11,7 +11,7 @@ The full class documentation is at the end of this chapter.
 The constructor sets up ultimately the Fab ``BuildConfig`` for the build.
 It takes the name of the application as argument. The name of the application
 will be used when creating the name of the build directory
-and it is also the default ``root_symbol`` when analysing the source code
+and it is also the default ``root_symbols`` when analysing the source code
 if the script creates an executable (see :ref:`analyse_step`).
 
 The actual build is then started calling the ``build`` method
@@ -403,7 +403,7 @@ There is usually no reason for an application to overwrite this step.
 
 In case of creating a binary, the analyse step will use the root symbol,
 which defaults to the name of the application, but can be changed
-using ``set_root_symbol``. This implies that ``set_root_symbol``
+using ``set_root_symbols``. This implies that ``set_root_symbols``
 must be called before ``analyse_step`` is called, e.g. it can be called
 from any method called from the constructor (including defining and
 handling command line options).

--- a/Documentation/source/writing_config.rst
+++ b/Documentation/source/writing_config.rst
@@ -207,7 +207,7 @@ The Analyse step looks for source to analyse in two collections:
             preprocess_fortran(state)
             preprocess_x90(state)
             psyclone(state)
-            analyse(state, root_symbol='<program>')
+            analyse(state, root_symbols='<program>')
 
 
 Here we tell the analyser which :term:`Root Symbol` we want to build into an executable.
@@ -245,7 +245,7 @@ then creates the executable.
             preprocess_fortran(state)
             preprocess_x90(state)
             psyclone(state)
-            analyse(state, root_symbol='<program>')
+            analyse(state, root_symbols='<program>')
             compile_fortran(state)
             link_exe(state)
 

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -32,6 +32,7 @@ from fab.steps.preprocess import preprocess_c, preprocess_fortran
 from fab.tools.category import Category
 from fab.tools.tool_box import ToolBox
 from fab.tools.tool_repository import ToolRepository
+from fab.fab_base.site_specific.default.config import Config as SiteConfig
 
 
 class FabBase:
@@ -168,12 +169,28 @@ class FabBase:
         return self._root_symbol
 
     @property
+    def name(self) -> str:
+
+        '''
+        :returns: the name of the apps.
+        '''
+        return self._name
+
+    @property
     def site(self) -> Optional[str]:
 
         '''
         :returns: the site, or None if no site is specified.
         '''
         return self._site
+
+    @property
+    def site_config(self) -> Optional[SiteConfig]:
+        """
+        :returns: the site configuration to use (or None if
+            no site config is used).
+        """
+        return self._site_config
 
     @property
     def logger(self) -> logging.Logger:
@@ -728,11 +745,11 @@ class FabBase:
         build config.
         """
         if self._link_target == "static-library":
-            out_path = self.config.project_workspace / f"lib{self._name}.a"
+            out_path = self.config.project_workspace / f"lib{self.name}.a"
             archive_objects(self.config,
                             output_fpath=str(out_path))
         elif self._link_target == "shared-library":
-            out_path = self.config.project_workspace / f"lib{self._name}.so"
+            out_path = self.config.project_workspace / f"lib{self.name}.so"
             link_shared_object(self.config,
                                output_fpath=str(out_path),
                                flags=self.linker_flags_commandline)

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -705,10 +705,10 @@ class FabBase:
                 analyse(self.config, find_programs=True,
                         ignore_dependencies=ignore_dependencies)
             else:
-                analyse(self.config, root_symbol=self.root_symbols,
+                analyse(self.config, root_symbols=self.root_symbols,
                         ignore_dependencies=ignore_dependencies)
         else:
-            analyse(self.config, root_symbol=None,
+            analyse(self.config, root_symbols=None,
                     ignore_dependencies=ignore_dependencies)
 
     def compile_c_step(

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -62,7 +62,7 @@ class FabBase:
         self._target = ""
         # Set the given name as root symbol, it can be set explicitly
         # using set_root_symbol()
-        self._root_symbol: list[str] = [name]
+        self._root_symbols: list[str] = [name]
 
         # The preprocessor flags to be used. One stores the common flags
         # (without path-specific component), the other the path-specific
@@ -149,24 +149,49 @@ class FabBase:
         label = f"{name}-{self.args.profile}-$compiler"
         return label
 
-    def set_root_symbol(self, root_symbol: Union[list[str], str]) -> None:
+    def set_root_symbols(self, root_symbols: Union[list[str], str]) -> None:
+        '''Defines the root symbol(s), which is set by default to be the
+        name given in the constructor.
+
+        :param root_symbols: the root symbol(s) to use when creating a binary
+            (unused otherwise).
+        '''
+        if isinstance(root_symbols, str):
+            self._root_symbols = [root_symbols]
+        else:
+            self._root_symbols = root_symbols
+
+    def set_root_symbol(self, root_symbols: Union[list[str], str]) -> None:
         '''Defines the root symbol. It defaults to the name given in
         the constructor.
 
-        :param name: the root symbol to use when creating a binary
+        :param root_symbols: the root symbol(s) to use when creating a binary
             (unused otherwise).
         '''
-        if isinstance(root_symbol, str):
-            self._root_symbol = [root_symbol]
-        else:
-            self._root_symbol = root_symbol
+        self.logger.warning("Using deprecated `set_root_symbol`. "
+                            "Use `set_root_symbols` instead.")
+        self.set_root_symbols(root_symbols)
+
+    @property
+    def root_symbols(self) -> list[str]:
+        '''
+        This function returns the list of root symbols. It allows an
+        application to add or remove to the list of root symbols.
+
+        :returns: the list of root symbols.
+        '''
+        return self._root_symbols
 
     @property
     def root_symbol(self) -> list[str]:
         '''
+        This function is deprecated and only provided for backward
+        compatibility. Use `root_symbols` instead.
         :returns: the list of root symbols.
         '''
-        return self._root_symbol
+        self.logger.warning("Using deprecated `root_symbol` property. "
+                            "Use `root_symbols` instead.")
+        return self.root_symbols
 
     @property
     def name(self) -> str:
@@ -680,7 +705,7 @@ class FabBase:
                 analyse(self.config, find_programs=True,
                         ignore_dependencies=ignore_dependencies)
             else:
-                analyse(self.config, root_symbol=self.root_symbol,
+                analyse(self.config, root_symbol=self.root_symbols,
                         ignore_dependencies=ignore_dependencies)
         else:
             analyse(self.config, root_symbol=None,

--- a/source/fab/fab_base/site_specific/default/config.py
+++ b/source/fab/fab_base/site_specific/default/config.py
@@ -10,13 +10,16 @@ from typing import cast
 
 from fab.api import AddFlags, BuildConfig, Category, Compiler, ToolRepository
 
-from fab.fab_base.site_specific.default.setup_cray import setup_cray
-from fab.fab_base.site_specific.default.setup_gnu import setup_gnu
-from fab.fab_base.site_specific.default.setup_intel_classic import (
-    setup_intel_classic)
-from fab.fab_base.site_specific.default.setup_intel_llvm import (
-    setup_intel_llvm)
-from fab.fab_base.site_specific.default.setup_nvidia import setup_nvidia
+from fab.fab_base.site_specific.default.setup_script_cray import (
+    setup_script_cray)
+from fab.fab_base.site_specific.default.setup_script_gnu import (
+    setup_script_gnu)
+from fab.fab_base.site_specific.default.setup_script_intel_classic import (
+    setup_script_intel_classic)
+from fab.fab_base.site_specific.default.setup_script_intel_llvm import (
+    setup_script_intel_llvm)
+from fab.fab_base.site_specific.default.setup_script_nvidia import (
+    setup_script_nvidia)
 
 
 class Config:
@@ -138,7 +141,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["cray"] = setup_cray(build_config, self.args)
+        self._path_flags["cray"] = setup_script_cray(build_config, self.args)
 
     def setup_gnu(self, build_config: BuildConfig) -> None:
         '''
@@ -149,7 +152,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["gnu"] = setup_gnu(build_config, self.args)
+        self._path_flags["gnu"] = setup_script_gnu(build_config, self.args)
 
     def setup_intel_classic(self, build_config: BuildConfig) -> None:
         '''
@@ -160,8 +163,8 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["intel_classic"] = setup_intel_classic(build_config,
-                                                                self.args)
+        self._path_flags["intel_classic"] = \
+            setup_script_intel_classic(build_config, self.args)
 
     def setup_intel_llvm(self, build_config: BuildConfig) -> None:
         '''
@@ -172,8 +175,8 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["intel-llvm"] = setup_intel_llvm(build_config,
-                                                          self.args)
+        self._path_flags["intel-llvm"] = setup_script_intel_llvm(build_config,
+                                                                 self.args)
 
     def setup_nvidia(self, build_config: BuildConfig) -> None:
         '''
@@ -184,4 +187,5 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["nvidia"] = setup_nvidia(build_config, self.args)
+        self._path_flags["nvidia"] = setup_script_nvidia(build_config,
+                                                         self.args)

--- a/source/fab/fab_base/site_specific/default/config.py
+++ b/source/fab/fab_base/site_specific/default/config.py
@@ -1,5 +1,10 @@
 #! /usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
 
 '''
 This module contains the default Baf configuration class.
@@ -63,6 +68,8 @@ class Config:
         a site-specific configuration should inherit from the default, and
         can then overwrite this method to add site-specific options or
         defaults.
+
+        :param args: the command line options added in the site config.
         '''
         # As examples (typically used in a site-specific derived class):
         # Adding a site-specific option to profile with Tau:
@@ -80,8 +87,7 @@ class Config:
         options have been added. This is for example used to add
         Vernier profiling flags, which are site-specific.
 
-        :param argparse.Namespace args: the command line options added in
-            the site configs
+        :param args: the command line options added in the site configs.
         '''
         # Keep a copy of the args, so they can be used when
         # initialising compilers
@@ -94,6 +100,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         # First create the default compiler profiles for all available
         # compilers. While we have a tool box with exactly one compiler
         # in it, compiler wrappers will require more than one compiler
@@ -127,7 +134,10 @@ class Config:
         Returns the path-specific flags to be used.
         TODO #313: Ideally we have only one kind of flag, but as a quick
         work around we provide this method.
+
+        :param build_config: the Fab build configuration instance
         '''
+
         compiler = build_config.tool_box.get_tool(Category.FORTRAN_COMPILER)
         compiler = cast(Compiler, compiler)
         return self._path_flags[compiler.suite].get(build_config.profile, [])
@@ -141,6 +151,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["cray"] = setup_script_cray(build_config, self.args)
 
     def setup_gnu(self, build_config: BuildConfig) -> None:
@@ -152,6 +163,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["gnu"] = setup_script_gnu(build_config, self.args)
 
     def setup_intel_classic(self, build_config: BuildConfig) -> None:
@@ -163,6 +175,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["intel_classic"] = \
             setup_script_intel_classic(build_config, self.args)
 
@@ -175,6 +188,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["intel-llvm"] = setup_script_intel_llvm(build_config,
                                                                  self.args)
 

--- a/source/fab/fab_base/site_specific/default/setup_script_cray.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_cray.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_cray(build_config: BuildConfig,
-               args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_cray(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-branches
     '''
     Defines the default flags for ftn.

--- a/source/fab/fab_base/site_specific/default/setup_script_cray.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_cray.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for the Cray
 compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_gnu.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_gnu.py
@@ -13,8 +13,9 @@ from typing import cast
 from fab.api import AddFlags, BuildConfig, Category, Linker, ToolRepository
 
 
-def setup_gnu(build_config: BuildConfig,
-              args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_gnu(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for all GNU compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_script_gnu.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_gnu.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 GNU based compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 Intel classic based compilers in the ToolRepository (ifort, icc).

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_intel_classic(build_config: BuildConfig,
-                        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_intel_classic(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel classic compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 Intel llvm based compilers and linkers in the ToolRepository (ifx, icx).

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_intel_llvm(build_config: BuildConfig,
-                     args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_intel_llvm(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel llvm compilers.

--- a/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for the NVIDIA
 compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_nvidia(build_config: BuildConfig,
-                 args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_nvidia(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for nvfortran.

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -16,7 +16,7 @@ from fparser.two.Fortran2003 import (  # type: ignore
     Function_Stmt, Language_Binding_Spec, Char_Literal_Constant,
     Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def,
     Derived_Type_Stmt, Type_Attr_Spec_List, Type_Attr_Spec, Type_Name,
-    Subroutine_Subprogram, Function_Subprogram)
+    Subroutine_Subprogram, Function_Subprogram, Internal_Subprogram_Part)
 from fparser.two.utils import walk  # type: ignore
 
 # todo: what else should we be importing from 2008 instead of 2003? This seems fragile.
@@ -406,13 +406,17 @@ class FortranAnalyser(FortranAnalyserBase):
             else:
                 analysed_file.add_symbol_def(bind_name)
 
-        # not bound, just record the presence of the fortran symbol
-        # we don't need to record stuff in modules (we think!)
+        # Not bound, just record the presence of the Fortran symbol.
+        # We don't need to record stuff in modules. Do not record
+        # any functions/subroutine that are part of a module, contained,
+        # or an interface block (since these symbols will not be external
+        # visible, and might otherwise trigger duplicated symbols in Fab)
         elif (not self._find_ancestor(obj, Module) and
+              not self._find_ancestor(obj, Internal_Subprogram_Part) and
               not self._find_ancestor(obj, Interface_Block)):
             if isinstance(obj, Subroutine_Stmt):
                 analysed_file.add_symbol_def(str(obj.get_name()))
-            if isinstance(obj, Function_Stmt):
+            elif isinstance(obj, Function_Stmt):
                 _, name, _, _ = obj.items
                 analysed_file.add_symbol_def(name.string)
 

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -16,7 +16,8 @@ from fparser.two.Fortran2003 import (  # type: ignore
     Function_Stmt, Language_Binding_Spec, Char_Literal_Constant,
     Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def,
     Derived_Type_Stmt, Type_Attr_Spec_List, Type_Attr_Spec, Type_Name,
-    Subroutine_Subprogram, Function_Subprogram, Internal_Subprogram_Part)
+    Subroutine_Subprogram, Function_Subprogram, Internal_Subprogram_Part,
+    External_Stmt)
 from fparser.two.utils import walk  # type: ignore
 
 # todo: what else should we be importing from 2008 instead of 2003? This seems fragile.
@@ -234,7 +235,9 @@ class FortranAnalyser(FortranAnalyserBase):
                 #        Or the new match statement, Python 3.10
                 if obj_type == Use_Stmt:
                     self._process_use_statement(analysed_fortran, obj)  # raises
-
+                elif obj_type == External_Stmt:
+                    for external in obj.items[1].items:
+                        analysed_fortran.add_symbol_dep(external.string)
                 elif obj_type == Call_Stmt:
                     called_name = _typed_child(obj, Name)
                     # called_name will be None for calls like thing%method(),

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -17,12 +17,8 @@ from fparser.two.Fortran2003 import (  # type: ignore
     Interface_Block, Name, Comment, Module, Call_Stmt, Derived_Type_Def,
     Derived_Type_Stmt, Type_Attr_Spec_List, Type_Attr_Spec, Type_Name,
     Subroutine_Subprogram, Function_Subprogram, Internal_Subprogram_Part,
-    External_Stmt)
+    External_Stmt, Type_Declaration_Stmt)
 from fparser.two.utils import walk  # type: ignore
-
-# todo: what else should we be importing from 2008 instead of 2003? This seems fragile.
-from fparser.two.Fortran2008 import (  # type: ignore
-    Type_Declaration_Stmt, Attr_Spec_List)
 
 from fab.build_config import BuildConfig
 from fab.dep_tree import AnalysedDependent
@@ -292,12 +288,8 @@ class FortranAnalyser(FortranAnalyserBase):
                 #       use in C. Variable bindings are bidirectional - does
                 #       this work the other way round, too?
                 #       Make sure we have a test for it.
-                elif obj_type == Type_Declaration_Stmt:
-                    # bound?
-                    specs = _typed_child(obj, Attr_Spec_List)
-                    if specs and _typed_child(specs, Language_Binding_Spec):
-                        self._process_variable_binding(analysed_fortran, obj)
-
+                elif isinstance(obj, Type_Declaration_Stmt):
+                    self._process_type_declaration(analysed_fortran, obj)
                 elif obj_type == Comment:
                     self._process_comment(analysed_fortran, obj)
 
@@ -343,6 +335,28 @@ class FortranAnalyser(FortranAnalyserBase):
         elif use_name.lower() not in self._intrinsic_modules:
             # found a dependency on fortran
             analysed_file.add_module_dep(use_name)
+
+    def _process_type_declaration(self, analysed_fortran, obj):
+        """
+        Handles a type declaration statement. A type declaration symbol
+        implies an outside dependency if:
+        1. there is a bind attribute (dependency to other language)
+        2. external attribute.
+
+        Syntax rule:
+            Type_Declaration_Stmt(        ! obj
+                Intrinsic_Type_Spec       ! obj.items[0]
+                Attr_Spec_List            ! obj.items[1]
+                Entity_Decl_List          ! obj.items[2]
+        """
+        attr_spec_list = obj.items[1].items if obj.items[1] else []
+        for attr in attr_spec_list:
+            if attr.string == "EXTERNAL":
+                for symbol in obj.items[2].items:
+                    analysed_fortran.add_symbol_dep(symbol.string)
+            elif isinstance(attr, Language_Binding_Spec):
+                # Bind attribute
+                self._process_variable_binding(analysed_fortran, obj)
 
     def _process_variable_binding(self, analysed_file,
                                   obj: Type_Declaration_Stmt):

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -277,10 +277,10 @@ class FortranAnalyser(FortranAnalyserBase):
                             analysed_fortran.add_symbol_dep(called_name.string)
 
                 elif obj_type == Program_Stmt:
-                    analysed_fortran.add_program_def(str(obj.get_name()))
+                    analysed_fortran.add_program_def(obj.get_name().string)
 
                 elif obj_type == Module_Stmt:
-                    analysed_fortran.add_module_def(str(obj.get_name()))
+                    analysed_fortran.add_module_def(obj.get_name().string)
 
                 elif obj_type in (Subroutine_Stmt, Function_Stmt):
                     self._process_subroutine_or_function(analysed_fortran,
@@ -386,7 +386,23 @@ class FortranAnalyser(FortranAnalyserBase):
                 # Without .o means a Fortran symbol
                 analysed_file.add_symbol_dep(dep)
 
-    def _process_subroutine_or_function(self, analysed_file, fpath, obj):
+    def _process_subroutine_or_function(
+            self,
+            analysed_file: AnalysedFortran,
+            fpath: Path,
+            obj: Union[Function_Stmt, Subroutine_Stmt]):
+        """
+        Processes a subroutine statement. It handles:
+        - a potential 'bind' attribute (which can change the external symbol
+          used),
+        - declaration of subroutines/functions in modules (which will not be
+          visible as external symbols, any dependencies will be covered by
+          the module symbol)
+        - declarations contained in other subroutines (which will not
+          at all be visible)
+        - declarations in an interface block (which declare an external
+          dependency)
+        """
         # binding?
         bind = _typed_child(obj, Language_Binding_Spec)
         if bind:
@@ -410,18 +426,19 @@ class FortranAnalyser(FortranAnalyserBase):
                 analysed_file.add_symbol_def(bind_name)
 
         # Not bound, just record the presence of the Fortran symbol.
-        # We don't need to record stuff in modules. Do not record
-        # any functions/subroutine that are part of a module, contained,
-        # or an interface block (since these symbols will not be external
-        # visible, and might otherwise trigger duplicated symbols in Fab)
+
+        elif self._find_ancestor(obj, Interface_Block):
+            # If the subroutine/function declaration is inside an interface
+            # block, we have an external dependency:
+            analysed_file.add_symbol_dep(str(obj.get_name()))
+
         elif (not self._find_ancestor(obj, Module) and
-              not self._find_ancestor(obj, Internal_Subprogram_Part) and
-              not self._find_ancestor(obj, Interface_Block)):
-            if isinstance(obj, Subroutine_Stmt):
-                analysed_file.add_symbol_def(str(obj.get_name()))
-            elif isinstance(obj, Function_Stmt):
-                _, name, _, _ = obj.items
-                analysed_file.add_symbol_def(name.string)
+              not self._find_ancestor(obj, Internal_Subprogram_Part)):
+            # We don't need to record stuff in modules, and any functions /
+            # subroutines that contained in a subroutine either (since these
+            # will not be externally visible). But otherwise record the
+            # declaration of the subroutine/function.
+            analysed_file.add_symbol_def(str(obj.get_name()))
 
 
 class FortranParserWorkaround():

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -14,7 +14,7 @@ This gives us a file dependency tree for the entire project source. The data str
 just a dict of *<source path>: <analysed file>*, where the analysed files' dependencies are other dict keys.
 
 If we're building a library, that's the end of the analysis process as we'll compile the entire project source.
-If we're building one or more executables, which happens when we use the `root_symbol` argument,
+If we're building one or more executables, which happens when we use the `root_symbols` argument,
 Fab will extract a subtree from the entire dependency tree for each root symbol we specify.
 
 Finally, the resulting artefact collection is a dict of these subtrees (*"build trees"*),
@@ -65,7 +65,7 @@ DEFAULT_SOURCE_GETTER = CollectionConcat([
 def analyse(
         config,
         source: Optional[ArtefactsGetter] = None,
-        root_symbol: Optional[Union[str, list[str]]] = None,
+        root_symbols: Optional[Union[str, list[str]]] = None,
         find_programs: bool = False,
         std: str = "f2008",
         special_measure_analysis_results: Optional[Iterable[FortranParserWorkaround]] = None,
@@ -83,7 +83,7 @@ def analyse(
     from multiple artefact collections, including the default C and Fortran preprocessor outputs
     and any source files with a 'little' *.f90* extension.
 
-    A build tree is produced for every root symbol specified in *root_symbol*, which can be a string or list of.
+    A build tree is produced for every root symbol specified in *root_symbols*, which can be a string or list of.
     This is how we create executable files. If no root symbol is specified, a single tree of the entire source
     is produced (with a root symbol of `None`). This is how we create shared and static libraries.
 
@@ -94,8 +94,8 @@ def analyse(
         An :class:`~fab.util.ArtefactsGetter` to get the source files.
     :param find_programs:
         Instructs the analyser to automatically identify program definitions in the source.
-        Alternatively, the required programs can be specified with the root_symbol argument.
-    :param root_symbol:
+        Alternatively, the required programs can be specified with the root_symbols argument.
+    :param root_symbols:
         When building an executable, provide the Fortran Program name(s), or 'main' for C.
         If None, build tree extraction will not be performed and the entire source will be used
         as the build tree - for building a shared or static library.
@@ -120,11 +120,13 @@ def analyse(
     # because the files they refer to probably don't exist yet,
     # because we're just creating steps at this point, so there's been no grab...
 
-    if find_programs and root_symbol:
-        raise ValueError("find_programs and root_symbol can't be used together")
+    if find_programs and root_symbols:
+        raise ValueError("find_programs and root_symbols can't be used together")
 
     source_getter = source or DEFAULT_SOURCE_GETTER
-    root_symbols: Optional[list[str]] = [root_symbol] if isinstance(root_symbol, str) else root_symbol
+    if isinstance(root_symbols, str):
+        root_symbols = [root_symbols]
+
     special_measure_analysis_results = list(special_measure_analysis_results or [])
     unreferenced_deps = list(unreferenced_deps or [])
 

--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -26,6 +26,7 @@ class Category(Enum):
     AR = auto()
     RSYNC = auto()
     SHELL = auto()
+    PFUNIT = auto()
     MISC = auto()
 
     def __str__(self):

--- a/source/fab/tools/pfunit.py
+++ b/source/fab/tools/pfunit.py
@@ -1,0 +1,71 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+
+"""This file contains the Rsync class for synchronising file trees.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from fab.tools.tool import Tool
+from fab.tools.category import Category
+
+
+logger = logging.getLogger(__name__)
+
+
+class PfUnit(Tool):
+    """
+    This is a class to encapsulate pFUnit. It relies on the environment
+    variable $PFUNIT to indicate the location of the source code.
+    This is required since besides .mod files and executable, it also
+    contains the source code for a Fortran driver program .
+    It assumes that pFUnit's preprocessor `funitproc` is in $PFUNIT/bin.
+    """
+
+    def __init__(self):
+        pfunit_home = os.environ.get("PFUNIT", "")
+        if not pfunit_home:
+            logger.error("$PFUNIT not defined in environment, pFUnit will "
+                         "likely not work.")
+        self._pfunit_home = Path(pfunit_home)
+
+        exec_name = self._pfunit_home / "bin" / "funitproc"
+        super().__init__("funitproc", exec_name=exec_name,
+                         category=Category.PFUNIT,
+                         availability_option="-v")
+
+    def get_root_path(self) -> Path:
+        """
+        :returns: the root path of pFUnit.
+        """
+        return self._pfunit_home
+
+    def get_include_path(self) -> Path:
+        """
+        :returns: the include directory for PFUnit.
+        """
+        return self._pfunit_home / "include"
+
+    def get_driver_f90(self) -> str:
+        """
+        :returns: the content of pFUnit's driver.F90 file.
+        """
+        driver_path = self._pfunit_home / "include" / "driver.F90"
+        with driver_path.open("r", encoding='utf-8') as f:
+            driver_f90 = f.read()
+        return driver_f90
+
+    def process(self, pf_path: Path,
+                f90_out_path: Path):
+        """
+        Processes the .pf file to create an output f90 file.
+
+        :param pf_path: the input path.
+        :param f90_out_path: destination path.
+        """
+        return self.run(additional_parameters=[pf_path, f90_out_path])

--- a/source/fab/tools/tool_repository.py
+++ b/source/fab/tools/tool_repository.py
@@ -26,6 +26,7 @@ from fab.tools.ar import Ar
 from fab.tools.preprocessor import Cpp, CppFortran
 from fab.tools.compiler import (Craycc, Crayftn, Gcc, Gfortran, Icc, Icx,
                                 Ifort, Ifx, Nvc, Nvfortran)
+from fab.tools.pfunit import PfUnit
 from fab.tools.psyclone import Psyclone
 from fab.tools.rsync import Rsync
 from fab.tools.shell import Shell
@@ -74,7 +75,7 @@ class ToolRepository(dict):
                     Icc, Icx, Ifort, Ifx,
                     Nvc, Nvfortran,
                     Cpp, CppFortran,
-                    Ar, Fcm, Git, Psyclone, Rsync, Subversion]:
+                    Ar, Fcm, Git, PfUnit, Psyclone, Rsync, Subversion]:
             self.add_tool(cls())
 
         # Add a standard shell. Additional shells (bash, ksh, dash)

--- a/tests/system_tests/CFortranInterop/test_CFortranInterop.py
+++ b/tests/system_tests/CFortranInterop/test_CFortranInterop.py
@@ -35,7 +35,7 @@ def test_CFortranInterop(tmp_path):
         c_pragma_injector(config)
         preprocess_c(config)
         preprocess_fortran(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         with warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])

--- a/tests/system_tests/CUserHeader/test_CUserHeader.py
+++ b/tests/system_tests/CUserHeader/test_CUserHeader.py
@@ -34,7 +34,7 @@ def test_CUseHeader(tmp_path):
         find_source_files(config)
         c_pragma_injector(config)
         preprocess_c(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         link_exe(config, flags=['-lgfortran'])
 

--- a/tests/system_tests/FortranDependencies/test_FortranDependencies.py
+++ b/tests/system_tests/FortranDependencies/test_FortranDependencies.py
@@ -29,7 +29,7 @@ def test_fortran_dependencies(tmp_path):
         grab_folder(config, src=Path(__file__).parent / 'project-source')
         find_source_files(config)
         preprocess_fortran(config)  # nothing to preprocess, actually, it's all little f90 files
-        analyse(config, root_symbol=['first', 'second'])
+        analyse(config, root_symbols=['first', 'second'])
         compile_c(config, common_flags=['-c', '-std=c99'])
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])

--- a/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
+++ b/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
@@ -26,7 +26,7 @@ def build(fab_workspace, fpp_flags=None):
         grab_folder(config, Path(__file__).parent / 'project-source')
         find_source_files(config)
         preprocess_fortran(config, common_flags=fpp_flags)
-        analyse(config, root_symbol=['stay_or_go_now'])
+        analyse(config, root_symbols=['stay_or_go_now'])
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])
         link_exe(config, flags=['-lgfortran'])

--- a/tests/system_tests/MinimalC/test_MinimalC.py
+++ b/tests/system_tests/MinimalC/test_MinimalC.py
@@ -34,7 +34,7 @@ def test_minimal_c(tmp_path):
         find_source_files(config)
         c_pragma_injector(config)
         preprocess_c(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         link_exe(config)
 

--- a/tests/system_tests/MinimalFortran/test_MinimalFortran.py
+++ b/tests/system_tests/MinimalFortran/test_MinimalFortran.py
@@ -29,7 +29,7 @@ def test_minimal_fortran(tmp_path):
         grab_folder(config, PROJECT_SOURCE)
         find_source_files(config)
         preprocess_fortran(config)
-        analyse(config, root_symbol='test')
+        analyse(config, root_symbols='test')
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])
         link_exe(config, flags=['-lgfortran'])

--- a/tests/system_tests/incremental_fortran/test_incremental_fortran.py
+++ b/tests/system_tests/incremental_fortran/test_incremental_fortran.py
@@ -56,7 +56,7 @@ class TestIncremental:
     def run_steps(self, build_config):
         find_source_files(build_config)
         preprocess_fortran(build_config)
-        analyse(build_config, root_symbol='my_prog')
+        analyse(build_config, root_symbols='my_prog')
         compile_fortran(build_config)
         link_exe(build_config, flags=['-lgfortran'])
         # Add a permissive cleanup step because we want to know about every file which is created,

--- a/tests/system_tests/prebuild/test_prebuild.py
+++ b/tests/system_tests/prebuild/test_prebuild.py
@@ -33,7 +33,7 @@ class TestFortranPrebuild(object):
                 grab_pre_build(config, grab_prebuild_folder)
             find_source_files(config)
             preprocess_fortran(config)
-            analyse(config, root_symbol='my_prog')
+            analyse(config, root_symbols='my_prog')
             compile_fortran(config)
             link_exe(config, flags=['-lgfortran'])
 

--- a/tests/unit_tests/fab_base/site_specific/default/config.py
+++ b/tests/unit_tests/fab_base/site_specific/default/config.py
@@ -2,7 +2,7 @@
 
 
 '''
-This module contains the default Baf configuration class.
+This module contains the default Fab configuration class.
 '''
 
 import argparse
@@ -14,7 +14,7 @@ from fab.tools.tool_repository import ToolRepository
 
 class Config:
     '''
-    This class is the default Configuration object for Baf builds.
+    This class is the default Configuration object for Fab builds.
     It provides several callbacks which will be called from the build
     scripts to allow site-specific customisations.
     '''

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -473,7 +473,7 @@ def test_build_static_lib(monkeypatch) -> None:
 
     mocks["analyse"][0].stop()
     mocks["analyse"][1].assert_called_once_with(
-        fab_base.config, root_symbol=None, ignore_dependencies=None)
+        fab_base.config, root_symbols=None, ignore_dependencies=None)
 
     mocks["archive_objects"][0].stop()
     mocks["archive_objects"][1].assert_called_once_with(
@@ -525,7 +525,7 @@ def test_build_shared_lib(monkeypatch) -> None:
 
     mocks["analyse"][0].stop()
     mocks["analyse"][1].assert_called_once_with(
-        fab_base.config, root_symbol=None, ignore_dependencies=None)
+        fab_base.config, root_symbols=None, ignore_dependencies=None)
 
     mocks["link_shared_object"][0].stop()
     mocks["link_shared_object"][1].assert_called_once_with(

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -141,11 +141,11 @@ def test_root_symbol(monkeypatch) -> None:
     fab_base = FabBase(name="test-help")
 
     # Set a single root symbol
-    fab_base.set_root_symbol("root1")
-    assert fab_base.root_symbol == ["root1"]
+    fab_base.set_root_symbols("root1")
+    assert fab_base.root_symbols == ["root1"]
 
-    fab_base.set_root_symbol(["root1", "root2"])
-    assert fab_base.root_symbol == ["root1", "root2"]
+    fab_base.set_root_symbols(["root1", "root2"])
+    assert fab_base.root_symbols == ["root1", "root2"]
 
 
 def test_profile_default(monkeypatch) -> None:

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -21,6 +21,9 @@ from fab.fab_base.fab_base import FabBase
 from fab.tools.category import Category
 from fab.tools.tool_repository import ToolRepository
 
+# Mypy does not handle the relative import here properly, ignore error:
+from site_specific.default.config import Config as SiteConfig   # type: ignore
+
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_tool_repository(stub_fortran_compiler, stub_c_compiler,
@@ -73,6 +76,8 @@ def test_constructor(monkeypatch) -> None:
 
     monkeypatch.setattr(sys, "argv", ["fab_base.py"])
     fab_base = FabBase(name="test_name", link_target="executable")
+
+    assert fab_base.name == "test_name"
 
     # Check other settings and functions
     # pylint: disable=use-implicit-booleaness-not-comparison
@@ -335,6 +340,8 @@ def test_site_specific_callbacks(monkeypatch):
         tfb = TestFabBase(name="test-help")
         mock_handle.assert_called_once_with(tfb.args)
         mock_define.assert_called_once_with(tfb.parser)
+        # Check that the property returns the right object
+        assert isinstance(tfb.site_config, SiteConfig)
 
 
 def test_site_specific_outside_dir(monkeypatch) -> None:

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine.py
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine.py
@@ -49,7 +49,7 @@ def test_contained_subroutine(tmp_path):
                      multiprocessing=False) as config:
         grab_folder(config, PROJECT_SOURCE)
         find_source_files(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         build_tree = config.artefact_store[ArtefactSet.BUILD_TREES]["main"]
 
         source_path = tmp_path / "contained_subroutine" / "source"

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine.py
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine.py
@@ -52,15 +52,16 @@ def test_contained_subroutine(tmp_path):
         analyse(config, root_symbol='main')
         build_tree = config.artefact_store[ArtefactSet.BUILD_TREES]["main"]
 
-        af_mod_with_contain = None
-        for file_name in build_tree:
-            if "mod_with_contain" in str(file_name):
-                af_mod_with_contain = build_tree[file_name]
-                break
+        source_path = tmp_path / "contained_subroutine" / "source"
 
+        af_mod_with_contain = build_tree[source_path / "mod_with_contain.f90"]
         # The module should not contain any dependencies, the dependency to
         # `contained` is resolved from the subroutine it contains.
         assert af_mod_with_contain.symbol_deps == set()
+
+        # The contained subroutine in main should not be exported
+        af_main = build_tree[source_path / "main.f90"]
+        assert af_main.symbol_defs == set(["main"])
 
         # Just in case, also compile and link
         compile_fortran(config)

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine/main.f90
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine/main.f90
@@ -1,3 +1,7 @@
 program main
     use mod_with_contain, only: my_sub
+
+contains
+    subroutine should_not_be_exported
+    end subroutine should_not_be_exported
 end program main

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
@@ -14,6 +14,7 @@ CONTAINS
 
     SUBROUTINE internal_sub
         ! DEPENDS ON: monty_func
+        external some_external_symbol
         RETURN
     END SUBROUTINE internal_sub
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
@@ -15,6 +15,7 @@ CONTAINS
     SUBROUTINE internal_sub
         ! DEPENDS ON: monty_func
         external some_external_symbol
+        integer, external :: some_external_as_attribute
         INTERFACE
             SUBROUTINE sub_in_interface
             END SUBROUTINE sub_in_interface

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.f90
@@ -15,6 +15,10 @@ CONTAINS
     SUBROUTINE internal_sub
         ! DEPENDS ON: monty_func
         external some_external_symbol
+        INTERFACE
+            SUBROUTINE sub_in_interface
+            END SUBROUTINE sub_in_interface
+        END INTERFACE
         RETURN
     END SUBROUTINE internal_sub
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 from fparser.common.readfortran import FortranStringReader  # type: ignore
-from fparser.two.Fortran2008 import Type_Declaration_Stmt  # type: ignore
+from fparser.two.Fortran2003 import Type_Declaration_Stmt  # type: ignore
 from fparser.two.parser import ParserFactory  # type: ignore
 from fparser.two.utils import walk  # type: ignore
 import pytest

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -37,12 +37,12 @@ def module_expected_fixture(module_fpath: Path) -> AnalysedFortran:
     test module.'''
     return AnalysedFortran(
         fpath=module_fpath,
-        file_hash=1015362680,
+        file_hash=2985613950,
         module_defs={'foo_mod'},
         symbol_defs={'external_sub', 'external_func', 'foo_mod'},
         module_deps={'bar_mod', 'compute_chunk_size_mod'},
         symbol_deps={'monty_func', 'bar_mod', 'compute_chunk_size_mod',
-                     'some_external_symbol'},
+                     'some_external_symbol', 'sub_in_interface'},
         file_deps=set(),
         mo_commented_file_deps={'some_file.o'},
     )
@@ -157,7 +157,7 @@ class TestAnalyser:
                     fpath=Path(tmp_file.name))
 
             module_expected.fpath = Path(tmp_file.name)
-            module_expected._file_hash = 3277624132
+            module_expected._file_hash = 3599767944
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -146,9 +146,6 @@ class TestAnalyser:
             module_expected._file_hash = 325155675
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
-            module_expected.symbol_defs.update({'internal_func',
-                                                'internal_sub',
-                                                'openmp_sentinel'})
 
             assert analysis == module_expected
             assert isinstance(analysis, AnalysedFortran)

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -37,12 +37,13 @@ def module_expected_fixture(module_fpath: Path) -> AnalysedFortran:
     test module.'''
     return AnalysedFortran(
         fpath=module_fpath,
-        file_hash=2985613950,
+        file_hash=3447500859,
         module_defs={'foo_mod'},
         symbol_defs={'external_sub', 'external_func', 'foo_mod'},
         module_deps={'bar_mod', 'compute_chunk_size_mod'},
         symbol_deps={'monty_func', 'bar_mod', 'compute_chunk_size_mod',
-                     'some_external_symbol', 'sub_in_interface'},
+                     'some_external_symbol', 'some_external_as_attribute',
+                     'sub_in_interface'},
         file_deps=set(),
         mo_commented_file_deps={'some_file.o'},
     )
@@ -157,7 +158,7 @@ class TestAnalyser:
                     fpath=Path(tmp_file.name))
 
             module_expected.fpath = Path(tmp_file.name)
-            module_expected._file_hash = 3599767944
+            module_expected._file_hash = 975186955
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -37,11 +37,12 @@ def module_expected_fixture(module_fpath: Path) -> AnalysedFortran:
     test module.'''
     return AnalysedFortran(
         fpath=module_fpath,
-        file_hash=3737289404,
+        file_hash=1015362680,
         module_defs={'foo_mod'},
         symbol_defs={'external_sub', 'external_func', 'foo_mod'},
         module_deps={'bar_mod', 'compute_chunk_size_mod'},
-        symbol_deps={'monty_func', 'bar_mod', 'compute_chunk_size_mod'},
+        symbol_deps={'monty_func', 'bar_mod', 'compute_chunk_size_mod',
+                     'some_external_symbol'},
         file_deps=set(),
         mo_commented_file_deps={'some_file.o'},
     )
@@ -156,7 +157,7 @@ class TestAnalyser:
                     fpath=Path(tmp_file.name))
 
             module_expected.fpath = Path(tmp_file.name)
-            module_expected._file_hash = 325155675
+            module_expected._file_hash = 3277624132
             module_expected.program_defs = {'foo_mod'}
             module_expected.module_defs = set()
 

--- a/tests/unit_tests/parse/fortran/test_fortran_analyser.py
+++ b/tests/unit_tests/parse/fortran/test_fortran_analyser.py
@@ -11,7 +11,7 @@
 from pathlib import Path
 from unittest import mock
 
-from fparser.common.readfortran import FortranFileReader  # type: ignore
+from fparser.common.readfortran import FortranStringReader  # type: ignore
 from fparser.two.Fortran2008 import Type_Declaration_Stmt  # type: ignore
 from fparser.two.parser import ParserFactory  # type: ignore
 from fparser.two.utils import walk  # type: ignore
@@ -21,19 +21,18 @@ from fab.build_config import BuildConfig
 from fab.parse import EmptySourceFile
 from fab.parse.fortran import FortranAnalyser, AnalysedFortran
 from fab.tools.tool_box import ToolBox
-from fab.tools.tool_repository import ToolRepository
 
 # todo: test function binding
 
 
-@pytest.fixture
-def module_fpath() -> Path:
+@pytest.fixture(name="module_fpath")
+def module_fpath_fixture() -> Path:
     '''Simple fixture that sets the name of the module test file.'''
     return Path(__file__).parent / "test_fortran_analyser.f90"
 
 
-@pytest.fixture
-def module_expected(module_fpath: Path) -> AnalysedFortran:
+@pytest.fixture(name="module_expected")
+def module_expected_fixture(module_fpath: Path) -> AnalysedFortran:
     '''Returns the expected AnalysedFortran instance for the Fortran
     test module.'''
     return AnalysedFortran(
@@ -49,12 +48,17 @@ def module_expected(module_fpath: Path) -> AnalysedFortran:
 
 
 class TestAnalyser:
+    """
+    Tests the Fortran analyser in various combinations.
+    """
 
     @pytest.fixture
     def fortran_analyser(
              self,
-             tmp_path: Path,
-             stub_tool_repository: ToolRepository) -> FortranAnalyser:
+             tmp_path: Path) -> FortranAnalyser:
+        """
+        A simple fixture that enables OpenMP and runs the analyser
+        """
         # Enable openmp, so fparser will handle the lines with omp sentinels
         config = BuildConfig('proj', ToolBox(),
                              fab_workspace=tmp_path, openmp=True)
@@ -62,7 +66,9 @@ class TestAnalyser:
         return fortran_analyser
 
     def test_empty_file(self, fortran_analyser: FortranAnalyser) -> None:
-        # make sure we get back an EmptySourceFile
+        """
+        Make sure we get back an EmptySourceFile if an empty file is given.
+        """
         with mock.patch('fab.parse.AnalysedFile.save'):
             analysis, artefact = fortran_analyser.run(
                 fpath=Path(Path(__file__).parent / "empty.f90"))
@@ -71,6 +77,10 @@ class TestAnalyser:
 
     def test_module_file(self, fortran_analyser, module_fpath,
                          module_expected):
+        """
+        Tests handling of module statement, including making sure that
+        subroutines in a module are not exported as external symbols.
+        """
         with mock.patch('fab.parse.AnalysedFile.save'):
             analysis, artefact = fortran_analyser.run(fpath=module_fpath)
         assert analysis == module_expected
@@ -132,7 +142,10 @@ class TestAnalyser:
                           fortran_analyser: FortranAnalyser,
                           module_fpath: Path,
                           module_expected: AnalysedFortran) -> None:
-        # same as test_module_file() but replacing MODULE with PROGRAM
+        """
+        Test the handling of a Program. This test replaces 'MODULE'
+        in the standard test here with 'PROGRAM'.
+        """
         prog_path = tmp_path / "prog.f90"
         with prog_path.open('w') as tmp_file:
             tmp_file.write(module_fpath.open().read().replace("MODULE",
@@ -161,12 +174,11 @@ class TestProcessVariableBinding:
 
     # todo: define and depend, with and without bind name
 
-    def test_define_without_bind_name(self, tmp_path: Path,
+    def test_define_without_bind_name(self,
                                       stub_configuration: BuildConfig) -> None:
         '''Test usage of bind'''
-        fpath = tmp_path / 'temp.f90'
 
-        open(fpath, 'wt').write("""
+        code = """
             MODULE f_var
 
             USE, INTRINSIC :: ISO_C_BINDING
@@ -179,10 +191,10 @@ class TestProcessVariableBinding:
                 helloworld=['H','e','L','l','O',' ','w','O','r','L','d','?']
 
             END MODULE f_var
-        """)
+        """
 
         # parse
-        reader = FortranFileReader(str(fpath), ignore_comments=False)
+        reader = FortranStringReader(code, ignore_comments=False)
         f2008_parser = ParserFactory().create(std="f2008")
         tree = f2008_parser(reader)
 

--- a/tests/unit_tests/tools/test_pfunit.py
+++ b/tests/unit_tests/tools/test_pfunit.py
@@ -1,0 +1,135 @@
+##############################################################################
+# (c) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT
+# which you should have received as part of this distribution
+##############################################################################
+"""
+Tests 'pfunit' tool.
+"""
+
+import logging
+from pathlib import Path
+
+from pytest_subprocess.fake_process import FakeProcess
+
+
+from fab.tools.category import Category
+from fab.tools.pfunit import PfUnit
+
+from tests.conftest import ExtendedRecorder, call_list
+
+
+def test_pfunit_constructor_no_env(monkeypatch, caplog) -> None:
+    """
+    Tests constructor when $PFUNIT is not defined
+    """
+    # Make sure the environment variable PFUNIT is not defined:
+    monkeypatch.delenv("PFUNIT", raising=False)
+
+    with caplog.at_level(logging.ERROR):
+        pfunit = PfUnit()
+    assert ("$PFUNIT not defined in environment, pFUnit will likely "
+            "not work." in caplog.text)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"
+
+    assert pfunit.category == Category.PFUNIT
+    assert pfunit.name == "funitproc"
+    assert pfunit.exec_name == "funitproc"
+    assert pfunit.get_flags() == []
+
+
+def test_pfunit_constructor_with_env(monkeypatch, caplog) -> None:
+    """
+    Tests constructor when $PFUNIT is defined
+    """
+
+    # Make sure the environment variable PFUNIT is defined:
+    monkeypatch.setenv("PFUNIT", "/tmp")
+
+    with caplog.at_level(logging.ERROR):
+        pfunit = PfUnit()
+    assert len(caplog.records) == 0
+    assert pfunit.category == Category.PFUNIT
+    assert pfunit.name == "funitproc"
+    assert pfunit.exec_name == "funitproc"
+    assert pfunit.get_flags() == []
+    assert pfunit.get_root_path() == Path("/tmp")
+
+
+def test_pfunit_paths(monkeypatch) -> None:
+    """
+    Tests root and include paths.
+    """
+
+    # Make sure the environment variable PFUNIT is defined:
+    monkeypatch.setenv("PFUNIT", "/tmp")
+
+    pfunit = PfUnit()
+    assert pfunit.get_root_path() == Path("/tmp")
+    assert pfunit.get_include_path() == Path("/tmp/include")
+
+
+def test_pfunit_driver(monkeypatch, tmp_path: Path) -> None:
+    """
+    Tests that pfunit reads the driver.F90 file:
+    """
+
+    # Make sure the environment variable PFUNIT is defined:
+    monkeypatch.setenv("PFUNIT", str(tmp_path))
+    include_path = tmp_path / "include"
+    include_path.mkdir()
+    (include_path / "driver.F90").write_text("DRIVER\n")
+
+    pfunit = PfUnit()
+    assert pfunit.get_driver_f90() == "DRIVER\n"
+
+
+def test_pfunit_check_available(monkeypatch,
+                                subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests availability functionality.
+    """
+    monkeypatch.setenv("PFUNIT", "/tmp")
+    pfunit = PfUnit()
+    assert pfunit.check_available()
+    assert subproc_record.invocations() == [["/tmp/bin/funitproc", "-v"]]
+    assert subproc_record.extras() == [{'cwd': None,
+                                        'env': None,
+                                        'stdout': None,
+                                        'stderr': None}]
+
+
+def test_pfunit_check_unavailable(monkeypatch,
+                                  fake_process: FakeProcess) -> None:
+    """
+    Tests availability failure.
+    """
+    monkeypatch.setenv("PFUNIT", "/tmp")
+    fake_process.register(['/tmp/bin/funitproc', '-v'],
+                          returncode=1,
+                          stderr="Something went wrong.")
+    pfunit = PfUnit()
+    assert not pfunit.check_available()
+    assert call_list(fake_process) == [["/tmp/bin/funitproc", "-v"]]
+
+
+def test_pfunit_process(monkeypatch,
+                        tmp_path: Path,
+                        subproc_record: ExtendedRecorder) -> None:
+    """
+    Tests processing a file
+    """
+    monkeypatch.setenv("PFUNIT", str(tmp_path))
+    pfunit = PfUnit()
+    pfunit.process(pf_path=tmp_path / "file.pf",
+                   f90_out_path=tmp_path / "file.f90")
+
+    assert subproc_record.invocations() \
+           == [[str(tmp_path / "bin" / "funitproc"),
+                str(tmp_path / "file.pf"),
+                str(tmp_path / "file.f90")]]
+    assert subproc_record.extras() == [{'cwd': None,
+                                        'env': None,
+                                        'stderr': None,
+                                        'stdout': None}]


### PR DESCRIPTION
This adds changes and improvements done, based on the code review for lfric_core and UM (plus pfunit for lfric core).

It's mostly a collection of small changes, but I've renamed `root_symbol` to `root_symbols`, since this has always been a list, and is frequently used this way (e.g. um builds um and recon; socrates has over 50 binaries, ...). I left the old names in place with a deprecation warning for now.