### PR TITLE
544 include LFRic_core and UM updates

### DIFF
--- a/Documentation/source/advanced_config.rst
+++ b/Documentation/source/advanced_config.rst
@@ -598,7 +598,7 @@ symbol and add it, *and all its dependencies*, to every :term:`Build Tree`.
     :linenos:
 
     ...
-    analyse(state, root_symbol='my_prog', unreferenced_deps=['my_func'])
+    analyse(state, root_symbols='my_prog', unreferenced_deps=['my_func'])
     ...
 
 Unparsable Files
@@ -623,7 +623,7 @@ definitions and dependencies found in one source file.
     ...
     analyse(
         config,
-        root_symbol='my_prog',
+        root_symbols='my_prog',
         special_measure_analysis_results=[
             FortranParserWorkaround(
                 fpath=Path(state.build_output / "path/to/file.f90"),

--- a/Documentation/source/fab_base/processing.rst
+++ b/Documentation/source/fab_base/processing.rst
@@ -11,7 +11,7 @@ The full class documentation is at the end of this chapter.
 The constructor sets up ultimately the Fab ``BuildConfig`` for the build.
 It takes the name of the application as argument. The name of the application
 will be used when creating the name of the build directory
-and it is also the default ``root_symbol`` when analysing the source code
+and it is also the default ``root_symbols`` when analysing the source code
 if the script creates an executable (see :ref:`analyse_step`).
 
 The actual build is then started calling the ``build`` method
@@ -403,7 +403,7 @@ There is usually no reason for an application to overwrite this step.
 
 In case of creating a binary, the analyse step will use the root symbol,
 which defaults to the name of the application, but can be changed
-using ``set_root_symbol``. This implies that ``set_root_symbol``
+using ``set_root_symbols``. This implies that ``set_root_symbols``
 must be called before ``analyse_step`` is called, e.g. it can be called
 from any method called from the constructor (including defining and
 handling command line options).

--- a/Documentation/source/writing_config.rst
+++ b/Documentation/source/writing_config.rst
@@ -207,7 +207,7 @@ The Analyse step looks for source to analyse in two collections:
             preprocess_fortran(state)
             preprocess_x90(state)
             psyclone(state)
-            analyse(state, root_symbol='<program>')
+            analyse(state, root_symbols='<program>')
 
 
 Here we tell the analyser which :term:`Root Symbol` we want to build into an executable.
@@ -245,7 +245,7 @@ then creates the executable.
             preprocess_fortran(state)
             preprocess_x90(state)
             psyclone(state)
-            analyse(state, root_symbol='<program>')
+            analyse(state, root_symbols='<program>')
             compile_fortran(state)
             link_exe(state)
 

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -32,6 +32,7 @@ from fab.steps.preprocess import preprocess_c, preprocess_fortran
 from fab.tools.category import Category
 from fab.tools.tool_box import ToolBox
 from fab.tools.tool_repository import ToolRepository
+from fab.fab_base.site_specific.default.config import Config as SiteConfig
 
 
 class FabBase:
@@ -168,12 +169,28 @@ class FabBase:
         return self._root_symbol
 
     @property
+    def name(self) -> str:
+
+        '''
+        :returns: the name of the apps.
+        '''
+        return self._name
+
+    @property
     def site(self) -> Optional[str]:
 
         '''
         :returns: the site, or None if no site is specified.
         '''
         return self._site
+
+    @property
+    def site_config(self) -> Optional[SiteConfig]:
+        """
+        :returns: the site configuration to use (or None if
+            no site config is used).
+        """
+        return self._site_config
 
     @property
     def logger(self) -> logging.Logger:
@@ -728,11 +745,11 @@ class FabBase:
         build config.
         """
         if self._link_target == "static-library":
-            out_path = self.config.project_workspace / f"lib{self._name}.a"
+            out_path = self.config.project_workspace / f"lib{self.name}.a"
             archive_objects(self.config,
                             output_fpath=str(out_path))
         elif self._link_target == "shared-library":
-            out_path = self.config.project_workspace / f"lib{self._name}.so"
+            out_path = self.config.project_workspace / f"lib{self.name}.so"
             link_shared_object(self.config,
                                output_fpath=str(out_path),
                                flags=self.linker_flags_commandline)

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -705,10 +705,10 @@ class FabBase:
                 analyse(self.config, find_programs=True,
                         ignore_dependencies=ignore_dependencies)
             else:
-                analyse(self.config, root_symbol=self.root_symbols,
+                analyse(self.config, root_symbols=self.root_symbols,
                         ignore_dependencies=ignore_dependencies)
         else:
-            analyse(self.config, root_symbol=None,
+            analyse(self.config, root_symbols=None,
                     ignore_dependencies=ignore_dependencies)
 
     def compile_c_step(

--- a/source/fab/fab_base/fab_base.py
+++ b/source/fab/fab_base/fab_base.py
@@ -62,7 +62,7 @@ class FabBase:
         self._target = ""
         # Set the given name as root symbol, it can be set explicitly
         # using set_root_symbol()
-        self._root_symbol: list[str] = [name]
+        self._root_symbols: list[str] = [name]
 
         # The preprocessor flags to be used. One stores the common flags
         # (without path-specific component), the other the path-specific
@@ -149,24 +149,49 @@ class FabBase:
         label = f"{name}-{self.args.profile}-$compiler"
         return label
 
-    def set_root_symbol(self, root_symbol: Union[list[str], str]) -> None:
+    def set_root_symbols(self, root_symbols: Union[list[str], str]) -> None:
+        '''Defines the root symbol(s), which is set by default to be the
+        name given in the constructor.
+
+        :param root_symbols: the root symbol(s) to use when creating a binary
+            (unused otherwise).
+        '''
+        if isinstance(root_symbols, str):
+            self._root_symbols = [root_symbols]
+        else:
+            self._root_symbols = root_symbols
+
+    def set_root_symbol(self, root_symbols: Union[list[str], str]) -> None:
         '''Defines the root symbol. It defaults to the name given in
         the constructor.
 
-        :param name: the root symbol to use when creating a binary
+        :param root_symbols: the root symbol(s) to use when creating a binary
             (unused otherwise).
         '''
-        if isinstance(root_symbol, str):
-            self._root_symbol = [root_symbol]
-        else:
-            self._root_symbol = root_symbol
+        self.logger.warning("Using deprecated `set_root_symbol`. "
+                            "Use `set_root_symbols` instead.")
+        self.set_root_symbols(root_symbols)
+
+    @property
+    def root_symbols(self) -> list[str]:
+        '''
+        This function returns the list of root symbols. It allows an
+        application to add or remove to the list of root symbols.
+
+        :returns: the list of root symbols.
+        '''
+        return self._root_symbols
 
     @property
     def root_symbol(self) -> list[str]:
         '''
+        This function is deprecated and only provided for backward
+        compatibility. Use `root_symbols` instead.
         :returns: the list of root symbols.
         '''
-        return self._root_symbol
+        self.logger.warning("Using deprecated `root_symbol` property. "
+                            "Use `root_symbols` instead.")
+        return self.root_symbols
 
     @property
     def name(self) -> str:
@@ -680,7 +705,7 @@ class FabBase:
                 analyse(self.config, find_programs=True,
                         ignore_dependencies=ignore_dependencies)
             else:
-                analyse(self.config, root_symbol=self.root_symbol,
+                analyse(self.config, root_symbol=self.root_symbols,
                         ignore_dependencies=ignore_dependencies)
         else:
             analyse(self.config, root_symbol=None,

--- a/source/fab/fab_base/site_specific/default/config.py
+++ b/source/fab/fab_base/site_specific/default/config.py
@@ -10,13 +10,16 @@ from typing import cast
 
 from fab.api import AddFlags, BuildConfig, Category, Compiler, ToolRepository
 
-from fab.fab_base.site_specific.default.setup_cray import setup_cray
-from fab.fab_base.site_specific.default.setup_gnu import setup_gnu
-from fab.fab_base.site_specific.default.setup_intel_classic import (
-    setup_intel_classic)
-from fab.fab_base.site_specific.default.setup_intel_llvm import (
-    setup_intel_llvm)
-from fab.fab_base.site_specific.default.setup_nvidia import setup_nvidia
+from fab.fab_base.site_specific.default.setup_script_cray import (
+    setup_script_cray)
+from fab.fab_base.site_specific.default.setup_script_gnu import (
+    setup_script_gnu)
+from fab.fab_base.site_specific.default.setup_script_intel_classic import (
+    setup_script_intel_classic)
+from fab.fab_base.site_specific.default.setup_script_intel_llvm import (
+    setup_script_intel_llvm)
+from fab.fab_base.site_specific.default.setup_script_nvidia import (
+    setup_script_nvidia)
 
 
 class Config:
@@ -138,7 +141,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["cray"] = setup_cray(build_config, self.args)
+        self._path_flags["cray"] = setup_script_cray(build_config, self.args)
 
     def setup_gnu(self, build_config: BuildConfig) -> None:
         '''
@@ -149,7 +152,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["gnu"] = setup_gnu(build_config, self.args)
+        self._path_flags["gnu"] = setup_script_gnu(build_config, self.args)
 
     def setup_intel_classic(self, build_config: BuildConfig) -> None:
         '''
@@ -160,8 +163,8 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["intel_classic"] = setup_intel_classic(build_config,
-                                                                self.args)
+        self._path_flags["intel_classic"] = \
+            setup_script_intel_classic(build_config, self.args)
 
     def setup_intel_llvm(self, build_config: BuildConfig) -> None:
         '''
@@ -172,8 +175,8 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["intel-llvm"] = setup_intel_llvm(build_config,
-                                                          self.args)
+        self._path_flags["intel-llvm"] = setup_script_intel_llvm(build_config,
+                                                                 self.args)
 
     def setup_nvidia(self, build_config: BuildConfig) -> None:
         '''
@@ -184,4 +187,5 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
-        self._path_flags["nvidia"] = setup_nvidia(build_config, self.args)
+        self._path_flags["nvidia"] = setup_script_nvidia(build_config,
+                                                         self.args)

--- a/source/fab/fab_base/site_specific/default/config.py
+++ b/source/fab/fab_base/site_specific/default/config.py
@@ -1,5 +1,10 @@
 #! /usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
 
 '''
 This module contains the default Baf configuration class.
@@ -63,6 +68,8 @@ class Config:
         a site-specific configuration should inherit from the default, and
         can then overwrite this method to add site-specific options or
         defaults.
+
+        :param args: the command line options added in the site config.
         '''
         # As examples (typically used in a site-specific derived class):
         # Adding a site-specific option to profile with Tau:
@@ -80,8 +87,7 @@ class Config:
         options have been added. This is for example used to add
         Vernier profiling flags, which are site-specific.
 
-        :param argparse.Namespace args: the command line options added in
-            the site configs
+        :param args: the command line options added in the site configs.
         '''
         # Keep a copy of the args, so they can be used when
         # initialising compilers
@@ -94,6 +100,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         # First create the default compiler profiles for all available
         # compilers. While we have a tool box with exactly one compiler
         # in it, compiler wrappers will require more than one compiler
@@ -127,7 +134,10 @@ class Config:
         Returns the path-specific flags to be used.
         TODO #313: Ideally we have only one kind of flag, but as a quick
         work around we provide this method.
+
+        :param build_config: the Fab build configuration instance
         '''
+
         compiler = build_config.tool_box.get_tool(Category.FORTRAN_COMPILER)
         compiler = cast(Compiler, compiler)
         return self._path_flags[compiler.suite].get(build_config.profile, [])
@@ -141,6 +151,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["cray"] = setup_script_cray(build_config, self.args)
 
     def setup_gnu(self, build_config: BuildConfig) -> None:
@@ -152,6 +163,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["gnu"] = setup_script_gnu(build_config, self.args)
 
     def setup_intel_classic(self, build_config: BuildConfig) -> None:
@@ -163,6 +175,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["intel_classic"] = \
             setup_script_intel_classic(build_config, self.args)
 
@@ -175,6 +188,7 @@ class Config:
 
         :param build_config: the Fab build configuration instance
         '''
+
         self._path_flags["intel-llvm"] = setup_script_intel_llvm(build_config,
                                                                  self.args)
 

--- a/source/fab/fab_base/site_specific/default/setup_script_cray.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_cray.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_cray(build_config: BuildConfig,
-               args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_cray(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-branches
     '''
     Defines the default flags for ftn.

--- a/source/fab/fab_base/site_specific/default/setup_script_cray.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_cray.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for the Cray
 compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_gnu.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_gnu.py
@@ -13,8 +13,9 @@ from typing import cast
 from fab.api import AddFlags, BuildConfig, Category, Linker, ToolRepository
 
 
-def setup_gnu(build_config: BuildConfig,
-              args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_gnu(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for all GNU compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_script_gnu.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_gnu.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 GNU based compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 Intel classic based compilers in the ToolRepository (ifort, icc).

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_classic.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_intel_classic(build_config: BuildConfig,
-                        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_intel_classic(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel classic compilers and linkers.

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for all
 Intel llvm based compilers and linkers in the ToolRepository (ifx, icx).

--- a/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_intel_llvm.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_intel_llvm(build_config: BuildConfig,
-                     args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_intel_llvm(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument, too-many-locals
     '''
     Defines the default flags for all Intel llvm compilers.

--- a/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# ##############################################################################
+#  (c) Crown copyright Met Office. All rights reserved.
+#  For further details please refer to the file COPYRIGHT
+#  which you should have received as part of this distribution
+# ##############################################################################
+
 '''
 This file contains a function that sets the default flags for the NVIDIA
 compilers and linkers in the ToolRepository.

--- a/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
+++ b/source/fab/fab_base/site_specific/default/setup_script_nvidia.py
@@ -14,8 +14,9 @@ from fab.api import (AddFlags, BuildConfig, Category, Compiler, Linker,
                      ToolRepository)
 
 
-def setup_nvidia(build_config: BuildConfig,
-                 args: argparse.Namespace) -> dict[str, list[AddFlags]]:
+def setup_script_nvidia(
+        build_config: BuildConfig,
+        args: argparse.Namespace) -> dict[str, list[AddFlags]]:
     # pylint: disable=unused-argument
     '''
     Defines the default flags for nvfortran.

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -14,7 +14,7 @@ This gives us a file dependency tree for the entire project source. The data str
 just a dict of *<source path>: <analysed file>*, where the analysed files' dependencies are other dict keys.
 
 If we're building a library, that's the end of the analysis process as we'll compile the entire project source.
-If we're building one or more executables, which happens when we use the `root_symbol` argument,
+If we're building one or more executables, which happens when we use the `root_symbols` argument,
 Fab will extract a subtree from the entire dependency tree for each root symbol we specify.
 
 Finally, the resulting artefact collection is a dict of these subtrees (*"build trees"*),
@@ -65,7 +65,7 @@ DEFAULT_SOURCE_GETTER = CollectionConcat([
 def analyse(
         config,
         source: Optional[ArtefactsGetter] = None,
-        root_symbol: Optional[Union[str, list[str]]] = None,
+        root_symbols: Optional[Union[str, list[str]]] = None,
         find_programs: bool = False,
         std: str = "f2008",
         special_measure_analysis_results: Optional[Iterable[FortranParserWorkaround]] = None,
@@ -83,7 +83,7 @@ def analyse(
     from multiple artefact collections, including the default C and Fortran preprocessor outputs
     and any source files with a 'little' *.f90* extension.
 
-    A build tree is produced for every root symbol specified in *root_symbol*, which can be a string or list of.
+    A build tree is produced for every root symbol specified in *root_symbols*, which can be a string or list of.
     This is how we create executable files. If no root symbol is specified, a single tree of the entire source
     is produced (with a root symbol of `None`). This is how we create shared and static libraries.
 
@@ -94,8 +94,8 @@ def analyse(
         An :class:`~fab.util.ArtefactsGetter` to get the source files.
     :param find_programs:
         Instructs the analyser to automatically identify program definitions in the source.
-        Alternatively, the required programs can be specified with the root_symbol argument.
-    :param root_symbol:
+        Alternatively, the required programs can be specified with the root_symbols argument.
+    :param root_symbols:
         When building an executable, provide the Fortran Program name(s), or 'main' for C.
         If None, build tree extraction will not be performed and the entire source will be used
         as the build tree - for building a shared or static library.
@@ -120,11 +120,13 @@ def analyse(
     # because the files they refer to probably don't exist yet,
     # because we're just creating steps at this point, so there's been no grab...
 
-    if find_programs and root_symbol:
-        raise ValueError("find_programs and root_symbol can't be used together")
+    if find_programs and root_symbols:
+        raise ValueError("find_programs and root_symbols can't be used together")
 
     source_getter = source or DEFAULT_SOURCE_GETTER
-    root_symbols: Optional[list[str]] = [root_symbol] if isinstance(root_symbol, str) else root_symbol
+    if isinstance(root_symbols, str):
+        root_symbols = [root_symbols]
+
     special_measure_analysis_results = list(special_measure_analysis_results or [])
     unreferenced_deps = list(unreferenced_deps or [])
 

--- a/tests/system_tests/CFortranInterop/test_CFortranInterop.py
+++ b/tests/system_tests/CFortranInterop/test_CFortranInterop.py
@@ -35,7 +35,7 @@ def test_CFortranInterop(tmp_path):
         c_pragma_injector(config)
         preprocess_c(config)
         preprocess_fortran(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         with warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])

--- a/tests/system_tests/CUserHeader/test_CUserHeader.py
+++ b/tests/system_tests/CUserHeader/test_CUserHeader.py
@@ -34,7 +34,7 @@ def test_CUseHeader(tmp_path):
         find_source_files(config)
         c_pragma_injector(config)
         preprocess_c(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         link_exe(config, flags=['-lgfortran'])
 

--- a/tests/system_tests/FortranDependencies/test_FortranDependencies.py
+++ b/tests/system_tests/FortranDependencies/test_FortranDependencies.py
@@ -29,7 +29,7 @@ def test_fortran_dependencies(tmp_path):
         grab_folder(config, src=Path(__file__).parent / 'project-source')
         find_source_files(config)
         preprocess_fortran(config)  # nothing to preprocess, actually, it's all little f90 files
-        analyse(config, root_symbol=['first', 'second'])
+        analyse(config, root_symbols=['first', 'second'])
         compile_c(config, common_flags=['-c', '-std=c99'])
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])

--- a/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
+++ b/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
@@ -26,7 +26,7 @@ def build(fab_workspace, fpp_flags=None):
         grab_folder(config, Path(__file__).parent / 'project-source')
         find_source_files(config)
         preprocess_fortran(config, common_flags=fpp_flags)
-        analyse(config, root_symbol=['stay_or_go_now'])
+        analyse(config, root_symbols=['stay_or_go_now'])
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])
         link_exe(config, flags=['-lgfortran'])

--- a/tests/system_tests/MinimalC/test_MinimalC.py
+++ b/tests/system_tests/MinimalC/test_MinimalC.py
@@ -34,7 +34,7 @@ def test_minimal_c(tmp_path):
         find_source_files(config)
         c_pragma_injector(config)
         preprocess_c(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         compile_c(config, common_flags=['-c', '-std=c99'])
         link_exe(config)
 

--- a/tests/system_tests/MinimalFortran/test_MinimalFortran.py
+++ b/tests/system_tests/MinimalFortran/test_MinimalFortran.py
@@ -29,7 +29,7 @@ def test_minimal_fortran(tmp_path):
         grab_folder(config, PROJECT_SOURCE)
         find_source_files(config)
         preprocess_fortran(config)
-        analyse(config, root_symbol='test')
+        analyse(config, root_symbols='test')
         with pytest.warns(UserWarning, match="Removing managed flag"):
             compile_fortran(config, common_flags=['-c'])
         link_exe(config, flags=['-lgfortran'])

--- a/tests/system_tests/incremental_fortran/test_incremental_fortran.py
+++ b/tests/system_tests/incremental_fortran/test_incremental_fortran.py
@@ -56,7 +56,7 @@ class TestIncremental:
     def run_steps(self, build_config):
         find_source_files(build_config)
         preprocess_fortran(build_config)
-        analyse(build_config, root_symbol='my_prog')
+        analyse(build_config, root_symbols='my_prog')
         compile_fortran(build_config)
         link_exe(build_config, flags=['-lgfortran'])
         # Add a permissive cleanup step because we want to know about every file which is created,

--- a/tests/system_tests/prebuild/test_prebuild.py
+++ b/tests/system_tests/prebuild/test_prebuild.py
@@ -33,7 +33,7 @@ class TestFortranPrebuild(object):
                 grab_pre_build(config, grab_prebuild_folder)
             find_source_files(config)
             preprocess_fortran(config)
-            analyse(config, root_symbol='my_prog')
+            analyse(config, root_symbols='my_prog')
             compile_fortran(config)
             link_exe(config, flags=['-lgfortran'])
 

--- a/tests/unit_tests/fab_base/site_specific/default/config.py
+++ b/tests/unit_tests/fab_base/site_specific/default/config.py
@@ -2,7 +2,7 @@
 
 
 '''
-This module contains the default Baf configuration class.
+This module contains the default Fab configuration class.
 '''
 
 import argparse
@@ -14,7 +14,7 @@ from fab.tools.tool_repository import ToolRepository
 
 class Config:
     '''
-    This class is the default Configuration object for Baf builds.
+    This class is the default Configuration object for Fab builds.
     It provides several callbacks which will be called from the build
     scripts to allow site-specific customisations.
     '''

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -473,7 +473,7 @@ def test_build_static_lib(monkeypatch) -> None:
 
     mocks["analyse"][0].stop()
     mocks["analyse"][1].assert_called_once_with(
-        fab_base.config, root_symbol=None, ignore_dependencies=None)
+        fab_base.config, root_symbols=None, ignore_dependencies=None)
 
     mocks["archive_objects"][0].stop()
     mocks["archive_objects"][1].assert_called_once_with(
@@ -525,7 +525,7 @@ def test_build_shared_lib(monkeypatch) -> None:
 
     mocks["analyse"][0].stop()
     mocks["analyse"][1].assert_called_once_with(
-        fab_base.config, root_symbol=None, ignore_dependencies=None)
+        fab_base.config, root_symbols=None, ignore_dependencies=None)
 
     mocks["link_shared_object"][0].stop()
     mocks["link_shared_object"][1].assert_called_once_with(

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -141,11 +141,11 @@ def test_root_symbol(monkeypatch) -> None:
     fab_base = FabBase(name="test-help")
 
     # Set a single root symbol
-    fab_base.set_root_symbol("root1")
-    assert fab_base.root_symbol == ["root1"]
+    fab_base.set_root_symbols("root1")
+    assert fab_base.root_symbols == ["root1"]
 
-    fab_base.set_root_symbol(["root1", "root2"])
-    assert fab_base.root_symbol == ["root1", "root2"]
+    fab_base.set_root_symbols(["root1", "root2"])
+    assert fab_base.root_symbols == ["root1", "root2"]
 
 
 def test_profile_default(monkeypatch) -> None:

--- a/tests/unit_tests/fab_base/test_fab_base.py
+++ b/tests/unit_tests/fab_base/test_fab_base.py
@@ -21,6 +21,9 @@ from fab.fab_base.fab_base import FabBase
 from fab.tools.category import Category
 from fab.tools.tool_repository import ToolRepository
 
+# Mypy does not handle the relative import here properly, ignore error:
+from site_specific.default.config import Config as SiteConfig   # type: ignore
+
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_tool_repository(stub_fortran_compiler, stub_c_compiler,
@@ -73,6 +76,8 @@ def test_constructor(monkeypatch) -> None:
 
     monkeypatch.setattr(sys, "argv", ["fab_base.py"])
     fab_base = FabBase(name="test_name", link_target="executable")
+
+    assert fab_base.name == "test_name"
 
     # Check other settings and functions
     # pylint: disable=use-implicit-booleaness-not-comparison
@@ -335,6 +340,8 @@ def test_site_specific_callbacks(monkeypatch):
         tfb = TestFabBase(name="test-help")
         mock_handle.assert_called_once_with(tfb.args)
         mock_define.assert_called_once_with(tfb.parser)
+        # Check that the property returns the right object
+        assert isinstance(tfb.site_config, SiteConfig)
 
 
 def test_site_specific_outside_dir(monkeypatch) -> None:

--- a/tests/unit_tests/parse/fortran/test_contained_subroutine.py
+++ b/tests/unit_tests/parse/fortran/test_contained_subroutine.py
@@ -49,7 +49,7 @@ def test_contained_subroutine(tmp_path):
                      multiprocessing=False) as config:
         grab_folder(config, PROJECT_SOURCE)
         find_source_files(config)
-        analyse(config, root_symbol='main')
+        analyse(config, root_symbols='main')
         build_tree = config.artefact_store[ArtefactSet.BUILD_TREES]["main"]
 
         source_path = tmp_path / "contained_subroutine" / "source"


### PR DESCRIPTION
This adds changes and improvements done, based on the code review for lfric_core and UM (plus pfunit for lfric core).

It's mostly a collection of small changes, but I've renamed `root_symbol` to `root_symbols`, since this has always been a list, and is frequently used this way (e.g. um builds `um` and `recon`; socrates has over 50 binaries, ...). I left the old names in place with a deprecation warning for now.