### PR TITLE
#568 Re-introduce MISC category, and make it default for a tool.

### DIFF
--- a/source/fab/tools/category.py
+++ b/source/fab/tools/category.py
@@ -116,6 +116,8 @@ class Category(int, metaclass=CategoryMeta):
     FORTRAN_PREPROCESSOR: Category
     GIT: Category
     LINKER: Category
+    MISC: Category
+    PFUNIT: Category
     PSYCLONE: Category
     RSYNC: Category
     SHELL: Category
@@ -131,3 +133,4 @@ Category.add("C_PREPROCESSOR")
 Category.add("FORTRAN_COMPILER")
 Category.add("FORTRAN_PREPROCESSOR")
 Category.add("LINKER")
+Category.add("MISC")

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -35,7 +35,7 @@ class Tool:
     '''
 
     def __init__(self, name: str, exec_name: Union[str, Path],
-                 category: Category,
+                 category: Category = Category.MISC,
                  availability_option: Optional[Union[str, list[str]]] = None):
         self._logger = logging.getLogger(__name__)
         self._name = name


### PR DESCRIPTION
This fixes current build failures in lfric_core (some tools rely on the default MISC category), and given that we don't have a new Fab release, it feels easier to support this in Fab than doing another lfric_core PR to define a category.