### PR TITLE
Abort analyse step when parse errors occur

### DIFF
--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -46,7 +46,7 @@ from fab.mo import add_mo_commented_file_deps
 from fab.parse import AnalysedFile, EmptySourceFile
 from fab.parse.c import AnalysedC, CAnalyser
 from fab.parse.fortran import AnalysedFortran, FortranParserWorkaround, FortranAnalyser
-from fab.steps import run_mp, step
+from fab.steps import check_for_errors, run_mp, step
 from fab.util import TimerLogger, by_type
 
 logger = logging.getLogger(__name__)
@@ -262,12 +262,9 @@ def _parse_files(config, files: list[Path], fortran_analyser, c_analyser) -> set
         c_results = run_mp(config, items=c_files, func=c_analyser.run, no_multiprocessing=no_multiprocessing)
     c_analyses, c_artefacts = zip(*c_results) if c_results else (tuple(), tuple())
 
-    # Check for parse errors but don't fail. The failed files might not be required.
+    # Check for parse errors before continuing to dependency analysis.
     analyses = fortran_analyses + c_analyses
-    exceptions = list(by_type(analyses, Exception))
-    if exceptions:
-        err_str = '\n\n'.join(map(str, exceptions))
-        print(f"\nThere were {len(exceptions)} analysis errors:\n\n{err_str}\n\n", file=sys.stderr)
+    check_for_errors(analyses, caller_label="analyse")
 
     # record the artefacts as being current
     artefacts = by_type(fortran_artefacts + c_artefacts, Path)

--- a/tests/unit_tests/steps/test_analyse.py
+++ b/tests/unit_tests/steps/test_analyse.py
@@ -153,26 +153,22 @@ class Test_parse_files(object):
                         stub_tool_repository: ToolRepository,
                         monkeypatch) -> None:
         """
-        Tests exceptions thrown from processing do not halt build.
-
-        ToDo: Do we want this? Shouldn't exceptions stop build?
+        Tests exceptions thrown from processing halt the build.
 
         ToDo: Messing with "private" methods.
         """
-        def raises(*args, **kwargs):
-            raise Exception("foo")
+        def analyse_error(*args, **kwargs):
+            return [(Exception("foo"), None)]
 
-        # The warning "deprecated 'DEPENDS ON:' comment found in fortran
-        # code" is in "def _parse_files" in "source/steps/analyse.py"
         config = BuildConfig('proj', ToolBox(), fab_workspace=tmp_path)
+        fortran_analyser = Mock(depends_on_comment_found=False)
+        c_analyser = Mock()
 
-        monkeypatch.setattr('fab.steps.run_mp', raises)
-        with warns(UserWarning, match="deprecated 'DEPENDS ON:'"):
-            # the exception should be suppressed (and logged) and this step
-            # should run to completion
+        monkeypatch.setattr('fab.steps.analyse.run_mp', analyse_error)
+        with raises(RuntimeError, match="foo"):
             _parse_files(config, files=[],
-                         fortran_analyser=Mock(),
-                         c_analyser=Mock())
+                         fortran_analyser=fortran_analyser,
+                         c_analyser=c_analyser)
 
 
 class TestAddManualResults:


### PR DESCRIPTION
## Summary
- stop the analyse step when parser errors are returned
- reuse the existing `check_for_errors` helper for consistent step behaviour
- update the unit test to assert parse errors halt the build

Closes #577.

## Tests
- `.venv/bin/python -m pytest tests/unit_tests/steps/test_analyse.py tests/unit_tests/steps/test_steps.py`
- `.venv/bin/python -m flake8 source/fab/steps/analyse.py tests/unit_tests/steps/test_analyse.py`

I also ran `.venv/bin/python -m pytest tests/unit_tests/steps`; unrelated `test_find_source_files` cases fail locally because no Fortran compiler is available.