### PR TITLE
Fail analyse step when parser errors occur

### DIFF
--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -46,7 +46,7 @@ from fab.mo import add_mo_commented_file_deps
 from fab.parse import AnalysedFile, EmptySourceFile
 from fab.parse.c import AnalysedC, CAnalyser
 from fab.parse.fortran import AnalysedFortran, FortranParserWorkaround, FortranAnalyser
-from fab.steps import run_mp, step
+from fab.steps import check_for_errors, run_mp, step
 from fab.util import TimerLogger, by_type
 
 logger = logging.getLogger(__name__)
@@ -262,12 +262,8 @@ def _parse_files(config, files: list[Path], fortran_analyser, c_analyser) -> set
         c_results = run_mp(config, items=c_files, func=c_analyser.run, no_multiprocessing=no_multiprocessing)
     c_analyses, c_artefacts = zip(*c_results) if c_results else (tuple(), tuple())
 
-    # Check for parse errors but don't fail. The failed files might not be required.
     analyses = fortran_analyses + c_analyses
-    exceptions = list(by_type(analyses, Exception))
-    if exceptions:
-        err_str = '\n\n'.join(map(str, exceptions))
-        print(f"\nThere were {len(exceptions)} analysis errors:\n\n{err_str}\n\n", file=sys.stderr)
+    check_for_errors(analyses, caller_label="analyse")
 
     # record the artefacts as being current
     artefacts = by_type(fortran_artefacts + c_artefacts, Path)

--- a/tests/unit_tests/steps/test_analyse.py
+++ b/tests/unit_tests/steps/test_analyse.py
@@ -151,27 +151,21 @@ class Test_parse_files(object):
     """
     def test_exceptions(self, tmp_path: Path,
                         stub_tool_repository: ToolRepository,
-                        monkeypatch) -> None:
+                        ) -> None:
         """
-        Tests exceptions thrown from processing do not halt build.
-
-        ToDo: Do we want this? Shouldn't exceptions stop build?
+        Tests exceptions from processing halt the build.
 
         ToDo: Messing with "private" methods.
         """
-        def raises(*args, **kwargs):
-            raise Exception("foo")
-
-        # The warning "deprecated 'DEPENDS ON:' comment found in fortran
-        # code" is in "def _parse_files" in "source/steps/analyse.py"
         config = BuildConfig('proj', ToolBox(), fab_workspace=tmp_path)
+        source_file = tmp_path / "bad.f90"
+        analyser = Mock()
+        analyser.depends_on_comment_found = False
+        analyser.run.return_value = (Exception("foo"), Path("bad.an"))
 
-        monkeypatch.setattr('fab.steps.run_mp', raises)
-        with warns(UserWarning, match="deprecated 'DEPENDS ON:'"):
-            # the exception should be suppressed (and logged) and this step
-            # should run to completion
-            _parse_files(config, files=[],
-                         fortran_analyser=Mock(),
+        with raises(RuntimeError, match="1 error\\(s\\) found during analyse"):
+            _parse_files(config, files=[source_file],
+                         fortran_analyser=analyser,
                          c_analyser=Mock())
 
 


### PR DESCRIPTION
Closes #577

## Summary
- fail the analyse step when parser/analyser results contain exceptions
- reuse the existing error-reporting helper for consistent behaviour
- update unit coverage for the new failure path

## Tests
- `git diff --check`
- `uv run --with '.[dev]' python -m flake8 source/fab/steps/analyse.py tests/unit_tests/steps/test_analyse.py`\n- `uv run --with '.[dev]' python -m pytest tests/unit_tests/steps/test_analyse.py tests/unit_tests/steps/test_steps.py -q`